### PR TITLE
ci: skip CI for non-code changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,21 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+      - '.agents/**'
+      - '.claude/**'
+      - '.gitignore'
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+      - '.agents/**'
+      - '.claude/**'
+      - '.gitignore'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- skip CI when pull requests only change Markdown, license, agent configuration, Claude configuration, or `.gitignore`
- apply the same filters to pushes to `main`
- keep manual workflow dispatch available

## Impact

Documentation and repository metadata-only changes no longer consume the full CI matrix. Changes containing any non-ignored file still run CI.

## Validation

- `git diff --check`
- reviewed GitHub Actions path filter syntax

`actionlint` was not available locally.
