### PR TITLE
Fix package assets and documentation for pub.dev (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ migrate_working_dir/
 **/build/
 **/coverage/
 /pubspec.lock
+/assets/shaderbundles/*.shaderbundle
 
 # Symbolication related
 app.*.symbols

--- a/.pubignore
+++ b/.pubignore
@@ -10,6 +10,7 @@
 /test/
 /tool/
 /vendor/maplibre-native/**
+/doc/images/
 
 # Release CI injects native artifacts under android/src/main/jniLibs and
 # darwin/maplibre_flutter_gpu/Frameworks. Keep those paths publishable.

--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ class _MapPageState extends State<MapPage> {
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| `cameraTargetBounds` | `CameraTargetBounds` | Unbounded | Limits the geographic camera target. |
-| `minMaxZoomPreference` | `MinMaxZoomPreference` | Unbounded | Limits camera zoom. |
-| `minMaxTiltPreference` | `MinMaxTiltPreference` | Unbounded | Limits camera tilt in degrees. |
+| `cameraTargetBounds` | `CameraTargetBounds` | No explicit bounds | Limits the geographic camera target. Web Mercator projection limits still apply. |
+| `minMaxZoomPreference` | `MinMaxZoomPreference` | 0–25.5 | Limits camera zoom. |
+| `minMaxTiltPreference` | `MinMaxTiltPreference` | 0–60° | Limits camera tilt in degrees. |
 | `rotateGesturesEnabled` | `bool` | `true` | Enables two-finger rotation. |
 | `scrollGesturesEnabled` | `bool` | `true` | Enables one-finger panning. |
 | `zoomGesturesEnabled` | `bool` | `true` | Enables pinch and scroll-wheel zoom. |
@@ -237,6 +237,7 @@ final position = controller.toScreenOffset(markerCoordinate);
 Stack(
   children: [
     MapLibreMap(
+      trackCameraPosition: true,
       ...
     ),
     Positioned(
@@ -309,11 +310,11 @@ instance received by `onMapCreated` for later use.
 | `toLatLngOffset(screenLocation)` | Synchronous `Offset` version of `toLatLng`. |
 | `getVisibleRegion()` | Returns the current visible geographic bounds. |
 | `getMetersPerPixelAtLatitude(latitude)` | Returns map resolution at a latitude. |
-| `setCameraBounds(...)` | Updates target, zoom, and tilt constraints. |
+| `setCameraBounds(...)` | Animates the camera to fit geographic bounds. |
 | `updateContentInsets(...)` | Updates camera padding in logical pixels. |
 | `resetNorth()` | Resets the camera bearing to north. |
 | `getPlacedLabels()` | Returns the latest native label-placement snapshot. |
-| `isMapIdle` | Whether camera, style, and pending map work are settled. |
+| `isMapIdle` | Whether the native map had no pending work after its last frame. This does not include Flutter fling animation. |
 
 The controller belongs to its `MapLibreMap`. Do not call `dispose()` yourself
 and do not use it after the map widget has been removed.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # maplibre_flutter_gpu
 
-Render MapLibre maps with Flutter GPU without Platform Views. Smooth, Synchronized, Widget-friendly, with support for custom 3D rendering.
+Render MapLibre maps with Flutter GPU without Platform Views. Maps and Flutter Widgets stay smooth and synchronized, with support for custom 3D rendering.
 
 ## Widgets on the map
 
 Have you ever wanted to place a Flutter widget on a map as a marker?
 
-With conventional map plugins, that widget drifts while the map moves.
+With conventional map packages, the widget falls out of sync while the map moves.
 
 <p align="center">
-  <img src="doc/images/map-widget-comparison.gif" alt="Flutter widget synchronization comparison" width="600">
+  <img src="https://raw.githubusercontent.com/hyshu/maplibre_flutter_gpu/main/doc/images/map-widget-comparison.gif" alt="Flutter widget synchronization comparison" width="600">
 </p>
 
 Flutter and the map use different rendering engines,
@@ -24,17 +24,17 @@ widgets together.
 Every label and symbol on the map is a Flutter widget. You can also place any
 widget you like at any geographic coordinate.
 
-Use Flutter to restyle place names and regional labels, make them tappable, or
-bring them to life with animations. Map content and your interface share the
-same widget system and stay synchronized while the camera moves.
+Use Flutter to restyle place names and regional labels or bring them to life
+with animations. Map content and your interface share the same widget system
+and stay synchronized while the camera moves.
 
-## Place 3D objects in the map space
+## Place 3D objects in map space
 
-Because the map is rendered with Flutter GPU, you can modify its 3D space
-directly from Dart.
+Because the map is rendered with Flutter GPU, you can render custom geometry
+directly in the map's 3D coordinate space from Dart.
 
 <p align="center">
-  <img src="doc/images/custom-3d-rendering.gif" alt="Custom 3D rendering on a Flutter GPU map" width="400" height="400">
+  <img src="https://raw.githubusercontent.com/hyshu/maplibre_flutter_gpu/main/doc/images/custom-3d-rendering.gif" alt="Custom 3D rendering on a Flutter GPU map" width="400" height="400">
 </p>
 
 New to Flutter GPU? That is fine. Modern LLMs can already help implement a
@@ -44,7 +44,7 @@ Turn a flat map pin into a 3D object positioned in geographic space. Animate
 cars along roads. If you want to go further, you could even build a flight
 simulator or an FPS game around a real map.
 
-## Supporting platforms
+## Supported platforms
 
 MapLibre Flutter GPU currently supports the following platforms.
 
@@ -64,6 +64,21 @@ Add MapLibre Flutter GPU to your project with this command.
 
 ```bash
 flutter pub add maplibre_flutter_gpu
+```
+
+Enable Flutter GPU in your app's `ios/Runner/Info.plist` and
+`macos/Runner/Info.plist`.
+
+```xml
+<key>FLTEnableFlutterGPU</key>
+<true/>
+```
+
+On macOS, also enable Impeller in `macos/Runner/Info.plist`.
+
+```xml
+<key>FLTEnableImpeller</key>
+<true/>
 ```
 
 Import the package and add a `MapLibreMap` widget.
@@ -210,9 +225,34 @@ MapLibreMap(
 )
 ```
 
-Custom symbol widgets are visual children and intentionally ignore pointer
-events so gestures can reach the map. Use `onMapClick` or place your own widget
-with a `Stack` when it needs direct interaction.
+### Interactive Flutter markers
+
+Widget overlays are intentionally decoupled from `MapLibreMap`. Use a `Stack`
+with the controller's coordinate conversion methods to place widgets at
+geographic coordinates.
+
+```dart
+final position = controller.toScreenOffset(markerCoordinate);
+
+Stack(
+  children: [
+    MapLibreMap(
+      ...
+    ),
+    Positioned(
+      left: position.dx,
+      top: position.dy,
+      child: const Icon(Icons.location_pin),
+    ),
+  ],
+)
+```
+
+Listen to the controller and update `position` when the camera changes. See the
+[`example`](example/) app for a complete implementation, including listener
+cleanup.
+
+### Style-dependent operations
 
 For operations that depend on the loaded style, wait for
 `onStyleLoadedCallback`.

--- a/assets/shaderbundles/README.md
+++ b/assets/shaderbundles/README.md
@@ -1,0 +1,3 @@
+# Generated shader bundles
+
+The package build hook writes compiled shader bundles to this directory.

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -80,6 +80,8 @@
 		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		784666492D4C4C64000A1A5F /* FlutterFramework */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterFramework; path = ephemeral/Packages/.packages/FlutterFramework; sourceTree = "<group>"; };
