### PR TITLE
chore: release 0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.0.4
+
+* Render symbol icons and text with closer MapLibre parity, including
+  data-driven styling, halos, formatted text, inline images, multiple sprite
+  sources, and style layer ordering.
+* Make symbol text and icons follow roads and other lines, with support for
+  bidirectional and vertical text.
+* Add opt-in `SymbolCompositingMode.fastOverlay` for maps where speed is
+  preferred over exact style layer ordering.
+
 ## 0.0.3
 
 * Add Linux and Windows support for x64 and ARM64 in debug and profile modes.

--- a/android/src/main/java/org/maplibre/android/http/NativeHttpRequest.java
+++ b/android/src/main/java/org/maplibre/android/http/NativeHttpRequest.java
@@ -76,7 +76,7 @@ public final class NativeHttpRequest {
       request.setReadTimeout(30_000);
       request.setInstanceFollowRedirects(true);
       request.setRequestMethod("GET");
-      request.setRequestProperty("User-Agent", "maplibre_flutter_gpu/0.0.3");
+      request.setRequestProperty("User-Agent", "maplibre_flutter_gpu/0.0.4");
       if (dataRange != null && !dataRange.isEmpty()) {
         request.setRequestProperty("Range", dataRange);
       }

--- a/darwin/maplibre_flutter_gpu.podspec
+++ b/darwin/maplibre_flutter_gpu.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'maplibre_flutter_gpu'
-  s.version = '0.0.3'
+  s.version = '0.0.4'
   s.summary = 'MapLibre maps rendered with Flutter GPU.'
   s.description = <<-DESC
 MapLibre maps for Flutter, rendered with Flutter GPU.

--- a/e2e/visual/gpu_app/pubspec.lock
+++ b/e2e/visual/gpu_app/pubspec.lock
@@ -181,7 +181,7 @@ packages:
       path: "../../.."
       relative: true
     source: path
-    version: "0.0.3"
+    version: "0.0.4"
   matcher:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -158,7 +158,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.3"
+    version: "0.0.4"
   matcher:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_flutter_landmarks_example
 description: World landmark Flutter marker example for maplibre_flutter_gpu.
 publish_to: 'none'
-version: 0.0.3
+version: 0.0.4
 
 environment:
   sdk: ^3.13.0

--- a/examples/gpu_map_scene/pubspec.lock
+++ b/examples/gpu_map_scene/pubspec.lock
@@ -158,7 +158,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.0.3"
+    version: "0.0.4"
   matcher:
     dependency: transitive
     description:

--- a/examples/gpu_map_scene/pubspec.yaml
+++ b/examples/gpu_map_scene/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_flutter_gpu_map_scene_example
 description: Geographic CC0 car and building GPU overlay example.
 publish_to: 'none'
-version: 0.0.3
+version: 0.0.4
 
 environment:
   sdk: ^3.13.0

--- a/examples/map_style_controls/pubspec.lock
+++ b/examples/map_style_controls/pubspec.lock
@@ -158,7 +158,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.0.3"
+    version: "0.0.4"
   matcher:
     dependency: transitive
     description:

--- a/examples/map_style_controls/pubspec.yaml
+++ b/examples/map_style_controls/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_flutter_map_style_controls_example
 description: Semantic map style controls using the MapLibre controller API.
 publish_to: 'none'
-version: 0.0.3
+version: 0.0.4
 
 environment:
   sdk: ^3.13.0

--- a/hook/desktop_artifacts.json
+++ b/hook/desktop_artifacts.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 1,
-  "baseUrl": "https://github.com/hyshu/maplibre_flutter_gpu/releases/download/v0.0.3/",
+  "baseUrl": "https://github.com/hyshu/maplibre_flutter_gpu/releases/download/v0.0.4/",
   "artifacts": [
-    {"os":"linux","architecture":"x64","archive":"native-linux-x64.tar.gz","member":"linux/x64/libmaplibre_bridge.so","library":"libmaplibre_bridge.so","sha256":"004e51c4bf6d17323de1ad52d1b3972b524f6d6f83f706a3d5435a5106b97485"},
-    {"os":"linux","architecture":"arm64","archive":"native-linux-arm64.tar.gz","member":"linux/arm64/libmaplibre_bridge.so","library":"libmaplibre_bridge.so","sha256":"c865341b749c5c8353bb815f0d450f751b28cb89bb8bd939e946895bbbb328ca"},
-    {"os":"windows","architecture":"x64","archive":"native-windows-x64.tar.gz","member":"windows/x64/maplibre_bridge.dll","library":"maplibre_bridge.dll","sha256":"e87ab538f040f7332f23771a698cde400034700bbcd2fa629673f14e22d4ddc4"},
-    {"os":"windows","architecture":"arm64","archive":"native-windows-arm64.tar.gz","member":"windows/arm64/maplibre_bridge.dll","library":"maplibre_bridge.dll","sha256":"60e3dc994c64185395d1515e59af87cc4efd7e357ca9f446aafee4733c2d47f7"}
+    {"os":"linux","architecture":"x64","archive":"native-linux-x64.tar.gz","member":"linux/x64/libmaplibre_bridge.so","library":"libmaplibre_bridge.so","sha256":"17feb7050d081d149da1c0e3afab098ec5a146a60da07d112b9f71f9511e9a9a"},
+    {"os":"linux","architecture":"arm64","archive":"native-linux-arm64.tar.gz","member":"linux/arm64/libmaplibre_bridge.so","library":"libmaplibre_bridge.so","sha256":"15912b0d108c85bb36a7f8ed9f4f9730aff9a38fea7c7a484507307f9254fb9c"},
+    {"os":"windows","architecture":"x64","archive":"native-windows-x64.tar.gz","member":"windows/x64/maplibre_bridge.dll","library":"maplibre_bridge.dll","sha256":"2925b0089976834053736a2aee554b1e1bd726b3181458135ee8fa0ce464eee7"},
+    {"os":"windows","architecture":"arm64","archive":"native-windows-arm64.tar.gz","member":"windows/arm64/maplibre_bridge.dll","library":"maplibre_bridge.dll","sha256":"7a9b59ee8cf940e85b7ca1022ff26b81118bb2ae01a515f774b3ff0233d49207"}
   ]
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_flutter_gpu
 description: >-
   MapLibre maps for Flutter, rendered with Flutter GPU.
-version: 0.0.3
+version: 0.0.4
 repository: https://github.com/hyshu/maplibre_flutter_gpu
 homepage: https://github.com/hyshu/maplibre_flutter_gpu
 issue_tracker: https://github.com/hyshu/maplibre_flutter_gpu/issues


### PR DESCRIPTION
## Summary

- Bump the package, examples, Darwin podspec, Android User-Agent, and generated lockfiles to 0.0.4.
- Add release notes for improved MapLibre symbol parity, line-following symbols, bidirectional and vertical text, and the fast overlay compositing option.
- Point Linux and Windows build-hook archives at `v0.0.4` GitHub Release assets. SHA-256 values match the desktop artifacts from release-prepare run 32329060624.

## Validation

- `git diff --check`
- `flutter test test/package_configuration_test.dart`
- `./tool/ci/check_publish.sh --metadata-only`

After merge, reuse `artifact_run_id=32329060624`. Do not new-build. That source run can be deleted after publication.