### PR TITLE
Improve test coverage and CI parallelism

### DIFF
--- a/.github/workflows/_native-artifacts.yml
+++ b/.github/workflows/_native-artifacts.yml
@@ -43,7 +43,17 @@ jobs:
           exit 64
 
       - name: Check out source
+        id: checkout
         if: ${{ matrix.kind != 'invalid' && matrix.kind != 'darwin-reuse' }}
+        continue-on-error: true
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Retry source checkout
+        if: ${{ matrix.kind != 'invalid' && matrix.kind != 'darwin-reuse' && steps.checkout.outcome == 'failure' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,40 @@ jobs:
       - name: Run analysis and tests
         run: ./tool/ci/quality.sh
 
+      - name: Upload Dart coverage
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dart-coverage-${{ github.run_id }}-${{ github.run_attempt }}
+          path: coverage/lcov.info
+          if-no-files-found: error
+          retention-days: 14
+
+  firebase_preflight:
+    name: Firebase authentication preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      id-token: write
+    steps:
+      - name: Validate Firebase configuration
+        env:
+          GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$GCP_SERVICE_ACCOUNT"
+          test -n "$GCP_WORKLOAD_IDENTITY_PROVIDER"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+          create_credentials_file: false
+          token_format: access_token
+
   native_ios:
     name: iOS native artifact
     uses: ./.github/workflows/_native-artifacts.yml
@@ -355,20 +389,20 @@ jobs:
           retention-days: 14
 
   android_e2e_gate:
-    name: Start Android stage
+    name: Authorize Firebase Test Lab stage
     if: ${{ always() }}
     needs:
       - quality
       - consumer_ios
       - ios_visual
-    runs-on: macos-15-intel
+      - firebase_preflight
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {}
     steps:
-      - name: Verify iOS stage and Firebase configuration
+      - name: Verify iOS stage and Firebase preflight
         env:
-          GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
-          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          FIREBASE_PREFLIGHT_RESULT: ${{ needs.firebase_preflight.result }}
           IOS_CONSUMER_RESULT: ${{ needs.consumer_ios.result }}
           IOS_VISUAL_RESULT: ${{ needs.ios_visual.result }}
           QUALITY_RESULT: ${{ needs.quality.result }}
@@ -378,14 +412,10 @@ jobs:
           test "$QUALITY_RESULT" = success
           test "$IOS_CONSUMER_RESULT" = success
           test "$IOS_VISUAL_RESULT" = success
-          test -n "$GCP_SERVICE_ACCOUNT"
-          test -n "$GCP_WORKLOAD_IDENTITY_PROVIDER"
+          test "$FIREBASE_PREFLIGHT_RESULT" = success
 
   native_android:
     name: Android native artifacts
-    if: ${{ always() && needs.android_e2e_gate.result == 'success' }}
-    needs:
-      - android_e2e_gate
     uses: ./.github/workflows/_native-artifacts.yml
     with:
       retention_days: 7
@@ -403,11 +433,11 @@ jobs:
 
   android_e2e_apks:
     name: Build Android E2E APKs
-    if: ${{ always() && needs.android_e2e_gate.result == 'success' && needs.native_android.result == 'success' && needs.consumer_android.result == 'success' }}
+    if: ${{ always() && needs.firebase_preflight.result == 'success' && needs.native_android.result == 'success' && needs.consumer_android.result == 'success' }}
     needs:
+      - firebase_preflight
       - native_android
       - consumer_android
-      - android_e2e_gate
     runs-on: macos-15-intel
     timeout-minutes: 45
     permissions:
@@ -545,14 +575,69 @@ jobs:
         with:
           project_id: ${{ env.FIREBASE_PROJECT_ID }}
 
-      - name: Acquire one-shot lock for this commit
+      - name: Acquire Firebase execution lease
+        id: firebase_lease
+        env:
+          FIREBASE_LEASE_TTL_SECONDS: 7200
         shell: bash
         run: |
           set -euo pipefail
           lock_file="$RUNNER_TEMP/android-e2e.lock"
+          existing_lock="$RUNNER_TEMP/android-e2e-existing.lock"
           lock_uri="gs://${FIREBASE_RESULTS_BUCKET}/visual-parity-locks/${GITHUB_SHA}.lock"
-          printf 'run_id=%s\nrun_attempt=%s\n' \
-            "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" >"$lock_file"
+          now="$(date +%s)"
+          current_results_id="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+          write_running_lock() {
+            printf 'state=running\nsha=%s\nrun_id=%s\nrun_attempt=%s\nresults_id=%s\nacquired_at=%s\n' \
+              "$GITHUB_SHA" \
+              "$GITHUB_RUN_ID" \
+              "$GITHUB_RUN_ATTEMPT" \
+              "$current_results_id" \
+              "$now" >"$lock_file"
+          }
+
+          record_execution() {
+            local run_firebase="$1"
+            local results_id="$2"
+            local generation="$3"
+            echo "run_firebase=$run_firebase" >>"$GITHUB_OUTPUT"
+            echo "results_id=$results_id" >>"$GITHUB_OUTPUT"
+            echo "lock_generation=$generation" >>"$GITHUB_OUTPUT"
+          }
+
+          completed_results_available() {
+            local results_id="$1"
+            local renderer
+            for renderer in maplibre_gl gpu; do
+              local listing="$RUNNER_TEMP/${renderer}-completed-objects.txt"
+              local attempt
+              for attempt in 1 2 3; do
+                if gcloud storage ls --recursive \
+                  "gs://${FIREBASE_RESULTS_BUCKET}/visual-parity/${GITHUB_SHA}/${results_id}/${renderer}/**" \
+                  >"$listing"; then
+                  break
+                fi
+                if [[ "$attempt" == 3 ]]; then
+                  return 1
+                fi
+                sleep $((attempt * 5))
+              done
+              local scene
+              while IFS= read -r scene; do
+                local suffix="/visual-e2e/${scene}/${renderer}.png"
+                local count
+                count="$(awk -v suffix="$suffix" \
+                  'substr($0, length($0) - length(suffix) + 1) == suffix { count++ } END { print count + 0 }' \
+                  "$listing")"
+                if [[ "$count" -ne 1 ]]; then
+                  return 1
+                fi
+              done < <(tr '|' '\n' <<<"$ANDROID_E2E_SCENES")
+            done
+          }
+
+          write_running_lock
 
           set +e
           gcloud storage cp \
@@ -565,13 +650,80 @@ jobs:
           set -e
           cat "$RUNNER_TEMP/android-e2e-lock.stdout"
           cat "$RUNNER_TEMP/android-e2e-lock.stderr" >&2
-          if [[ "$status" -ne 0 ]]; then
-            echo "STOP: Android E2E already attempted for ${GITHUB_SHA}, or the one-shot lock could not be created." >&2
+          if [[ "$status" -eq 0 ]]; then
+            generation="$(gcloud storage objects describe \
+              "$lock_uri" --format='value(generation)')"
+            [[ "$generation" =~ ^[1-9][0-9]*$ ]]
+            record_execution true "$current_results_id" "$generation"
+            exit 0
+          fi
+
+          generation="$(gcloud storage objects describe \
+            "$lock_uri" --format='value(generation)')"
+          [[ "$generation" =~ ^[1-9][0-9]*$ ]]
+          if ! gcloud storage cp "$lock_uri" "$existing_lock"; then
+            echo "Could not read the existing Firebase execution lease." >&2
+            exit 1
+          fi
+          observed_generation="$(gcloud storage objects describe \
+            "$lock_uri" --format='value(generation)')"
+          if [[ "$observed_generation" != "$generation" ]]; then
+            echo "Firebase execution lease changed while it was being read." >&2
+            exit 78
+          fi
+
+          state="$(awk -F= '$1 == "state" { print $2; exit }' "$existing_lock")"
+          owner_run_id="$(awk -F= '$1 == "run_id" { print $2; exit }' "$existing_lock")"
+          results_id="$(awk -F= '$1 == "results_id" { print $2; exit }' "$existing_lock")"
+          acquired_at="$(awk -F= '$1 == "acquired_at" { print $2; exit }' "$existing_lock")"
+
+          takeover_reason=
+          if [[ "$state" == complete ]]; then
+            if [[ ! "$results_id" =~ ^[1-9][0-9]*-[1-9][0-9]*$ ]]; then
+              echo "Completed Firebase lease has an invalid results ID." >&2
+              exit 1
+            fi
+            if completed_results_available "$results_id"; then
+              echo "Reusing completed Firebase results ${results_id}."
+              record_execution false "$results_id" "$generation"
+              exit 0
+            fi
+            takeover_reason="completed results are no longer available"
+          fi
+
+          if [[ -z "$takeover_reason" && "$owner_run_id" == "$GITHUB_RUN_ID" ]]; then
+            takeover_reason="retry of the lease owner"
+          elif [[ -z "$takeover_reason" && -z "$acquired_at" ]]; then
+            takeover_reason="legacy lease without an expiry"
+          elif [[ -z "$takeover_reason" && "$acquired_at" =~ ^[0-9]+$ ]] && \
+            (( now - acquired_at >= FIREBASE_LEASE_TTL_SECONDS )); then
+            takeover_reason="expired lease"
+          fi
+
+          if [[ -z "$takeover_reason" ]]; then
+            echo "Firebase execution lease is active for run ${owner_run_id:-unknown}." >&2
             echo "No Firebase Test Lab execution started." >&2
             exit 78
           fi
 
+          echo "Replacing Firebase execution lease due to ${takeover_reason}."
+          write_running_lock
+          if ! gcloud storage cp \
+            --if-generation-match="$generation" \
+            "$lock_file" \
+            "$lock_uri"; then
+            echo "Firebase execution lease changed while attempting takeover." >&2
+            exit 78
+          fi
+          generation="$(gcloud storage objects describe \
+            "$lock_uri" --format='value(generation)')"
+          [[ "$generation" =~ ^[1-9][0-9]*$ ]]
+          record_execution true "$current_results_id" "$generation"
+
       - name: Run both renderers once in Firebase Test Lab
+        if: ${{ steps.firebase_lease.outputs.run_firebase == 'true' }}
+        env:
+          FIREBASE_RESULTS_ID: ${{ steps.firebase_lease.outputs.results_id }}
         shell: bash
         run: |
           set -euo pipefail
@@ -583,7 +735,7 @@ jobs:
             local renderer="$1"
             local application_id="$2"
             local external_dir="/sdcard/Android/data/${application_id}/files"
-            local results_dir="visual-parity/${GITHUB_SHA}/${GITHUB_RUN_ID}/${renderer}"
+            local results_dir="visual-parity/${GITHUB_SHA}/${FIREBASE_RESULTS_ID}/${renderer}"
             local apk_dir="gs://${FIREBASE_RESULTS_BUCKET}/visual-parity-apks/${GITHUB_SHA}/${renderer}"
             local app_apk="${apk_dir}/app.apk"
             local test_apk="${apk_dir}/test.apk"
@@ -606,7 +758,7 @@ jobs:
               --environment-variables="visualScenes=${ANDROID_E2E_SCENES}" \
               --num-flaky-test-attempts=0 \
               --results-dir="$results_dir" \
-              --client-details=matrixLabel="visual-parity-${renderer}-${GITHUB_RUN_ID}" \
+              --client-details=matrixLabel="visual-parity-${renderer}-${FIREBASE_RESULTS_ID}" \
               --format=json >"$matrix_json" 2>"$matrix_stderr"
             status=$?
             set -e
@@ -621,8 +773,6 @@ jobs:
             if [[ "$status" -ne 0 ]]; then
               return "$status"
             fi
-
-            collect_renderer "$renderer" "$results_dir"
           }
 
           upload_with_retry() {
@@ -640,9 +790,26 @@ jobs:
             done
           }
 
