### PR TITLE
(cancelled) chore: release 0.0.3

### DIFF
--- a/.agents/skills/release-maplibre-flutter-gpu/SKILL.md
+++ b/.agents/skills/release-maplibre-flutter-gpu/SKILL.md
@@ -100,8 +100,9 @@ Continue only after CHANGELOG approval.
 1. Run the `skill-creator` quick validator against
    `.agents/skills/release-maplibre-flutter-gpu`.
 
-2. Review the complete diff and stage only release files. Commit with a terse
-   release message.
+2. Review the complete diff and stage only release files. Keep release content,
+   release automation, and Skill changes in separate focused commits. They may
+   share one pull request.
 
 3. Run `./tool/ci/quality.sh` from the clean commit. Fix failures before pushing.
    Ask for CHANGELOG approval again if a fix changes release notes.
@@ -115,41 +116,51 @@ Continue only after CHANGELOG approval.
 
 ## Prepare artifacts from merged main
 
-1. Resolve the exact merge commit on `origin/main`. Wait for the `push` CI run
-   for that SHA to succeed.
+1. Fetch `origin/main` after merge and resolve its exact commit. This may be a
+   squash merge commit, so never substitute the pull request head SHA.
 
-2. Confirm the selected CI run has event `push`, branch `main`, the exact merge
-   SHA, and conclusion `success`. Reuse its native artifacts when dispatching
-   release preparation.
+2. Select a successful native-artifact run. Prefer a `push` run for the exact
+   merge SHA. An earlier successful run may be reused when every later change
+   is demonstrably unrelated to native build inputs or packaging, such as
+   README, CHANGELOG, funding, version metadata, or this Skill. Inspect the full
+   diff from the artifact source SHA to the merge SHA and stop if it changes
+   native sources, vendor revisions, build hooks, artifact manifests, or native
+   build and packaging scripts.
+
+3. Before dispatching, list release preparation runs for the exact merge SHA.
+   Match both the SHA and `artifact_run_id` shown in the run title. Reuse or wait
+   for an existing matching run instead of dispatching the same preparation
+   twice.
 
    ```sh
    gh workflow run release-prepare.yml --ref main \
      -f artifact_run_id="$CI_RUN_ID"
    ```
 
-3. Wait for the release preparation run. Download
+4. Wait for the release preparation run. Download
    `release-bundle-<merge-sha>` into a new temporary directory.
 
-4. Verify all bundle evidence.
+5. Verify all bundle evidence.
 
    - `release-manifest.txt` names `hyshu/maplibre_flutter_gpu` and the exact
      merge SHA.
    - `SHA256SUMS` validates every native archive.
-   - `pub-dry-run.log` reports the expected version and only the explicitly
-     accepted ignored-gitlink warning.
+   - `pub-dry-run.log` reports the expected version and exactly the accepted
+     checked-in gitlink warning involving `vendor/maplibre-native`.
    - Android arm64 and x86_64 archives and the Darwin archive are present.
    - Linux and Windows x64 and ARM64 archives match
      `hook/desktop_artifacts.json` byte for byte.
 
-5. Require every URL in `hook/desktop_artifacts.json` to resolve to an immutable
+6. Require every URL in `hook/desktop_artifacts.json` to resolve to an immutable
    GitHub Release asset with the recorded SHA-256. If the release does not
    exist, stop and request explicit approval before creating it. Do not use an
    expiring Actions artifact URL as a build-hook endpoint.
 
-6. Create an isolated detached worktree at the exact merge SHA. Install only
+7. Create an isolated detached worktree at the exact merge SHA. Install only
    the Android and Darwin artifacts with `tool/ci/install_native_artifacts.sh`.
    Desktop binaries stay outside the pub package. Run
-   `./tool/ci/check_publish.sh` there and require success.
+   `./tool/ci/check_publish.sh` there and require zero warnings. The isolated
+   worktree expectation differs from the accepted CI bundle gitlink warning.
 
 ## Publish and tag
 
@@ -160,13 +171,14 @@ Continue only after CHANGELOG approval.
 2. Run the interactive command from the verified worktree with a TTY.
 
    ```sh
-   dart pub publish --ignore-warnings
+   dart pub publish
    ```
 
-3. Verify the pub.dev API reports the target version. Confirm the published
-   archive contains the Android libraries, Darwin XCFramework, shader bundle,
-   build hook, and desktop artifact manifest. Confirm it excludes the raw
-   Linux and Windows libraries.
+3. Read the target version from the pub.dev version API. Download its
+   `archive_url`, calculate SHA-256, and require it to equal the API's
+   `archive_sha256`. Inspect that downloaded archive for the Android arm64 and
+   x86_64 libraries, Darwin XCFramework, shader bundle, build hook, and desktop
+   artifact manifest. Confirm it excludes raw Linux and Windows libraries.
 
 4. Create annotated tag `v<target-version>` on the exact merge SHA only after
    publication succeeds. Push that tag and verify its peeled remote commit.

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: hyshu

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,4 +1,5 @@
 name: Release preparation
+run-name: Release preparation for ${{ github.sha }} using artifacts ${{ inputs.artifact_run_id || 'new-build' }}
 
 on:
   workflow_dispatch:
