### PR TITLE
Fix macOS shutdown crash

### DIFF
--- a/darwin/maplibre_flutter_gpu/Headers/MapLibreBridge.h
+++ b/darwin/maplibre_flutter_gpu/Headers/MapLibreBridge.h
@@ -8,6 +8,8 @@ extern "C" {
 // Returns the retained FFI symbol table so static linkers keep every entry point.
 __attribute__((visibility("default")))
 const void* maplibre_flutter_gpu_force_link(void);
+// Stops the shared runtime before process teardown.
+void maplibre_shutdown_all(void);
 
 #ifdef __cplusplus
 }

--- a/darwin/maplibre_flutter_gpu/Packaging/maplibre_bridge_anchor.cpp
+++ b/darwin/maplibre_flutter_gpu/Packaging/maplibre_bridge_anchor.cpp
@@ -52,6 +52,7 @@
     X(maplibre_get_drawable_name) \
     X(maplibre_get_drawable_summary) \
     X(maplibre_destroy) \
+    X(maplibre_shutdown_all) \
     X(maplibre_frame_begin) \
     X(maplibre_frame_end) \
     X(maplibre_request_label_extraction) \

--- a/darwin/maplibre_flutter_gpu/Sources/maplibre_flutter_gpu/MaplibreFlutterGpuPlugin.swift
+++ b/darwin/maplibre_flutter_gpu/Sources/maplibre_flutter_gpu/MaplibreFlutterGpuPlugin.swift
@@ -1,12 +1,28 @@
 #if os(iOS)
 import Flutter
 #elseif os(macOS)
+import AppKit
 import FlutterMacOS
 #endif
 import MapLibreBridge
 
 public final class MaplibreFlutterGpuPlugin: NSObject, FlutterPlugin {
+#if os(macOS)
+  private static var terminationObserver: NSObjectProtocol?
+#endif
+
   public static func register(with registrar: FlutterPluginRegistrar) {
     _ = maplibre_flutter_gpu_force_link()
+#if os(macOS)
+    if terminationObserver == nil {
+      terminationObserver = NotificationCenter.default.addObserver(
+        forName: NSApplication.willTerminateNotification,
+        object: nil,
+        queue: nil
+      ) { _ in
+        maplibre_shutdown_all()
+      }
+    }
+#endif
   }
 }