+          run_renderer \
+            maplibre_gl \
+            dev.maplibre.fluttergpu.e2e.visual_e2e_maplibre_gl
+          run_renderer \
+            gpu \
+            dev.maplibre.fluttergpu.e2e.visual_e2e_gpu
+
+      - name: Collect Firebase screenshots
+        if: ${{ always() && steps.firebase_lease.outcome == 'success' }}
+        env:
+          FIREBASE_RESULTS_ID: ${{ steps.firebase_lease.outputs.results_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          output="$RUNNER_TEMP/android-e2e-results"
+          mkdir -p "$output/logs" "$output/screenshots"
+
           collect_renderer() {
             local renderer="$1"
-            local results_dir="$2"
+            local results_dir="visual-parity/${GITHUB_SHA}/${FIREBASE_RESULTS_ID}/${renderer}"
             local listing="$output/logs/${renderer}-objects.txt"
             local attempt
             for attempt in 1 2 3; do
@@ -680,12 +847,29 @@ jobs:
             done < <(tr '|' '\n' <<<"$ANDROID_E2E_SCENES")
           }
 
-          run_renderer \
-            maplibre_gl \
-            dev.maplibre.fluttergpu.e2e.visual_e2e_maplibre_gl
-          run_renderer \
-            gpu \
-            dev.maplibre.fluttergpu.e2e.visual_e2e_gpu
+          collect_renderer maplibre_gl
+          collect_renderer gpu
+
+      - name: Mark Firebase results complete
+        if: ${{ steps.firebase_lease.outputs.run_firebase == 'true' }}
+        env:
+          FIREBASE_LOCK_GENERATION: ${{ steps.firebase_lease.outputs.lock_generation }}
+          FIREBASE_RESULTS_ID: ${{ steps.firebase_lease.outputs.results_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          completed_lock="$RUNNER_TEMP/android-e2e-complete.lock"
+          lock_uri="gs://${FIREBASE_RESULTS_BUCKET}/visual-parity-locks/${GITHUB_SHA}.lock"
+          printf 'state=complete\nsha=%s\nrun_id=%s\nrun_attempt=%s\nresults_id=%s\ncompleted_at=%s\n' \
+            "$GITHUB_SHA" \
+            "$GITHUB_RUN_ID" \
+            "$GITHUB_RUN_ATTEMPT" \
+            "$FIREBASE_RESULTS_ID" \
+            "$(date +%s)" >"$completed_lock"
+          gcloud storage cp \
+            --if-generation-match="$FIREBASE_LOCK_GENERATION" \
+            "$completed_lock" \
+            "$lock_uri"
 
       - name: Upload Firebase Test Lab results
         if: ${{ always() }}
@@ -698,51 +882,22 @@ jobs:
           overwrite: true
 
   android_visual:
-    name: Android visual parity / ${{ matrix.scene }}
+    name: Android visual parity / ${{ matrix.group }}
     if: ${{ always() && needs.android_e2e_firebase.result == 'success' }}
     needs:
       - android_e2e_firebase
-    runs-on: macos-15-intel
-    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
         include:
-          - scene: geometry
-            minimum_similarity: '0.998'
-            minimum_content_retention: '0'
-          - scene: text-symbol
-            minimum_similarity: '0.970'
-            minimum_content_retention: '0.700'
-          - scene: 3d-buildings
-            minimum_similarity: '0.880'
-            minimum_content_retention: '0.700'
-          - scene: mvt
-            minimum_similarity: '0.980'
-            minimum_content_retention: '0.700'
-          - scene: tilejson-mvt
-            minimum_similarity: '0.980'
-            minimum_content_retention: '0.700'
-          - scene: image-source
-            minimum_similarity: '0.980'
-            minimum_content_retention: '0.700'
-          - scene: geojson-url
-            minimum_similarity: '0.980'
-            minimum_content_retention: '0.700'
-          - scene: raster-jpeg
-            minimum_similarity: '0.980'
-            minimum_content_retention: '0.700'
-          - scene: raster-webp
-            minimum_similarity: '0.980'
-            minimum_content_retention: '0.700'
-          - scene: raster-tms
-            minimum_similarity: '0.980'
-            minimum_content_retention: '0.700'
-          - scene: wmts
-            minimum_similarity: '0.980'
-            minimum_content_retention: '0.700'
+          - group: core
+            scenes: geometry|text-symbol|3d-buildings|mvt|tilejson-mvt|image-source
+          - group: sources
+            scenes: geojson-url|raster-jpeg|raster-webp|raster-tms|wmts
     steps:
       - name: Check out source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -763,43 +918,79 @@ jobs:
           name: android-e2e-results
           path: ${{ runner.temp }}/android-e2e-results
 
-      - name: Prepare renderer screenshots
+      - name: Resolve visual runner dependencies
+        working-directory: e2e/visual/runner
+        run: dart pub get --enforce-lockfile
+
+      - name: Compare Android renderers
+        env:
+          ANDROID_VISUAL_SCENES: ${{ matrix.scenes }}
         shell: bash
         run: |
           set -euo pipefail
-          images="e2e/visual/report/${{ matrix.scene }}/images"
-          mkdir -p "$images"
-          install -m 0644 \
-            "$RUNNER_TEMP/android-e2e-results/screenshots/${{ matrix.scene }}/maplibre_gl.png" \
-            "$images/maplibre_gl.png"
-          install -m 0644 \
-            "$RUNNER_TEMP/android-e2e-results/screenshots/${{ matrix.scene }}/gpu.png" \
-            "$images/gpu.png"
+          failed=0
+          while IFS= read -r scene; do
+            case "$scene" in
+              geometry)
+                minimum_similarity=0.998
+                minimum_content_retention=0
+                ;;
+              text-symbol)
+                minimum_similarity=0.970
+                minimum_content_retention=0.700
+                ;;
+              3d-buildings)
+                minimum_similarity=0.880
+                minimum_content_retention=0.700
+                ;;
+              *)
+                minimum_similarity=0.980
+                minimum_content_retention=0.700
+                ;;
+            esac
 
