### PR TITLE
fix(android): initialize MapLibre before native HTTP requests

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,3 +35,12 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 }
+
+dependencies {
+    // The native bridge's tile/HTTP fetching reuses maplibre-native's Android
+    // platform module (org.maplibre.android.*) via JNI rather than bundling
+    // its own copy. MapLibre.getInstance(...) must run before that module
+    // touches OnlineFileSource/HttpRequestImpl, so this plugin needs the
+    // classes at compile time even though it never creates a MapView itself.
+    implementation("org.maplibre.gl:android-sdk-opengl:13.3.0")
+}

--- a/android/src/main/java/dev/maplibre/fluttergpu/MaplibreFlutterGpuPlugin.java
+++ b/android/src/main/java/dev/maplibre/fluttergpu/MaplibreFlutterGpuPlugin.java
@@ -4,6 +4,9 @@ import android.content.Context;
 
 import androidx.annotation.NonNull;
 
+import org.maplibre.android.MapLibre;
+import org.maplibre.android.WellKnownTileServer;
+
 import java.io.File;
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
@@ -23,6 +26,16 @@ public final class MaplibreFlutterGpuPlugin
   @Override
   public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
     applicationContext = binding.getApplicationContext();
+    // The native bridge fetches tiles through maplibre-native's Android
+    // platform module (org.maplibre.android.module.http.HttpRequestImpl),
+    // which reads its application context off this singleton. Nothing else
+    // in this package's Dart/native path ever calls it, so without this the
+    // first HTTP request throws MapLibreConfigurationException from a
+    // background native thread and takes the whole process down with it
+    // (uncaught JNI exception -> SIGABRT), not just a caught Dart error.
+    // Styles here are always raw JSON (see MapLibreMap.styleString), never a
+    // maptiler/maplibre-hosted style URL, so no API key is needed.
+    MapLibre.getInstance(applicationContext, /* apiKey= */ null, WellKnownTileServer.MapLibre);
     sourceLibrary =
         new File(applicationContext.getApplicationInfo().nativeLibraryDir,
             "libmaplibre_bridge.so");


### PR DESCRIPTION
## Summary
- Android's native bridge fetches tiles through maplibre-native's Android platform module (`org.maplibre.android.module.http.HttpRequestImpl`), which reads its application context off the `MapLibre` singleton — but nothing in this package ever calls `MapLibre.getInstance(...)`.
- The first HTTP request then throws `MapLibreConfigurationException` from a background native thread (`OnlineFileSourc`). That exception crosses the JNI boundary uncaught, which takes down the whole process with `SIGABRT` instead of surfacing as a catchable Dart error.
- Fixed by calling `MapLibre.getInstance(applicationContext, null, WellKnownTileServer.MapLibre)` in `onAttachedToEngine`, before the native bridge can issue any HTTP request. No API key is needed since this package only ever loads raw JSON styles (`MapLibreMap.styleString`), never a maptiler/maplibre-hosted style URL.
- Also declared the `org.maplibre.gl:android-sdk-opengl` dependency this plugin actually needs at compile time for the `MapLibre`/`WellKnownTileServer` import — previously it only resolved by accident when a consuming app also depended on `maplibre_gl`.

## Test plan
- [x] Reproduced the crash on a real Android TV device (NVIDIA Shield, API 30) running this package's `MapLibreMap` with no other MapLibre-touching plugin in the app — confirmed native `SIGABRT` with `MapLibreConfigurationException` in logcat.
- [x] Applied this fix locally, rebuilt, reran on the same device — the `MapLibreConfigurationException`/`SIGABRT` no longer occurs; `MapLibre.getInstance()` succeeds and the native HTTP path proceeds.
- Note: that same device separately hits an unrelated `SIGSEGV` inside its Vulkan driver during Impeller command-buffer submission — a Tegra/Vulkan driver issue, not something this package can fix, and orthogonal to the crash addressed here.