--- a/native/src/bridge_owner_thread.cpp
+++ b/native/src/bridge_owner_thread.cpp
@@ -13,10 +13,27 @@ namespace {
 
 class BridgeRuntime {
 public:
+    ~BridgeRuntime() { shutdown(); }
+
+    void shutdown() {
+        std::unique_lock<std::mutex> lock(mutex);
+        if (!worker.joinable()) return;
+
+        processExiting = true;
+        stopping = true;
+        try {
+            if (g_run_loop) g_run_loop->stop();
+        } catch (...) {
+        }
+        lock.unlock();
+        worker.join();
+    }
+
     bool acquire(void* session) {
         if (!session) return false;
 
         std::unique_lock<std::mutex> lock(mutex);
+        if (processExiting) return false;
         if (sessions.contains(session)) {
             return running && !stopping;
         }
@@ -111,7 +128,12 @@ private:
 
             // HTTP, timers, actor messages, and FFI work share one ordered
             // queue. MapSession activation is attached to each posted task.
-            g_run_loop->run();
+            bool shouldRun = false;
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+                shouldRun = !stopping;
+            }
+            if (shouldRun) g_run_loop->run();
         } catch (const std::exception& error) {
             std::fprintf(
                 stderr,
@@ -137,7 +159,7 @@ private:
         {
             std::lock_guard<std::mutex> lock(mutex);
             running = false;
-            if (!stopping) {
+            if (!stopping || processExiting) {
                 abandonedSessions.assign(sessions.begin(), sessions.end());
                 sessions.clear();
             }
@@ -166,6 +188,7 @@ private:
     bool running = false;
     bool stopping = false;
     bool started = false;
+    bool processExiting = false;
 
     static thread_local bool isOwnerThread;
 };
@@ -181,6 +204,10 @@ bool bridge_startOwnerThread() {
 
 void bridge_stopOwnerThread() {
     g_runtime.release(bridge_currentSession());
+}
+
+void bridge_shutdownOwnerRuntime() {
+    g_runtime.shutdown();
 }
 
 bool bridge_ownerThreadRunning() {

--- a/native/src/bridge_state.hpp
+++ b/native/src/bridge_state.hpp
@@ -61,6 +61,7 @@ std::unique_ptr<mbgl::util::RunLoop>& bridge_runLoopStorage();
 // Individual tasks reactivate their explicit session before touching map state.
 bool bridge_startOwnerThread();
 void bridge_stopOwnerThread();
+void bridge_shutdownOwnerRuntime();
 bool bridge_ownerThreadRunning();
 bool bridge_isOwnerThread();
 bool bridge_postOwnerTask(std::function<void()> task);

--- a/native/src/maplibre_bridge.cpp
+++ b/native/src/maplibre_bridge.cpp
@@ -2115,6 +2115,10 @@ MAPLIBRE_API void maplibre_destroy(void) {
     fflush(stdout);
 }
 
+MAPLIBRE_API void maplibre_shutdown_all(void) {
+    bridge_shutdownOwnerRuntime();
+}
+
 // ── Command Export backend: DrawCommand-based FFI ────────────────────
 // These functions read FrameData populated by command_export::Drawable::draw().
 

--- a/test/native_build_configuration_test.dart
+++ b/test/native_build_configuration_test.dart
@@ -113,6 +113,20 @@ void main() {
     expect(runtime, contains('g_run_loop->run();'));
   });
 
+  test('macOS stops the native runtime before process teardown', () {
+    final plugin = File(
+      'darwin/maplibre_flutter_gpu/Sources/maplibre_flutter_gpu/'
+      'MaplibreFlutterGpuPlugin.swift',
+    ).readAsStringSync();
+    final runtime = File(
+      'native/src/bridge_owner_thread.cpp',
+    ).readAsStringSync();
+    expect(plugin, contains('NSApplication.willTerminateNotification'));
+    expect(plugin, contains('maplibre_shutdown_all()'));
+    expect(runtime, contains('void bridge_shutdownOwnerRuntime()'));
+    expect(runtime, contains('worker.join();'));
+  });
+
   test('Android reuses one process DSO for every map session', () {
     final plugin = File(
       'android/src/main/java/dev/maplibre/fluttergpu/'


### PR DESCRIPTION
## Problem

Running the example on macOS in release mode could end with a system crash dialog:

1. Run `flutter run -d macos --release`.
2. Close the example application first.
3. Press `q` in the `flutter run` terminal.

The command printed `Application finished.`, but macOS then reported that `maplibre_flutter_landmarks_example` had quit unexpectedly. Pressing `q` while the application was still open did not reproduce the problem.

## Cause

Closing the application did not stop MapLibre's shared native owner thread. When `flutter run` later finished the process, static teardown began while that thread was still alive. This could abort because the thread was still joinable or access MapLibre state that had already been destroyed.

## Fix

The macOS plugin now listens for `NSApplication.willTerminateNotification` and explicitly shuts down the shared native runtime before static teardown starts. Shutdown stops the run loop and joins the owner thread. Destructor shutdown remains as a fallback.

After this change, closing the application and then pressing `q` exits normally without the unexpected termination dialog or a crash report.

## Validation

- Reproduced the original close-then-`q` sequence with `flutter run -d macos --release`
- Confirmed exit code 0 with no macOS crash report after the fix
- Built the universal arm64 and x86_64 native archive
- Ran `flutter test` with all 424 tests passing
- Ran `git diff --check`