+		78DABEA22ED26510000E7860 /* maplibre_flutter_gpu */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = maplibre_flutter_gpu; path = ../../../darwin/maplibre_flutter_gpu; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -154,6 +156,8 @@
 		33CEB47122A05771004F2AC0 /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78DABEA22ED26510000E7860 /* maplibre_flutter_gpu */,
+				784666492D4C4C64000A1A5F /* FlutterFramework */,
 				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */,
 				33CEB47222A05771004F2AC0 /* Flutter-Debug.xcconfig */,

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -41,7 +41,7 @@ void main(List<String> args) async {
 
     final shadersDir = packageRoot.resolve('shaders/');
     final outDir = Directory.fromUri(
-      packageRoot.resolve('build/shaderbundles/'),
+      packageRoot.resolve('assets/shaderbundles/'),
     );
     await outDir.create(recursive: true);
     final shaderLibPath = impellercExec.resolve('./shader_lib');

--- a/lib/src/geo/camera_constraints.dart
+++ b/lib/src/geo/camera_constraints.dart
@@ -7,10 +7,12 @@ import 'camera.dart';
 class CameraTargetBounds {
   const CameraTargetBounds(this.bounds);
 
-  /// The geographical bounding box, or `null` for an unbounded target.
+  /// The geographical bounding box, or `null` for no explicit target bounds.
+  ///
+  /// The map projection's intrinsic latitude limits still apply.
   final LatLngBounds? bounds;
 
-  /// Camera target bounds with no geographical restriction.
+  /// Camera target bounds with no explicit geographical restriction.
   static const CameraTargetBounds unbounded = CameraTargetBounds(null);
 
   dynamic toJson() => <dynamic>[bounds?.toList()];
@@ -39,7 +41,7 @@ class MinMaxZoomPreference {
   /// The maximum zoom level, or `null` when unspecified.
   final double? maxZoom;
 
-  /// A zoom preference with no minimum or maximum level.
+  /// A zoom preference that uses the default range from 0 to 25.5.
   static const MinMaxZoomPreference unbounded = MinMaxZoomPreference(
     null,
     null,
@@ -76,7 +78,7 @@ class MinMaxTiltPreference {
   /// The maximum tilt in degrees, or `null` when unspecified.
   final double? maxTilt;
 
-  /// A tilt preference with no minimum or maximum angle.
+  /// A tilt preference that uses the default range from 0 to 60 degrees.
   static const MinMaxTiltPreference unbounded = MinMaxTiltPreference(
     null,
     null,

--- a/lib/src/gpu/shaders.dart
+++ b/lib/src/gpu/shaders.dart
@@ -4,7 +4,7 @@ gpu.ShaderLibrary? _mapShaderLibrary;
 
 /// Package asset path of the compiled map shader bundle.
 const _shaderBundleAsset =
-    'packages/maplibre_flutter_gpu/build/shaderbundles/MapShaders.shaderbundle';
+    'packages/maplibre_flutter_gpu/assets/shaderbundles/MapShaders.shaderbundle';
 
 /// Loads the map shader library on first access and reuses it thereafter.
 ///

--- a/lib/src/widgets/map_controls.dart
+++ b/lib/src/widgets/map_controls.dart
@@ -514,7 +514,7 @@ Widget buildDefaultAttributionButton(
 
 /// Builds the default dialog from attribution declared by the active style.
 ///
-/// Source attribution links open outside the app.
+/// Source attribution links call the configured handler when one is available.
 Widget buildDefaultAttributionDialog(BuildContext context) =>
     _DefaultAttributionDialog(
       controller: _AttributionControllerScope.maybeControllerOf(context),

--- a/lib/src/widgets/maplibre_map.dart
+++ b/lib/src/widgets/maplibre_map.dart
@@ -277,7 +277,9 @@ class MapLibreMap extends StatefulWidget {
 
   /// The minimum and maximum zoom levels allowed for the camera.
   ///
-  /// Updated limits are applied after the active style has loaded.
+  /// Updated limits are applied after the active style has loaded. An
+  /// unspecified minimum defaults to zero, and an unspecified maximum defaults
+  /// to 25.5.
   ///
   /// Defaults to [MinMaxZoomPreference.unbounded].
   final MinMaxZoomPreference minMaxZoomPreference;
@@ -285,7 +287,8 @@ class MapLibreMap extends StatefulWidget {
   /// The minimum and maximum tilt angles allowed for the camera.
   ///
   /// Values are measured in degrees. Updated limits are applied after the
-  /// active style has loaded.
+  /// active style has loaded. An unspecified minimum defaults to zero, and an
+  /// unspecified maximum defaults to 60.
   ///
   /// Defaults to [MinMaxTiltPreference.unbounded].
   final MinMaxTiltPreference minMaxTiltPreference;
@@ -520,7 +523,7 @@ class MapLibreMap extends StatefulWidget {
 
   /// Builds the default dialog from attribution declared by the active style.
   ///
-  /// Source attribution links open outside the app.
+  /// Source attribution links call [onAttributionLinkTap] when it is configured.
   static const WidgetBuilder defaultAttributionDialogBuilder =
       buildDefaultAttributionDialog;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,4 +41,4 @@ flutter:
         pluginClass: MaplibreFlutterGpuPlugin
         sharedDarwinSource: true
   assets:
-    - build/shaderbundles/
+    - assets/shaderbundles/

--- a/tool/ci/check_publish.sh
+++ b/tool/ci/check_publish.sh
@@ -50,7 +50,7 @@ test -f darwin/maplibre_flutter_gpu/Frameworks/MapLibreBridge.xcframework/Info.p
 
 flutter pub get
 flutter test test/package_configuration_test.dart
-test -s build/shaderbundles/MapShaders.shaderbundle
+test -s assets/shaderbundles/MapShaders.shaderbundle
 publish_log="$(mktemp)"
 trap 'rm -f "${publish_log}"' EXIT
 

--- a/tool/ci/quality.sh
+++ b/tool/ci/quality.sh
@@ -32,7 +32,7 @@ git ls-files -z -- '*.dart' |
     xargs -0 dart format --output=none --set-exit-if-changed
 
 flutter test
-test -s build/shaderbundles/MapShaders.shaderbundle
+test -s assets/shaderbundles/MapShaders.shaderbundle
 
 unit_test_packages=(
     example


### PR DESCRIPTION
## Summary

- move generated shader bundles from the transient build directory to the package's asset directory
- restore local Swift package references used by the macOS example
- reduce the compressed pub archive from 95 MB to 82 MB
- improve the README and correct API documentation that did not match runtime behavior

## Details

### Shader asset packaging

The build hook now writes compiled shader bundles to `assets/shaderbundles`. The Flutter asset declaration, runtime lookup, and CI checks use the same persistent location.

### Pub archive size

The README now loads its two demo GIFs from this GitHub repository. Because the images remain available from GitHub, `doc/images` can be excluded from the pub archive without breaking the package page. This reduces the dry-run archive size from 95 MB to 82 MB.

### Documentation

The README has clearer introductory copy and an example for interactive Flutter markers. Camera documentation now reflects the effective zoom range of 0–25.5, tilt range of 0–60 degrees, and Web Mercator target limits. Controller idle state, camera fitting, attribution links, and camera listener requirements are also described consistently with the implementation.

## Validation

- `flutter test` (423 tests passed)
- `dart pub publish --dry-run` (82 MB compressed archive)
- `git diff --check`