-      - name: Compare Android renderers
-        run: >-
-          ./e2e/visual/run_android.sh
-          --skip-drive
-          --scene "${{ matrix.scene }}"
-          --output "e2e/visual/report/${{ matrix.scene }}"
-          --minimum-similarity "${{ matrix.minimum_similarity }}"
-          --minimum-content-retention "${{ matrix.minimum_content_retention }}"
+            report="e2e/visual/report/$scene"
+            images="$report/images"
+            mkdir -p "$images"
+            if ! install -m 0644 \
+              "$RUNNER_TEMP/android-e2e-results/screenshots/$scene/maplibre_gl.png" \
+              "$images/maplibre_gl.png" || \
+              ! install -m 0644 \
+                "$RUNNER_TEMP/android-e2e-results/screenshots/$scene/gpu.png" \
+                "$images/gpu.png"; then
+              echo "Missing Firebase screenshots for ${scene}." >&2
+              failed=1
+              continue
+            fi
+
+            if ! (
+              cd e2e/visual/runner
+              dart run bin/run_android.dart \
+                --skip-drive \
+                --scene "$scene" \
+                --output "$report" \
+                --minimum-similarity "$minimum_similarity" \
+                --minimum-content-retention "$minimum_content_retention"
+            ); then
+              failed=1
+            fi
+          done < <(tr '|' '\n' <<<"$ANDROID_VISUAL_SCENES")
+          exit "$failed"
 
       - name: Upload Android visual report
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: android-visual-parity-${{ matrix.scene }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: e2e/visual/report/${{ matrix.scene }}/
+          name: android-visual-parity-${{ matrix.group }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: e2e/visual/report/
           if-no-files-found: warn
           retention-days: 14
 
   native_macos:
     name: macOS native artifact
-    if: ${{ always() && needs.quality.result == 'success' && needs.android_visual.result == 'success' }}
+    if: ${{ always() && needs.native_ios.result == 'success' }}
     needs:
-      - quality
-      - android_visual
+      - native_ios
     uses: ./.github/workflows/_native-artifacts.yml
     with:
       retention_days: 7
@@ -820,6 +1011,7 @@ jobs:
     if: ${{ always() }}
     needs:
       - quality
+      - firebase_preflight
       - native_ios
       - consumer_ios
       - ios_visual
@@ -834,12 +1026,13 @@ jobs:
       - package
       - macos_visual
       - macos_functional
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Check required jobs
         env:
           QUALITY_RESULT: ${{ needs.quality.result }}
+          FIREBASE_PREFLIGHT_RESULT: ${{ needs.firebase_preflight.result }}
           IOS_NATIVE_RESULT: ${{ needs.native_ios.result }}
           IOS_CONSUMER_RESULT: ${{ needs.consumer_ios.result }}
           IOS_VISUAL_RESULT: ${{ needs.ios_visual.result }}
@@ -858,6 +1051,7 @@ jobs:
         run: |
           set -euo pipefail
           test "$QUALITY_RESULT" = success
+          test "$FIREBASE_PREFLIGHT_RESULT" = success
           test "$IOS_NATIVE_RESULT" = success
           test "$IOS_CONSUMER_RESULT" = success
           test "$IOS_VISUAL_RESULT" = success

--- a/e2e/visual/run_ios.sh
+++ b/e2e/visual/run_ios.sh
@@ -16,6 +16,7 @@ drive_retries="${VISUAL_E2E_IOS_DRIVE_RETRIES:-2}"
 idle_retries="${VISUAL_E2E_IOS_IDLE_RETRIES:-1}"
 drive_kill_grace_seconds="${VISUAL_E2E_IOS_DRIVE_KILL_GRACE_SECONDS:-5}"
 simctl_timeout_seconds="${VISUAL_E2E_IOS_SIMCTL_TIMEOUT_SECONDS:-300}"
+simctl_cleanup_timeout_seconds="${VISUAL_E2E_IOS_SIMCTL_CLEANUP_TIMEOUT_SECONDS:-30}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -78,6 +79,10 @@ if ! [[ "$drive_kill_grace_seconds" =~ ^[1-9][0-9]*$ ]]; then
 fi
 if ! [[ "$simctl_timeout_seconds" =~ ^[1-9][0-9]*$ ]]; then
   echo "VISUAL_E2E_IOS_SIMCTL_TIMEOUT_SECONDS must be a positive integer." >&2
+  exit 2
+fi
+if ! [[ "$simctl_cleanup_timeout_seconds" =~ ^[1-9][0-9]*$ ]]; then
+  echo "VISUAL_E2E_IOS_SIMCTL_CLEANUP_TIMEOUT_SECONDS must be a positive integer." >&2
   exit 2
 fi
 
@@ -264,9 +269,11 @@ run_with_deadline() {
 }
 
 run_optional_simctl() {
+  local timeout_seconds="$1"
+  shift
   local status=0
 
-  if run_with_deadline "$simctl_timeout_seconds" xcrun simctl "$@"; then
+  if run_with_deadline "$timeout_seconds" xcrun simctl "$@"; then
     status=0
   else
     status=$?
@@ -324,7 +331,7 @@ configure_simulator_status_bar() {
 }
 
 boot_simulator() {
-  run_optional_simctl boot "$device"
+  run_optional_simctl "$simctl_timeout_seconds" boot "$device"
   open -gj -a Simulator 2>/dev/null || true
   run_with_deadline "$simctl_timeout_seconds" \
     xcrun simctl bootstatus "$device" -b
@@ -332,7 +339,7 @@ boot_simulator() {
 }
 
 restart_simulator() {
-  run_optional_simctl shutdown "$device"
+  run_optional_simctl "$simctl_cleanup_timeout_seconds" shutdown "$device"
   boot_simulator
 }
 
@@ -360,6 +367,7 @@ run_fixture() {
   local capture_name=""
   local bundle_id=""
   local timeout_marker="$output/logs/.$label-drive-timeout"
+  local scenes_define=""
   if [[ "$label" == "maplibre_gl" ]]; then
     bundle_id="dev.maplibre.fluttergpu.e2e.visualE2eMaplibreGl"
     capture_name="maplibre_gl"
@@ -374,150 +382,166 @@ run_fixture() {
     flutter pub get
   ) 2>&1 | tee "$output/logs/$label-pub-get.log"
 
-  run_optional_simctl uninstall "$device" "$bundle_id"
+  run_optional_simctl \
+    "$simctl_cleanup_timeout_seconds" uninstall "$device" "$bundle_id"
 
   : >"$output/logs/$label-drive.log"
   for scene in "${scenes[@]}"; do
     rm -f "$output/logs/$label-$scene-attempt-"*.log
-    local invocation=1
-    local timeout_attempt=1
-    local idle_attempt=1
-    local max_timeout_attempts=$((drive_retries + 1))
-    local max_idle_attempts=$((idle_retries + 1))
+  done
 
-    while true; do
-      local scene_capture_dir="$capture_dir/$label/$scene/attempt-$invocation"
-      local current_log="$scene_capture_dir/drive.log"
-      local watchdog_ready_marker="$scene_capture_dir/watchdog-ready"
-      local performance_output=""
-      local canonical_capture=""
-      local canonical_performance=""
-      local -a dart_defines=(
-        --dart-define="VISUAL_E2E_SCENE=$scene"
+  scenes_define="$(IFS=,; echo "${scenes[*]}")"
+  local invocation=1
+  local timeout_attempt=1
+  local idle_attempt=1
+  local max_timeout_attempts=$((drive_retries + 1))
+  local max_idle_attempts=$((idle_retries + 1))
+  local fixture_drive_timeout_seconds=$((drive_timeout_seconds * ${#scenes[@]}))
+  local drive_description="scenes $scenes_define"
+  if [[ "${#scenes[@]}" -eq 1 ]]; then
+    drive_description="scene ${scenes[0]}"
+  fi
+
+  while true; do
+    local fixture_capture_dir="$capture_dir/$label/attempt-$invocation"
+    local current_log="$fixture_capture_dir/drive.log"
+    local watchdog_ready_marker="$fixture_capture_dir/watchdog-ready"
+    local performance_output=""
+    local canonical_performance=""
+    local -a dart_defines=()
+    mkdir -p "$fixture_capture_dir"
+    rm -f "$timeout_marker"
+
+    if [[ "${#scenes[@]}" -eq 1 ]]; then
+      dart_defines+=(--dart-define="VISUAL_E2E_SCENE=${scenes[0]}")
+    else
+      dart_defines+=(--dart-define="VISUAL_E2E_SCENES=$scenes_define")
+    fi
+    if [[ -n "$zoom" ]]; then
+      dart_defines+=(--dart-define="VISUAL_E2E_ZOOM=$zoom")
+    fi
+    if [[ "$performance" == true ]]; then
+      dart_defines+=(
+        --dart-define=VISUAL_E2E_PERFORMANCE=true
+        --dart-define="VISUAL_E2E_PERFORMANCE_ENVIRONMENT=iOS Simulator"
       )
-      mkdir -p "$scene_capture_dir"
-      rm -f "$timeout_marker"
+      performance_output="$fixture_capture_dir/performance.json"
+      canonical_performance="$output/performance/$label.json"
+    fi
 
-      if [[ -n "$zoom" ]]; then
-        dart_defines+=(--dart-define="VISUAL_E2E_ZOOM=$zoom")
-      fi
-      if [[ "$performance" == true ]]; then
-        dart_defines+=(
-          --dart-define=VISUAL_E2E_PERFORMANCE=true
-          --dart-define="VISUAL_E2E_PERFORMANCE_ENVIRONMENT=iOS Simulator"
-        )
-        performance_output="$scene_capture_dir/performance.json"
-        canonical_performance="$output/performance/$label.json"
-      fi
-
-      echo "[$label] running iOS visual scene $scene, attempt $invocation"
-      (
-        cd "$root"
-        exec env \
-          VISUAL_E2E_SCREENSHOT_DIR="$scene_capture_dir" \
-          VISUAL_E2E_PERFORMANCE_OUTPUT="$performance_output" \
-          ruby -e \
-            'Process.setsid unless Process.getpgrp == Process.pid; exec(*ARGV)' \
-            flutter drive \
-            --driver=test_driver/integration_test.dart \
-            --target=integration_test/visual_test.dart \
-            --device-id="$device" \
-            "${dart_defines[@]}"
-      ) >"$current_log" 2>&1 &
-      local drive_pid=$!
-      active_drive_pid="$drive_pid"
-      (
-        local watchdog_sleep_pid=""
-        stop_watchdog_sleep() {
-          if [[ -n "$watchdog_sleep_pid" ]]; then
-            kill -TERM "$watchdog_sleep_pid" 2>/dev/null || true
-            wait "$watchdog_sleep_pid" 2>/dev/null || true
-          fi
-        }
-        trap 'stop_watchdog_sleep; exit 0' TERM INT
-        sleep "$drive_timeout_seconds" &
+    echo "[$label] running iOS visual $drive_description, attempt $invocation"
+    (
+      cd "$root"
+      exec env \
+        VISUAL_E2E_SCREENSHOT_DIR="$fixture_capture_dir" \
+        VISUAL_E2E_PERFORMANCE_OUTPUT="$performance_output" \
+        ruby -e \
+          'Process.setsid unless Process.getpgrp == Process.pid; exec(*ARGV)' \
+          flutter drive \
+          --driver=test_driver/integration_test.dart \
+          --target=integration_test/visual_test.dart \
+          --device-id="$device" \
+          "${dart_defines[@]}"
+    ) >"$current_log" 2>&1 &
+    local drive_pid=$!
+    active_drive_pid="$drive_pid"
+    (
+      local watchdog_sleep_pid=""
+      stop_watchdog_sleep() {
+        if [[ -n "$watchdog_sleep_pid" ]]; then
+          kill -TERM "$watchdog_sleep_pid" 2>/dev/null || true
+          wait "$watchdog_sleep_pid" 2>/dev/null || true
+        fi
+      }
+      trap 'stop_watchdog_sleep; exit 0' TERM INT
+      sleep "$fixture_drive_timeout_seconds" &
+      watchdog_sleep_pid=$!
+      touch "$watchdog_ready_marker"
+      wait "$watchdog_sleep_pid"
+      watchdog_sleep_pid=""
+      if managed_process_exists "$drive_pid"; then
+        touch "$timeout_marker"
+        echo "[$label] $drive_description timed out after ${fixture_drive_timeout_seconds}s." >&2
+        terminate_process_group "$drive_pid"
+        /bin/sleep "$drive_kill_grace_seconds" &
         watchdog_sleep_pid=$!
-        touch "$watchdog_ready_marker"
         wait "$watchdog_sleep_pid"
         watchdog_sleep_pid=""
-        if managed_process_exists "$drive_pid"; then
-          touch "$timeout_marker"
-          echo "[$label] scene $scene timed out after ${drive_timeout_seconds}s." >&2
-          terminate_process_group "$drive_pid"
-          /bin/sleep "$drive_kill_grace_seconds" &
-          watchdog_sleep_pid=$!
-          wait "$watchdog_sleep_pid"
-          watchdog_sleep_pid=""
-          force_kill_process_group "$drive_pid"
-        fi
-        trap - TERM INT
-      ) &
-      local watchdog_pid=$!
-      active_watchdog_pid="$watchdog_pid"
-      while [[ ! -f "$watchdog_ready_marker" ]]; do
-        if ! kill -0 "$watchdog_pid" 2>/dev/null; then
-          wait "$watchdog_pid" 2>/dev/null || true
-          active_watchdog_pid=""
-          echo "[$label] scene $scene watchdog failed to start." >&2
-          return 1
-        fi
-        /bin/sleep 0.01
-      done
-
-      set +e
-      wait "$drive_pid"
-      local drive_status=$?
-      set -e
-      if [[ ! -f "$timeout_marker" ]]; then
-        kill -TERM "$watchdog_pid" 2>/dev/null || true
+        force_kill_process_group "$drive_pid"
       fi
-      wait "$watchdog_pid" 2>/dev/null || true
-      active_watchdog_pid=""
-      active_drive_pid=""
-      local attempt_log="$output/logs/$label-$scene-attempt-$invocation.log"
-      cp "$current_log" "$attempt_log"
-      tee -a "$output/logs/$label-drive.log" <"$attempt_log"
+      trap - TERM INT
+    ) &
+    local watchdog_pid=$!
+    active_watchdog_pid="$watchdog_pid"
+    while [[ ! -f "$watchdog_ready_marker" ]]; do
+      if ! kill -0 "$watchdog_pid" 2>/dev/null; then
+        wait "$watchdog_pid" 2>/dev/null || true
+        active_watchdog_pid=""
+        echo "[$label] $drive_description watchdog failed to start." >&2
+        return 1
+      fi
+      /bin/sleep 0.01
+    done
 
-      if [[ "$drive_status" -eq 0 && ! -f "$timeout_marker" ]]; then
-        if [[ "${#scenes[@]}" -eq 1 ]]; then
-          canonical_capture="$capture_dir/$capture_name.png"
-        else
+    set +e
+    wait "$drive_pid"
+    local drive_status=$?
+    set -e
+    if [[ ! -f "$timeout_marker" ]]; then
+      kill -TERM "$watchdog_pid" 2>/dev/null || true
+    fi
+    wait "$watchdog_pid" 2>/dev/null || true
+    active_watchdog_pid=""
+    active_drive_pid=""
+    for scene in "${scenes[@]}"; do
+      cp \
+        "$current_log" \
+        "$output/logs/$label-$scene-attempt-$invocation.log"
+    done
+    tee -a "$output/logs/$label-drive.log" <"$current_log"
+
+    if [[ "$drive_status" -eq 0 && ! -f "$timeout_marker" ]]; then
+      for scene in "${scenes[@]}"; do
+        local attempt_capture="$fixture_capture_dir/$capture_name.png"
+        local canonical_capture="$capture_dir/$capture_name.png"
+        if [[ "${#scenes[@]}" -gt 1 ]]; then
+          attempt_capture="$fixture_capture_dir/$capture_name-$scene.png"
           canonical_capture="$capture_dir/$capture_name-$scene.png"
         fi
-        cp "$scene_capture_dir/$capture_name.png" "$canonical_capture"
-        if [[ "$performance" == true ]]; then
-          cp "$performance_output" "$canonical_performance"
-        fi
-        break
+        cp "$attempt_capture" "$canonical_capture"
+      done
+      if [[ "$performance" == true ]]; then
+        cp "$performance_output" "$canonical_performance"
       fi
+      break
+    fi
 
-      run_optional_simctl terminate "$device" "$bundle_id"
-      run_optional_simctl uninstall "$device" "$bundle_id"
-      if [[ -f "$timeout_marker" ]]; then
-        if [[ "$timeout_attempt" -ge "$max_timeout_attempts" ]]; then
-          echo "[$label] scene $scene timed out after $timeout_attempt attempts." >&2
-          return 124
-        fi
-        echo "[$label] retrying scene $scene after timeout." >&2
-        if [[ "$timeout_attempt" -gt 1 ]]; then
-          restart_simulator
-        fi
-        timeout_attempt=$((timeout_attempt + 1))
-        invocation=$((invocation + 1))
-        continue
+    run_optional_simctl \
+      "$simctl_cleanup_timeout_seconds" terminate "$device" "$bundle_id"
+    run_optional_simctl \
+      "$simctl_cleanup_timeout_seconds" uninstall "$device" "$bundle_id"
+    if [[ -f "$timeout_marker" ]]; then
+      if [[ "$timeout_attempt" -ge "$max_timeout_attempts" ]]; then
+        echo "[$label] $drive_description timed out after $timeout_attempt attempts." >&2
+        return 124
       fi
-      if ! grep -Fq 'did not become idle' "$current_log"; then
-        echo "[$label] scene $scene failed for a reason other than the idle timeout." >&2
-        return "$drive_status"
-      fi
-      if [[ "$idle_attempt" -ge "$max_idle_attempts" ]]; then
-        echo "[$label] scene $scene did not become idle after $idle_attempt attempts." >&2
-        return "$drive_status"
-      fi
-      echo "[$label] retrying scene $scene after the idle timeout." >&2
-      idle_attempt=$((idle_attempt + 1))
+      echo "[$label] retrying $drive_description after timeout." >&2
+      restart_simulator
+      timeout_attempt=$((timeout_attempt + 1))
       invocation=$((invocation + 1))
-    done
+      continue
+    fi
+    if ! grep -Fq 'did not become idle' "$current_log"; then
+      echo "[$label] $drive_description failed for a reason other than the idle timeout." >&2
+      return "$drive_status"
+    fi
+    if [[ "$idle_attempt" -ge "$max_idle_attempts" ]]; then
+      echo "[$label] $drive_description did not become idle after $idle_attempt attempts." >&2
+      return "$drive_status"
+    fi
+    echo "[$label] retrying $drive_description after the idle timeout." >&2
+    idle_attempt=$((idle_attempt + 1))
+    invocation=$((invocation + 1))
   done
 }
 

--- a/e2e/visual/runner/test/run_ios_cli_test.dart
+++ b/e2e/visual/runner/test/run_ios_cli_test.dart
@@ -18,7 +18,7 @@ const _ciScenes = <String>[
 ];
 
 void main() {
-  test('all CI scenes run in separate processes for both fixtures', () async {
+  test('all CI scenes run in one process for each fixture', () async {
     final harness = await _IosCliHarness.create(
       environment: const <String, String>{'FAKE_FLUTTER_DELAY_SECONDS': '0.05'},
     );
@@ -28,22 +28,22 @@ void main() {
 
     expect(result.exitCode, 0, reason: '${result.stdout}\n${result.stderr}');
     final driveCalls = harness.driveCalls;
-    expect(driveCalls, hasLength(_ciScenes.length * 2));
+    expect(driveCalls, hasLength(2));
     expect(driveCalls.map(_fixture), <String>[
-      for (final _ in _ciScenes) 'maplibre_gl',
-      for (final _ in _ciScenes) 'maplibre_flutter_gpu',
+      'maplibre_gl',
+      'maplibre_flutter_gpu',
     ]);
-    expect(driveCalls.map(_sceneDefine), <String?>[..._ciScenes, ..._ciScenes]);
+    expect(driveCalls.map(_scenesDefine), everyElement(_ciScenes.join(',')));
     for (final arguments in driveCalls) {
       expect(
         arguments.where(
-          (argument) => argument.startsWith('--dart-define=VISUAL_E2E_SCENES='),
+          (argument) => argument.startsWith('--dart-define=VISUAL_E2E_SCENE='),
         ),
         isEmpty,
       );
     }
     expect(harness.watchdogSleeps, isNotEmpty);
-    expect(harness.watchdogSleeps, everyElement('600'));
+    expect(harness.watchdogSleeps, everyElement('${600 * _ciScenes.length}'));
 
     for (final scene in _ciScenes) {
       expect(
@@ -98,7 +98,7 @@ void main() {
     );
   });
 
-  test('an idle failure retries only that fixture scene', () async {
+  test('an idle failure retries that fixture batch', () async {
     final harness = await _IosCliHarness.create(
       environment: const <String, String>{
         'FAKE_FLUTTER_FAIL_FIXTURE': 'maplibre_gl',
@@ -117,22 +117,26 @@ void main() {
     expect(result.exitCode, 0, reason: '${result.stdout}\n${result.stderr}');
     expect(
       harness.driveCalls.map(
-        (call) => '${_fixture(call)}:${_sceneDefine(call)}',
+        (call) => '${_fixture(call)}:${_scenesDefine(call)}',
       ),
       <String>[
-        'maplibre_gl:geometry',
-        'maplibre_gl:geometry',
-        'maplibre_gl:text-symbol',
-        'maplibre_flutter_gpu:geometry',
-        'maplibre_flutter_gpu:text-symbol',
+        'maplibre_gl:geometry,text-symbol',
+        'maplibre_gl:geometry,text-symbol',
+        'maplibre_flutter_gpu:geometry,text-symbol',
       ],
     );
-    expect(result.stderr, contains('retrying scene geometry'));
+    expect(result.stderr, contains('retrying scenes geometry,text-symbol'));
     expect(
       File(
         '${harness.output.path}/geometry/images/maplibre_gl.png',
       ).readAsStringSync(),
       'maplibre_gl:geometry:2',
+    );
+    expect(
+      File(
+        '${harness.output.path}/text-symbol/images/maplibre_gl.png',
+      ).readAsStringSync(),
+      'maplibre_gl:text-symbol:2',
     );
     final driveLog = File(
       '${harness.output.path}/logs/maplibre_gl-drive.log',
@@ -146,7 +150,7 @@ void main() {
     );
   });
 
-  test('a non-idle failure is not retried and stops later scenes', () async {
+  test('a non-idle failure is not retried', () async {
     final harness = await _IosCliHarness.create(
       environment: const <String, String>{
         'FAKE_FLUTTER_FAIL_FIXTURE': 'maplibre_gl',
@@ -167,82 +171,86 @@ void main() {
     expect(result.stderr, contains('reason other than the idle timeout'));
     expect(harness.driveCalls, hasLength(1));
     expect(_fixture(harness.driveCalls.single), 'maplibre_gl');
-    expect(_sceneDefine(harness.driveCalls.single), 'geometry');
+    expect(_scenesDefine(harness.driveCalls.single), 'geometry,text-symbol');
   });
 
-  test('a drive timeout retries only that fixture scene', () async {
-    final harness = await _IosCliHarness.create(
-      environment: const <String, String>{
-        'FAKE_FLUTTER_FAIL_FIXTURE': 'maplibre_gl',
-        'FAKE_FLUTTER_FAIL_SCENE': 'geometry',
-        'FAKE_FLUTTER_FAIL_COUNT': '1',
-        'FAKE_FLUTTER_FAIL_KIND': 'timeout',
-        'VISUAL_E2E_IOS_DRIVE_TIMEOUT_SECONDS': '1',
-        'VISUAL_E2E_IOS_DRIVE_RETRIES': '1',
-      },
-    );
-    addTearDown(harness.dispose);
+  test(
+    'a drive timeout retries that fixture batch after a cold restart',
+    () async {
+      final harness = await _IosCliHarness.create(
+        environment: const <String, String>{
+          'FAKE_FLUTTER_FAIL_FIXTURE': 'maplibre_gl',
+          'FAKE_FLUTTER_FAIL_SCENE': 'geometry',
+          'FAKE_FLUTTER_FAIL_COUNT': '1',
+          'FAKE_FLUTTER_FAIL_KIND': 'timeout',
+          'VISUAL_E2E_IOS_DRIVE_TIMEOUT_SECONDS': '1',
+          'VISUAL_E2E_IOS_DRIVE_RETRIES': '1',
+        },
+      );
+      addTearDown(harness.dispose);
 
-    final result = await harness.run(<String>[
-      '--scenes',
-      'geometry,text-symbol',
-    ]);
+      final result = await harness.run(<String>[
+        '--scenes',
+        'geometry,text-symbol',
+      ]);
 
-    expect(result.exitCode, 0, reason: '${result.stdout}\n${result.stderr}');
-    expect(
-      harness.driveCalls.map(
-        (call) => '${_fixture(call)}:${_sceneDefine(call)}',
-      ),
-      <String>[
-        'maplibre_gl:geometry',
-        'maplibre_gl:geometry',
-        'maplibre_gl:text-symbol',
-        'maplibre_flutter_gpu:geometry',
-        'maplibre_flutter_gpu:text-symbol',
-      ],
-    );
-    expect(result.stderr, contains('retrying scene geometry after timeout'));
+      expect(result.exitCode, 0, reason: '${result.stdout}\n${result.stderr}');
+      expect(
+        harness.driveCalls.map(
+          (call) => '${_fixture(call)}:${_scenesDefine(call)}',
+        ),
+        <String>[
+          'maplibre_gl:geometry,text-symbol',
+          'maplibre_gl:geometry,text-symbol',
+          'maplibre_flutter_gpu:geometry,text-symbol',
+        ],
+      );
+      expect(
+        result.stderr,
+        contains('retrying scenes geometry,text-symbol after timeout'),
+      );
 
-    final simctlCalls = harness.xcrunCalls
-        .where((call) => call.length >= 2 && call.first == 'simctl')
-        .toList();
-    final retryCleanupStart = simctlCalls.indexWhere(
-      (call) =>
-          call[1] == 'terminate' &&
-          call.last == 'dev.maplibre.fluttergpu.e2e.visualE2eMaplibreGl',
-    );
-    expect(retryCleanupStart, isNonNegative);
-    expect(
-      simctlCalls
-          .sublist(retryCleanupStart, retryCleanupStart + 2)
-          .map((call) => call[1]),
-      <String>['terminate', 'uninstall'],
-    );
-    expect(
-      _simctlOperations(
-        harness.xcrunCalls,
-      ).where((value) => value == 'shutdown'),
-      isEmpty,
-    );
-    expect(
-      _simctlOperations(harness.xcrunCalls).where((value) => value == 'boot'),
-      hasLength(1),
-    );
-    expect(
-      File(
-        '${harness.output.path}/logs/'
-        'maplibre_gl-geometry-attempt-1.log',
-      ).readAsStringSync(),
-      contains('synthetic hung drive'),
-    );
-    expect(
-      File(
-        '${harness.output.path}/logs/'
-        'maplibre_gl-geometry-attempt-2.log',
-      ).readAsStringSync(),
-      contains('flutter-drive maplibre_gl:geometry:2'),
-    );
-  });
+      final simctlCalls = harness.xcrunCalls
+          .where((call) => call.length >= 2 && call.first == 'simctl')
+          .toList();
+      final retryCleanupStart = simctlCalls.indexWhere(
+        (call) =>
+            call[1] == 'terminate' &&
+            call.last == 'dev.maplibre.fluttergpu.e2e.visualE2eMaplibreGl',
+      );
+      expect(retryCleanupStart, isNonNegative);
+      expect(
+        simctlCalls
+            .sublist(retryCleanupStart, retryCleanupStart + 2)
+            .map((call) => call[1]),
+        <String>['terminate', 'uninstall'],
+      );
+      expect(
+        _simctlOperations(
+          harness.xcrunCalls,
+        ).where((value) => value == 'shutdown'),
+        hasLength(1),
+      );
+      expect(
+        _simctlOperations(harness.xcrunCalls).where((value) => value == 'boot'),
+        hasLength(2),
+      );
+      expect(
+        File(
+          '${harness.output.path}/logs/'
+          'maplibre_gl-geometry-attempt-1.log',
+        ).readAsStringSync(),
+        contains('synthetic hung drive'),
+      );
+      expect(
+        File(
+          '${harness.output.path}/logs/'
+          'maplibre_gl-geometry-attempt-2.log',
+        ).readAsStringSync(),
+        contains('flutter-drive maplibre_gl:geometry:2'),
+      );
+    },
+  );
 
   test('repeated drive timeouts cold-restart before the final retry', () async {
     final harness = await _IosCliHarness.create(
@@ -280,8 +288,8 @@ void main() {
         'status_bar',
       ]),
     );
-    expect(operations.where((value) => value == 'shutdown'), hasLength(1));
-    expect(operations.where((value) => value == 'boot'), hasLength(2));
+    expect(operations.where((value) => value == 'shutdown'), hasLength(2));
+    expect(operations.where((value) => value == 'boot'), hasLength(3));
   });
 
   test('a final drive timeout does not reboot the simulator', () async {
@@ -429,6 +437,33 @@ void main() {
     expect(harness.driveCalls, isEmpty);
   });
 
+  test('a stuck simulator cleanup exits at its shorter deadline', () async {
+    final harness = await _IosCliHarness.create(
+      environment: const <String, String>{
+        'FAKE_FLUTTER_FAIL_FIXTURE': 'maplibre_gl',
+        'FAKE_FLUTTER_FAIL_SCENE': 'geometry',
+        'FAKE_FLUTTER_FAIL_COUNT': '1',
+        'FAKE_FLUTTER_FAIL_KIND': 'other',
+        'FAKE_XCRUN_HANG_OPERATION': 'terminate',
+        'VISUAL_E2E_IOS_SIMCTL_CLEANUP_TIMEOUT_SECONDS': '1',
+        'VISUAL_E2E_IOS_DRIVE_KILL_GRACE_SECONDS': '1',
+      },
+    );
+    addTearDown(harness.dispose);
+
+    final stopwatch = Stopwatch()..start();
+    final result = await harness.run(<String>['--scene', 'geometry']);
+    stopwatch.stop();
+
+    expect(result.exitCode, 124);
+    expect(
+      result.stderr,
+      contains('Command timed out after 1s: xcrun simctl terminate'),
+    );
+    expect(stopwatch.elapsed, lessThan(const Duration(seconds: 10)));
+    expect(harness.driveCalls, hasLength(1));
+  });
+
   test(
     'single scene keeps zoom, performance, output, and log contracts',
     () async {
@@ -449,6 +484,13 @@ void main() {
         expect(
           arguments,
           contains('--dart-define=VISUAL_E2E_SCENE=flutter-markers'),
+        );
+        expect(
+          arguments.where(
+            (argument) =>
+                argument.startsWith('--dart-define=VISUAL_E2E_SCENES='),
+          ),
+          isEmpty,
         );
         expect(arguments, contains('--dart-define=VISUAL_E2E_ZOOM=13'));
         expect(
@@ -512,12 +554,44 @@ void main() {
     );
     expect(harness.flutterCalls, isEmpty);
   });
+
+  test('simulator cleanup timeout must be a positive integer', () async {
+    final harness = await _IosCliHarness.create(
+      environment: const <String, String>{
+        'VISUAL_E2E_IOS_SIMCTL_CLEANUP_TIMEOUT_SECONDS': '0',
+      },
+    );
+    addTearDown(harness.dispose);
+
+    final result = await harness.run(const <String>[]);
+
+    expect(result.exitCode, 2);
+    expect(
+      result.stderr,
+      contains(
+        'VISUAL_E2E_IOS_SIMCTL_CLEANUP_TIMEOUT_SECONDS must be a positive '
+        'integer.',
+      ),
+    );
+    expect(harness.flutterCalls, isEmpty);
+  });
 }
 
 String? _fixture(List<String> arguments) => _metadata(arguments, 'FIXTURE=');
 
 String? _sceneDefine(List<String> arguments) {
   const prefix = '--dart-define=VISUAL_E2E_SCENE=';
+  for (final argument in arguments) {
+    if (argument.startsWith(prefix)) {
+      return argument.substring(prefix.length);
+    }
+  }
+
+  return null;
+}
+
+String? _scenesDefine(List<String> arguments) {
+  const prefix = '--dart-define=VISUAL_E2E_SCENES=';
   for (final argument in arguments) {
     if (argument.startsWith(prefix)) {
       return argument.substring(prefix.length);
@@ -783,38 +857,58 @@ if [[ ! -s "$FAKE_WATCHDOG_LOG" ]]; then
 fi
 
 scene=""
+scenes_option=""
 for argument in "$@"; do
   case "$argument" in
     --dart-define=VISUAL_E2E_SCENE=*)
       scene="${argument#--dart-define=VISUAL_E2E_SCENE=}"
       ;;
+    --dart-define=VISUAL_E2E_SCENES=*)
+      scenes_option="${argument#--dart-define=VISUAL_E2E_SCENES=}"
+      ;;
   esac
 done
-if [[ -z "$fixture" || -z "$capture_name" || -z "$scene" || \
+if [[ -n "$scenes_option" ]]; then
+  IFS=',' read -r -a scenes <<<"$scenes_option"
+else
+  scenes=("$scene")
+fi
+if [[ -z "$fixture" || -z "$capture_name" || "${#scenes[@]}" -eq 0 || \
       -z "${VISUAL_E2E_SCREENSHOT_DIR:-}" ]]; then
-  echo "fake flutter could not resolve its fixture, scene, or capture path" >&2
+  echo "fake flutter could not resolve its fixture, scenes, or capture path" >&2
   exit 64
 fi
-
-counter="$FAKE_FLUTTER_STATE/$fixture-$scene.count"
-attempt=1
-if [[ -f "$counter" ]]; then
-  attempt=$(( $(<"$counter") + 1 ))
-fi
-printf '%s' "$attempt" >"$counter"
-echo "flutter-drive $fixture:$scene:$attempt"
-printf '%s' "$$" >"$FAKE_FLUTTER_STATE/$fixture-$scene.drive.pid"
 
 if [[ -n "${FAKE_FLUTTER_DELAY_SECONDS:-}" ]]; then
   /bin/sleep "$FAKE_FLUTTER_DELAY_SECONDS"
 fi
 
 mkdir -p "$VISUAL_E2E_SCREENSHOT_DIR"
-screenshot="$VISUAL_E2E_SCREENSHOT_DIR/$capture_name.png"
-if [[ "$fixture" == "${FAKE_FLUTTER_FAIL_FIXTURE:-}" && \
-      "$scene" == "${FAKE_FLUTTER_FAIL_SCENE:-}" && \
-      "$attempt" -le "${FAKE_FLUTTER_FAIL_COUNT:-0}" ]]; then
-  printf 'stale' >"$screenshot"
+failed_scene=""
+for scene in "${scenes[@]}"; do
+  counter="$FAKE_FLUTTER_STATE/$fixture-$scene.count"
+  attempt=1
+  if [[ -f "$counter" ]]; then
+    attempt=$(( $(<"$counter") + 1 ))
+  fi
+  printf '%s' "$attempt" >"$counter"
+  echo "flutter-drive $fixture:$scene:$attempt"
+  printf '%s' "$$" >"$FAKE_FLUTTER_STATE/$fixture-$scene.drive.pid"
+
+  screenshot="$VISUAL_E2E_SCREENSHOT_DIR/$capture_name.png"
+  if [[ "${#scenes[@]}" -gt 1 ]]; then
+    screenshot="$VISUAL_E2E_SCREENSHOT_DIR/$capture_name-$scene.png"
+  fi
+  printf '%s' "$fixture:$scene:$attempt" >"$screenshot"
+  if [[ "$fixture" == "${FAKE_FLUTTER_FAIL_FIXTURE:-}" && \
+        "$scene" == "${FAKE_FLUTTER_FAIL_SCENE:-}" && \
+        "$attempt" -le "${FAKE_FLUTTER_FAIL_COUNT:-0}" ]]; then
+    printf 'stale' >"$screenshot"
+    failed_scene="$scene"
+  fi
+done
+
+if [[ -n "$failed_scene" ]]; then
   case "${FAKE_FLUTTER_FAIL_KIND:-other}" in
     idle)
       echo "$fixture did not become idle within 60 seconds"
@@ -830,7 +924,7 @@ if [[ "$fixture" == "${FAKE_FLUTTER_FAIL_FIXTURE:-}" && \
         ' &
         child_pid=$!
         printf '%s' "$child_pid" \
-          >"$FAKE_FLUTTER_STATE/$fixture-$scene.child.pid"
+          >"$FAKE_FLUTTER_STATE/$fixture-$failed_scene.child.pid"
         wait "$child_pid" || true
       elif [[ "${FAKE_FLUTTER_IGNORE_TERM:-false}" == "true" ]]; then
         trap '' TERM
@@ -838,7 +932,7 @@ if [[ "$fixture" == "${FAKE_FLUTTER_FAIL_FIXTURE:-}" && \
           /bin/sleep 30 &
           child_pid=$!
           printf '%s' "$child_pid" \
-            >"$FAKE_FLUTTER_STATE/$fixture-$scene.child.pid"
+            >"$FAKE_FLUTTER_STATE/$fixture-$failed_scene.child.pid"
           wait "$child_pid" || true
         done
       else
@@ -852,7 +946,6 @@ if [[ "$fixture" == "${FAKE_FLUTTER_FAIL_FIXTURE:-}" && \
   exit 23
 fi
 
-printf '%s' "$fixture:$scene:$attempt" >"$screenshot"
 if [[ -n "${VISUAL_E2E_PERFORMANCE_OUTPUT:-}" ]]; then
   mkdir -p "$(dirname "$VISUAL_E2E_PERFORMANCE_OUTPUT")"
   printf '{"fixture":"%s"}\n' "$fixture" >"$VISUAL_E2E_PERFORMANCE_OUTPUT"
@@ -894,7 +987,7 @@ const _fakeSleep = r'''#!/usr/bin/env bash
 set -euo pipefail
 
 printf '%s\n' "$*" >>"$FAKE_SLEEP_LOG"
-if [[ "${1:-}" == "600" ]]; then
+if [[ "${1:-}" =~ ^[0-9]+$ && "${1:-}" -ge 600 ]]; then
   printf '%s\n' "$$" >>"$FAKE_WATCHDOG_PID_LOG"
   exec /bin/sleep 4
 fi

--- a/test/coverage_gate_test.dart
+++ b/test/coverage_gate_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../tool/ci/check_coverage.dart';
+
+void main() {
+  test('parses one passing LCOV record', () {
+    final summary = parseLcov('''
+SF:lib/example.dart
+LF:10
+LH:8
+end_of_record
+''');
+
+    expect(summary.linesFound, 10);
+    expect(summary.linesHit, 8);
+    expect(summary.percentage, 80);
+  });
+
+  test('aggregates records before evaluating coverage', () {
+    final summary = parseLcov('''
+SF:lib/first.dart
+LF:10
+LH:4
+end_of_record
+SF:lib/second.dart
+LF:30
+LH:26
+end_of_record
+''');
+
+    expect(summary.linesFound, 40);
+    expect(summary.linesHit, 30);
+    expect(summary.percentage, 75);
+  });
+
+  test('reports coverage below a proposed threshold', () {
+    final summary = parseLcov('LF:5\nLH:2\nend_of_record\n');
+
+    expect(meetsCoverageMinimum(summary, parseMinimumCoverage('40')), isTrue);
+    expect(
+      meetsCoverageMinimum(summary, parseMinimumCoverage('40.01')),
+      isFalse,
+    );
+  });
+
+  test('rejects malformed and inconsistent records', () {
+    expect(() => parseLcov('LF:many\nLH:1\n'), throwsFormatException);
+    expect(() => parseLcov('LF:1\nLH:2\n'), throwsFormatException);
+    expect(() => parseLcov('LF:1\n'), throwsFormatException);
+    expect(() => parseLcov('LF:0\nLH:0\n'), throwsFormatException);
+  });
+
+  test('minimum coverage must be finite and within range', () {
+    expect(parseMinimumCoverage('40'), 40);
+    expect(parseMinimumCoverage('40.5'), 40.5);
+    for (final value in <String>['', '-1', '101', 'NaN', 'Infinity']) {
+      expect(
+        () => parseMinimumCoverage(value),
+        throwsFormatException,
+        reason: value,
+      );
+    }
+  });
+}

--- a/test/gesture_coordinator_test.dart
+++ b/test/gesture_coordinator_test.dart
@@ -1,0 +1,281 @@
+import 'dart:math' as math;
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_flutter_gpu/src/native/maplibre_ffi.dart';
+import 'package:maplibre_flutter_gpu/src/state/gesture/gesture_coordinator.dart';
+import 'package:maplibre_flutter_gpu/src/state/gesture/gesture_options.dart';
+
+class _RecordingBridge implements MaplibreBridge {
+  final List<({double scale, double x, double y})> scaleCalls =
+      <({double scale, double x, double y})>[];
+  final List<Offset> moveCalls = <Offset>[];
+  final List<double> rotationCalls = <double>[];
+  int animatedScaleCalls = 0;
+
+  @override
+  void moveBy(double dx, double dy) => moveCalls.add(Offset(dx, dy));
+
+  @override
+  void scaleBy(double scale, double cx, double cy) {
+    scaleCalls.add((scale: scale, x: cx, y: cy));
+  }
+
+  @override
+  void rotateBy(double degrees) => rotationCalls.add(degrees);
+
+  @override
+  bool scaleByAnimated({
+    required double amount,
+    Offset? focus,
+    required Duration duration,
+    required int easing,
+  }) {
+    animatedScaleCalls++;
+
+    return true;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnsupportedError('unexpected ${invocation.memberName}');
+}
+
+class _FakeHost implements MapGestureHost {
+  _FakeHost({this.bridge, MapGestureSettings? settings})
+    : settings = settings ?? _allGesturesEnabled;
+
+  static const MapGestureSettings _allGesturesEnabled = (
+    scrollEnabled: true,
+    zoomEnabled: true,
+    rotateEnabled: true,
+    tiltEnabled: true,
+    doubleClickZoomEnabled: null,
+  );
+
+  MaplibreBridge? bridge;
+  MapGestureSettings settings;
+  final MapGestureOptions options = const MapGestureOptions();
+  int beginCalls = 0;
+  int endCalls = 0;
+  int renderCalls = 0;
+  int scheduleRepaintCalls = 0;
+
+  @override
+  MaplibreBridge? get gestureBridge => bridge;
+
+  @override
+  MapGestureSettings get gestureSettings => settings;
+
+  @override
+  MapGestureOptions get gestureOptions => options;
+
+  @override
+  Size get logicalMapSize => const Size(400, 300);
+
+  @override
+  void beginCameraGesture() => beginCalls++;
+
+  @override
+  void endCameraGesture() => endCalls++;
+
+  @override
+  void renderGesture() => renderCalls++;
+
+  @override
+  void scheduleRepaint() => scheduleRepaintCalls++;
+}
+
+void main() {
+  testWidgets('coalesces wheel renders within one frame', (tester) async {
+    final bridge = _RecordingBridge();
+    final host = _FakeHost(bridge: bridge);
+    final coordinator = MapGestureCoordinator(
+      vsync: const TestVSync(),
+      host: host,
+    );
+    addTearDown(coordinator.dispose);
+
+    coordinator.onPointerSignal(
+      const PointerScrollEvent(
+        position: Offset(20, 30),
+        scrollDelta: Offset(0, -1),
+      ),
+    );
+    coordinator.onPointerSignal(
+      const PointerScrollEvent(
+        position: Offset(40, 50),
+        scrollDelta: Offset(0, 1),
+      ),
+    );
+
+    expect(bridge.scaleCalls, <({double scale, double x, double y})>[
+      (scale: 1.03, x: 20, y: 30),
+      (scale: 0.97, x: 40, y: 50),
+    ]);
+    expect(host.beginCalls, 2);
+    expect(host.scheduleRepaintCalls, 2);
+    expect(host.renderCalls, 0);
+
+    await tester.pump();
+
+    expect(host.renderCalls, 1);
+  });
+
+  testWidgets('drops scheduled wheel render when bridge becomes unavailable', (
+    tester,
+  ) async {
+    final bridge = _RecordingBridge();
+    final host = _FakeHost(bridge: bridge);
+    final coordinator = MapGestureCoordinator(
+      vsync: const TestVSync(),
+      host: host,
+    );
+    addTearDown(coordinator.dispose);
+
+    coordinator.onPointerSignal(
+      const PointerScrollEvent(
+        position: Offset(20, 30),
+        scrollDelta: Offset(0, -1),
+      ),
+    );
+    host.bridge = null;
+
+    await tester.pump();
+
+    expect(bridge.scaleCalls, hasLength(1));
+    expect(host.renderCalls, 0);
+  });
+
+  testWidgets('suppresses touch scale while every input is disabled', (
+    tester,
+  ) async {
+    final bridge = _RecordingBridge();
+    final host = _FakeHost(
+      bridge: bridge,
+      settings: (
+        scrollEnabled: false,
+        zoomEnabled: false,
+        rotateEnabled: false,
+        tiltEnabled: false,
+        doubleClickZoomEnabled: null,
+      ),
+    );
+    final coordinator = MapGestureCoordinator(
+      vsync: const TestVSync(),
+      host: host,
+    );
+    addTearDown(coordinator.dispose);
+
+    coordinator.onPointerDown(
+      const PointerDownEvent(pointer: 1, position: Offset(10, 10)),
+    );
+    coordinator.onScaleStart(
+      ScaleStartDetails(kind: PointerDeviceKind.touch, pointerCount: 1),
+    );
+    coordinator.onScaleUpdate(
+      ScaleUpdateDetails(focalPointDelta: const Offset(8, 5), pointerCount: 1),
+    );
+
+    expect(coordinator.isScaleGestureActive, isFalse);
+    expect(host.beginCalls, 0);
+    expect(bridge.moveCalls, isEmpty);
+
+    coordinator.onPointerEnd(
+      const PointerUpEvent(pointer: 1, position: Offset(10, 10)),
+    );
+    host.settings = (
+      scrollEnabled: true,
+      zoomEnabled: false,
+      rotateEnabled: false,
+      tiltEnabled: false,
+      doubleClickZoomEnabled: null,
+    );
+    coordinator.onScaleStart(
+      ScaleStartDetails(kind: PointerDeviceKind.touch, pointerCount: 1),
+    );
+    coordinator.onScaleUpdate(
+      ScaleUpdateDetails(focalPointDelta: const Offset(8, 5), pointerCount: 1),
+    );
+
+    expect(coordinator.isScaleGestureActive, isTrue);
+    expect(host.beginCalls, 1);
+    expect(bridge.moveCalls, <Offset>[const Offset(8, 5)]);
+
+    coordinator.onScaleEnd(ScaleEndDetails(pointerCount: 1));
+    await tester.pump();
+  });
+
+  testWidgets('applies incremental trackpad pan zoom and rotation', (
+    tester,
+  ) async {
+    final bridge = _RecordingBridge();
+    final host = _FakeHost(bridge: bridge);
+    final coordinator = MapGestureCoordinator(
+      vsync: const TestVSync(),
+      host: host,
+    );
+    addTearDown(coordinator.dispose);
+
+    coordinator.onScaleStart(
+      ScaleStartDetails(kind: PointerDeviceKind.trackpad, pointerCount: 2),
+    );
+    coordinator.onScaleUpdate(
+      ScaleUpdateDetails(
+        localFocalPoint: const Offset(20, 30),
+        focalPointDelta: const Offset(4, -3),
+        scale: 1.2,
+        rotation: math.pi / 4,
+        pointerCount: 2,
+      ),
+    );
+    coordinator.onScaleUpdate(
+      ScaleUpdateDetails(
+        localFocalPoint: const Offset(25, 35),
+        scale: 1.8,
+        rotation: math.pi / 2,
+        pointerCount: 2,
+      ),
+    );
+
+    expect(host.beginCalls, 1);
+    expect(bridge.moveCalls, <Offset>[const Offset(4, -3)]);
+    expect(bridge.scaleCalls, hasLength(2));
+    expect(bridge.scaleCalls[0].scale, closeTo(1.2, 0.0001));
+    expect(bridge.scaleCalls[1].scale, closeTo(1.5, 0.0001));
+    expect(bridge.rotationCalls, hasLength(2));
+    expect(bridge.rotationCalls[0], closeTo(-45, 0.0001));
+    expect(bridge.rotationCalls[1], closeTo(-45, 0.0001));
+
+    await tester.pump();
+    coordinator.onScaleEnd(ScaleEndDetails(pointerCount: 2));
+
+    expect(host.renderCalls, 2);
+    expect(host.endCalls, 1);
+  });
+
+  testWidgets('dispose cancels pending tap zoom completion', (tester) async {
+    final bridge = _RecordingBridge();
+    final host = _FakeHost(bridge: bridge);
+    final coordinator = MapGestureCoordinator(
+      vsync: const TestVSync(),
+      host: host,
+    );
+
+    coordinator.onDoubleTapDown(
+      TapDownDetails(localPosition: const Offset(80, 90)),
+    );
+    coordinator.onDoubleTap();
+
+    expect(bridge.animatedScaleCalls, 1);
+    expect(host.beginCalls, 1);
+    expect(host.scheduleRepaintCalls, 1);
+
+    coordinator.dispose();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(host.renderCalls, 0);
+    expect(host.endCalls, 0);
+  });
+}

--- a/test/symbol_overlay_test.dart
+++ b/test/symbol_overlay_test.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:maplibre_flutter_gpu/maplibre_flutter_gpu.dart';
 import 'package:maplibre_flutter_gpu/src/sprites/sprite_atlas.dart';
+import 'package:maplibre_flutter_gpu/src/widgets/symbol_overlay.dart'
+    show buildDefaultSymbolText;
 
 LabelData _label(
   String text,
@@ -91,6 +93,127 @@ void main() {
     );
 
     expect(find.text('hidden'), findsNothing);
+  });
+
+  testWidgets('custom symbols receive taps while defaults pass them through', (
+    tester,
+  ) async {
+    final symbol = MapSymbol(
+      key: 'tap-target',
+      data: _label('tap target', 16),
+      textPos: const Offset(100, 100),
+      iconPos: null,
+      icon: null,
+      visible: true,
+      fadeIn: false,
+    );
+    var mapTaps = 0;
+    var symbolTaps = 0;
+
+    Future<void> pump(SymbolWidgetBuilder textBuilder) => tester.pumpWidget(
+      MaterialApp(
+        home: Stack(
+          children: [
+            Positioned.fill(
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () => mapTaps++,
+              ),
+            ),
+            Positioned.fill(
+              child: MapSymbolOverlay(
+                symbols: [symbol],
+                screenSize: const Size(200, 200),
+                onFadedOut: (_) {},
+                textBuilder: textBuilder,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    await pump(buildDefaultSymbolText);
+    await tester.tapAt(tester.getCenter(find.text('tap target')));
+    await tester.pump();
+
+    expect(mapTaps, 1);
+    expect(symbolTaps, 0);
+
+    await pump(
+      (_, _) => GestureDetector(
+        key: const ValueKey('custom-symbol'),
+        behavior: HitTestBehavior.opaque,
+        onTap: () => symbolTaps++,
+        child: const SizedBox(width: 80, height: 40),
+      ),
+    );
+    await tester.tapAt(
+      tester.getCenter(find.byKey(const ValueKey('custom-symbol'))),
+    );
+    await tester.pump();
+
+    expect(mapTaps, 1);
+    expect(symbolTaps, 1);
+  });
+
+  testWidgets('hidden custom symbols pass taps through while fading out', (
+    tester,
+  ) async {
+    var mapTaps = 0;
+    var symbolTaps = 0;
+
+    Future<void> pump(bool visible) => tester.pumpWidget(
+      MaterialApp(
+        home: Stack(
+          children: [
+            Positioned.fill(
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () => mapTaps++,
+              ),
+            ),
+            Positioned.fill(
+              child: MapSymbolOverlay(
+                symbols: [
+                  MapSymbol(
+                    key: 'fading-tap-target',
+                    data: _label('fading tap target', 16),
+                    textPos: const Offset(100, 100),
+                    iconPos: null,
+                    icon: null,
+                    visible: visible,
+                  ),
+                ],
+                screenSize: const Size(200, 200),
+                fadeDuration: const Duration(seconds: 1),
+                onFadedOut: (_) {},
+                textBuilder: (_, _) => GestureDetector(
+                  key: const ValueKey('fading-custom-symbol'),
+                  behavior: HitTestBehavior.opaque,
+                  onTap: () => symbolTaps++,
+                  child: const SizedBox(width: 80, height: 40),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    await pump(true);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+    await pump(false);
+
+    expect(find.byType(AnimatedOpacity), findsOneWidget);
+    await tester.tapAt(
+      tester.getCenter(find.byKey(const ValueKey('fading-custom-symbol'))),
+    );
+    await tester.pump();
+
+    expect(mapTaps, 1);
+    expect(symbolTaps, 0);
   });
 
   testWidgets('symbol culling padding is configurable', (tester) async {

--- a/tool/ci/check_coverage.dart
+++ b/tool/ci/check_coverage.dart
@@ -1,0 +1,153 @@
+import 'dart:io';
+
+/// Aggregated line coverage from an LCOV report.
+final class CoverageSummary {
+  const CoverageSummary({required this.linesFound, required this.linesHit});
+
+  /// Number of executable lines reported by LCOV.
+  final int linesFound;
+
+  /// Number of executable lines reached by tests.
+  final int linesHit;
+
+  /// Percentage of executable lines reached by tests.
+  double get percentage => linesHit * 100 / linesFound;
+}
+
+/// Parses and validates LCOV `LF` and `LH` records.
+CoverageSummary parseLcov(String contents) {
+  var totalFound = 0;
+  var totalHit = 0;
+  int? recordFound;
+  int? recordHit;
+
+  void finishRecord() {
+    if (recordFound == null && recordHit == null) return;
+    if (recordFound == null || recordHit == null) {
+      throw const FormatException('Each LCOV record must contain LF and LH.');
+    }
+    if (recordHit! > recordFound!) {
+      throw const FormatException('LCOV lines hit cannot exceed lines found.');
+    }
+    totalFound += recordFound!;
+    totalHit += recordHit!;
+    recordFound = null;
+    recordHit = null;
+  }
+
+  final lines = contents.split('\n');
+  for (var index = 0; index < lines.length; index += 1) {
+    final line = lines[index].trim();
+    if (line == 'end_of_record') {
+      finishRecord();
+      continue;
+    }
+    if (line.startsWith('LF:')) {
+      if (recordFound != null) {
+        throw FormatException('Duplicate LF at line ${index + 1}.');
+      }
+      recordFound = _parseCount(line.substring(3), 'LF', index + 1);
+    } else if (line.startsWith('LH:')) {
+      if (recordHit != null) {
+        throw FormatException('Duplicate LH at line ${index + 1}.');
+      }
+      recordHit = _parseCount(line.substring(3), 'LH', index + 1);
+    }
+  }
+  finishRecord();
+
+  if (totalFound == 0) {
+    throw const FormatException('LCOV report contains no executable lines.');
+  }
+
+  return CoverageSummary(linesFound: totalFound, linesHit: totalHit);
+}
+
+/// Parses a minimum line coverage percentage in the inclusive range 0 to 100.
+double parseMinimumCoverage(String value) {
+  final minimum = double.tryParse(value);
+  if (minimum == null || !minimum.isFinite || minimum < 0 || minimum > 100) {
+    throw FormatException('Invalid minimum coverage: $value');
+  }
+
+  return minimum;
+}
+
+/// Whether [summary] reaches [minimum] percent line coverage.
+bool meetsCoverageMinimum(CoverageSummary summary, double minimum) =>
+    summary.percentage >= minimum;
+
+int _parseCount(String value, String field, int lineNumber) {
+  final count = int.tryParse(value);
+  if (count == null || count < 0) {
+    throw FormatException('Invalid $field count at line $lineNumber.');
+  }
+
+  return count;
+}
+
+({String lcovPath, double minimum}) _parseArguments(List<String> arguments) {
+  String? lcovPath;
+  double? minimum;
+
+  for (var index = 0; index < arguments.length; index += 1) {
+    final option = arguments[index];
+    if (index + 1 >= arguments.length) {
+      throw FormatException('Missing value for $option.');
+    }
+    final value = arguments[index + 1];
+    switch (option) {
+      case '--lcov':
+        if (lcovPath != null || value.isEmpty) {
+          throw const FormatException('Invalid --lcov option.');
+        }
+        lcovPath = value;
+      case '--minimum':
+        if (minimum != null) {
+          throw const FormatException('Duplicate --minimum option.');
+        }
+        minimum = parseMinimumCoverage(value);
+      default:
+        throw FormatException('Unknown option: $option');
+    }
+    index += 1;
+  }
+
+  if (lcovPath == null || minimum == null) {
+    throw const FormatException('--lcov and --minimum are required.');
+  }
+
+  return (lcovPath: lcovPath, minimum: minimum);
+}
+
+Future<void> main(List<String> arguments) async {
+  try {
+    final options = _parseArguments(arguments);
+    final report = File(options.lcovPath);
+    if (!await report.exists()) {
+      throw FileSystemException('LCOV report does not exist', report.path);
+    }
+    final summary = parseLcov(await report.readAsString());
+    final percentage = summary.percentage;
+    stdout.writeln(
+      'Line coverage ${percentage.toStringAsFixed(2)}% '
+      '(${summary.linesHit}/${summary.linesFound}), '
+      'minimum ${options.minimum.toStringAsFixed(2)}%.',
+    );
+    if (!meetsCoverageMinimum(summary, options.minimum)) {
+      stderr.writeln('Line coverage is below the required minimum.');
+      exitCode = 1;
+    }
+  } on FileSystemException catch (error) {
+    stderr.writeln(error.message);
+    exitCode = 66;
+  } on FormatException catch (error) {
+    stderr
+      ..writeln(error.message)
+      ..writeln(
+        'Usage: dart run tool/ci/check_coverage.dart '
+        '--lcov <path> --minimum <0..100>',
+      );
+    exitCode = 64;
+  }
+}

--- a/tool/ci/quality.sh
+++ b/tool/ci/quality.sh
@@ -31,7 +31,10 @@ done
 git ls-files -z -- '*.dart' |
     xargs -0 dart format --output=none --set-exit-if-changed
 
-flutter test
+flutter test --coverage
+dart run tool/ci/check_coverage.dart \
+    --lcov coverage/lcov.info \
+    --minimum "${MINIMUM_LINE_COVERAGE:-44}"
 test -s assets/shaderbundles/MapShaders.shaderbundle
 
 unit_test_packages=(


### PR DESCRIPTION
## Summary

- run native Android immediately and start native macOS after iOS native, removing visual-stage serialization
- batch each iOS visual group into one Flutter drive per renderer and cold-restart the simulator after the first timeout
- replace the permanent Firebase commit lock with a CAS lease, per-attempt result paths, and completed-result reuse
- shard Android screenshot comparisons into two Ubuntu jobs and reuse one dependency resolution per shard
- add a 44% line-coverage gate plus coverage artifacts
- add direct gesture and symbol-overlay behavior regressions

## Local verification

- `./tool/ci/quality.sh`
  - 437 root tests passed
  - all workspace package tests passed
  - all analyzers passed
  - line coverage 44.32% (1950/4400), minimum 44%
- `dart test test/run_ios_cli_test.dart` in `e2e/visual/runner`
- `actionlint v1.7.12`
- YAML parse, `bash -n`, and `git diff --check`
- pure-Dart Android visual comparison smoke with identical PNGs
