### PR TITLE
(cancelled) chore: release 0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.0.4
+
+* Render symbol icons and text with closer MapLibre parity, including
+  data-driven styling, halos, formatted text, inline images, multiple sprite
+  sources, and style layer ordering.
+* Make symbol text and icons follow roads and other lines, with support for
+  bidirectional and vertical text.
+* Add opt-in `SymbolCompositingMode.fastOverlay` for maps where speed is
+  preferred over exact style layer ordering.
+
 ## 0.0.3
 
 * Add Linux and Windows support for x64 and ARM64 in debug and profile modes.

--- a/android/src/main/java/org/maplibre/android/http/NativeHttpRequest.java
+++ b/android/src/main/java/org/maplibre/android/http/NativeHttpRequest.java
@@ -76,7 +76,7 @@ public final class NativeHttpRequest {
       request.setReadTimeout(30_000);
       request.setInstanceFollowRedirects(true);
       request.setRequestMethod("GET");
-      request.setRequestProperty("User-Agent", "maplibre_flutter_gpu/0.0.3");
+      request.setRequestProperty("User-Agent", "maplibre_flutter_gpu/0.0.4");
       if (dataRange != null && !dataRange.isEmpty()) {
         request.setRequestProperty("Range", dataRange);
       }

--- a/darwin/maplibre_flutter_gpu.podspec
+++ b/darwin/maplibre_flutter_gpu.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'maplibre_flutter_gpu'
-  s.version = '0.0.3'
+  s.version = '0.0.4'
   s.summary = 'MapLibre maps rendered with Flutter GPU.'
   s.description = <<-DESC
 MapLibre maps for Flutter, rendered with Flutter GPU.

--- a/e2e/visual/gpu_app/pubspec.lock
+++ b/e2e/visual/gpu_app/pubspec.lock
@@ -181,7 +181,7 @@ packages:
       path: "../../.."
       relative: true
     source: path
-    version: "0.0.3"
+    version: "0.0.4"
   matcher:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -158,7 +158,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.3"
+    version: "0.0.4"
   matcher:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_flutter_landmarks_example
 description: World landmark Flutter marker example for maplibre_flutter_gpu.
 publish_to: 'none'
-version: 0.0.3
+version: 0.0.4
 
 environment:
   sdk: ^3.13.0

--- a/examples/gpu_map_scene/pubspec.lock
+++ b/examples/gpu_map_scene/pubspec.lock
@@ -158,7 +158,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.0.3"
+    version: "0.0.4"
   matcher:
     dependency: transitive
     description:

--- a/examples/gpu_map_scene/pubspec.yaml
+++ b/examples/gpu_map_scene/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_flutter_gpu_map_scene_example
 description: Geographic CC0 car and building GPU overlay example.
 publish_to: 'none'
-version: 0.0.3
+version: 0.0.4
 
 environment:
   sdk: ^3.13.0

--- a/examples/map_style_controls/pubspec.lock
+++ b/examples/map_style_controls/pubspec.lock
@@ -158,7 +158,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.0.3"
+    version: "0.0.4"
   matcher:
     dependency: transitive
     description:

--- a/examples/map_style_controls/pubspec.yaml
+++ b/examples/map_style_controls/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_flutter_map_style_controls_example
 description: Semantic map style controls using the MapLibre controller API.
 publish_to: 'none'
-version: 0.0.3
+version: 0.0.4
 
 environment:
   sdk: ^3.13.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_flutter_gpu
 description: >-
   MapLibre maps for Flutter, rendered with Flutter GPU.
-version: 0.0.3
+version: 0.0.4
 repository: https://github.com/hyshu/maplibre_flutter_gpu
 homepage: https://github.com/hyshu/maplibre_flutter_gpu
 issue_tracker: https://github.com/hyshu/maplibre_flutter_gpu/issues


### PR DESCRIPTION
## Summary

- Bump the package, examples, Darwin podspec, Android User-Agent, and generated lockfiles to 0.0.4.
- Add release notes for improved MapLibre symbol parity, line-following symbols, bidirectional and vertical text, and the fast overlay compositing option.
- Keep the release skill excluded from the pub archive and validate it with the skill-creator quick validator.

## Validation

- `git diff --check`
- `flutter test test/package_configuration_test.dart`
- `./tool/ci/check_publish.sh --metadata-only`
- `./tool/ci/quality.sh`
- Skill quick validator