@@ -14,7 +15,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: release-prepare-${{ github.sha }}
+  group: release-prepare-${{ github.sha }}-${{ inputs.artifact_run_id || 'new-build' }}
   cancel-in-progress: false
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,11 @@
 - Leave a blank line before a `return` that follows another statement.
 - Do not leave that blank line when the preceding line closes a scope or the `return` is the only statement in its scope.
 - A one-line control statement still requires a blank line before a following `return`.
+
+# Git Style
+
+- Use Conventional Commits for commit messages and pull request titles.
+- Use a lowercase type followed by a concise imperative summary, such as
+  `fix: handle missing native library`.
+- Name release commits and pull requests `chore: release <version>`.
+- Keep pull request titles suitable for use as squash merge commit titles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.3
+
+* Add Linux and Windows support for x64 and ARM64 in debug and profile modes.
+* Upgrade to Flutter 3.47.0 and Dart 3.13.0.
+
 ## 0.0.2
 
 * Improve Flutter GPU setup instructions and API documentation in the README.

--- a/README.md
+++ b/README.md
@@ -333,3 +333,5 @@ devices and environments.
 
 Bug reports, device compatibility results, and other feedback are welcome in
 [GitHub Issues](https://github.com/hyshu/maplibre_flutter_gpu/issues).
+
+This is an independent community project. It is not affiliated with or endorsed by the MapLibre organization.

--- a/android/src/main/java/org/maplibre/android/http/NativeHttpRequest.java
+++ b/android/src/main/java/org/maplibre/android/http/NativeHttpRequest.java
@@ -76,7 +76,7 @@ public final class NativeHttpRequest {
       request.setReadTimeout(30_000);
       request.setInstanceFollowRedirects(true);
       request.setRequestMethod("GET");
-      request.setRequestProperty("User-Agent", "maplibre_flutter_gpu/0.0.2");
+      request.setRequestProperty("User-Agent", "maplibre_flutter_gpu/0.0.3");
       if (dataRange != null && !dataRange.isEmpty()) {
         request.setRequestProperty("Range", dataRange);
       }

--- a/darwin/maplibre_flutter_gpu.podspec
+++ b/darwin/maplibre_flutter_gpu.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'maplibre_flutter_gpu'
-  s.version = '0.0.2'
+  s.version = '0.0.3'
   s.summary = 'MapLibre maps rendered with Flutter GPU.'
   s.description = <<-DESC
 MapLibre maps for Flutter, rendered with Flutter GPU.

--- a/e2e/visual/gpu_app/pubspec.lock
+++ b/e2e/visual/gpu_app/pubspec.lock
@@ -181,7 +181,7 @@ packages:
       path: "../../.."
       relative: true
     source: path
-    version: "0.0.2"
+    version: "0.0.3"
   matcher:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -158,7 +158,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.2"
+    version: "0.0.3"
   matcher:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_flutter_landmarks_example
 description: World landmark Flutter marker example for maplibre_flutter_gpu.
 publish_to: 'none'
-version: 0.0.2
+version: 0.0.3
 
 environment:
   sdk: ^3.13.0

--- a/examples/gpu_map_scene/pubspec.lock
+++ b/examples/gpu_map_scene/pubspec.lock
@@ -158,7 +158,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.0.2"
+    version: "0.0.3"
   matcher:
     dependency: transitive
     description:

--- a/examples/gpu_map_scene/pubspec.yaml
+++ b/examples/gpu_map_scene/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_flutter_gpu_map_scene_example
 description: Geographic CC0 car and building GPU overlay example.
 publish_to: 'none'
-version: 0.0.2
+version: 0.0.3
 
 environment:
   sdk: ^3.13.0

--- a/examples/map_style_controls/pubspec.lock
+++ b/examples/map_style_controls/pubspec.lock
@@ -158,7 +158,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.0.2"
+    version: "0.0.3"
   matcher:
     dependency: transitive
     description:

--- a/examples/map_style_controls/pubspec.yaml
+++ b/examples/map_style_controls/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_flutter_map_style_controls_example
 description: Semantic map style controls using the MapLibre controller API.
 publish_to: 'none'
-version: 0.0.2
+version: 0.0.3
 
 environment:
   sdk: ^3.13.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_flutter_gpu
 description: >-
   MapLibre maps for Flutter, rendered with Flutter GPU.
-version: 0.0.2
+version: 0.0.3
 repository: https://github.com/hyshu/maplibre_flutter_gpu
 homepage: https://github.com/hyshu/maplibre_flutter_gpu
 issue_tracker: https://github.com/hyshu/maplibre_flutter_gpu/issues


### PR DESCRIPTION
## Summary

- bump package and examples to 0.0.3
- document Linux and Windows desktop support and add project funding/disclaimer metadata
- make release preparation runs identifiable by source SHA and artifact run
- update release procedure for squash merges, artifact reuse, interactive publication, warning expectations, and published archive verification

## Validation

- `./tool/ci/quality.sh`
- release Skill quick validation
- `./tool/ci/check_publish.sh --metadata-only`