### PR TITLE
(cancelled) fix: use supported Android artifact mode

### DIFF
--- a/test/package_configuration_test.dart
+++ b/test/package_configuration_test.dart
@@ -184,6 +184,9 @@ void main() {
     expect(publishScript, isNot(contains('linux/x64/libmaplibre_bridge.so')));
     expect(publishScript, contains('hook/desktop_artifacts.json'));
     expect(bundleScript, contains('verify_desktop_release_manifest.py'));
+    expect(bundleScript, contains(r'"${ARTIFACT_DIRECTORY}" android'));
+    expect(bundleScript, isNot(contains('android-arm64-v8a\n')));
+    expect(bundleScript, isNot(contains('android-x86_64\n')));
     expect(archiveScript, contains('linux-x64|linux-arm64'));
     expect(archiveScript, contains(r'linux/${ARCHITECTURE}'));
     expect(archiveScript, contains('windows-x64|windows-arm64'));

--- a/tool/ci/prepare_release_bundle.sh
+++ b/tool/ci/prepare_release_bundle.sh
@@ -13,10 +13,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 mkdir -p "${OUTPUT_DIRECTORY}"
-"${SCRIPT_DIR}/install_native_artifacts.sh" \
-    "${ARTIFACT_DIRECTORY}" android-arm64-v8a
-"${SCRIPT_DIR}/install_native_artifacts.sh" \
-    "${ARTIFACT_DIRECTORY}" android-x86_64
+"${SCRIPT_DIR}/install_native_artifacts.sh" "${ARTIFACT_DIRECTORY}" android
 "${SCRIPT_DIR}/install_native_artifacts.sh" "${ARTIFACT_DIRECTORY}" darwin
 
 archives=(


### PR DESCRIPTION
## Summary

- install both Android release artifacts through the supported `android` mode
- add a regression assertion for release bundle installer modes

## Validation

- `bash -n tool/ci/prepare_release_bundle.sh`
- `flutter test test/package_configuration_test.dart`
- `git diff --check`

Fixes release preparation run 31817187172.