### PR TITLE
fix(darwin): allow macOS-only XCFramework packaging

### DIFF
--- a/native/scripts/package_darwin.sh
+++ b/native/scripts/package_darwin.sh
@@ -29,11 +29,16 @@ MACOS_PACKAGE_ROOT="${PROJECT_ROOT}/build-macos-fluttergpu-package"
 HEADERS="${DARWIN_PACKAGE_ROOT}/Headers"
 OUTPUT="${DARWIN_PACKAGE_ROOT}/Frameworks/MapLibreBridge.xcframework"
 
-verify_reusable_ios_library() {
+verify_reusable_ios_slice() {
     local library="$1"
-    shift
+    local headers="$2"
+    shift 2
     if [[ ! -f "${library}" ]]; then
         echo "error: existing iOS slice is missing: ${library}" >&2
+        exit 1
+    fi
+    if [[ ! -f "${headers}/MapLibreBridge.h" || ! -f "${headers}/module.modulemap" ]]; then
+        echo "error: existing iOS headers are incomplete: ${headers}" >&2
         exit 1
     fi
 
@@ -57,21 +62,35 @@ if [[ "${MODE}" == all || "${MODE}" == ios ]]; then
     "${SCRIPT_DIR}/build_ios.sh" all
     device_archive="${IOS_PACKAGE_ROOT}/iphoneos/libMapLibreBridge.a"
     simulator_archive="${IOS_PACKAGE_ROOT}/iphonesimulator/libMapLibreBridge.a"
+    device_headers="${HEADERS}"
+    simulator_headers="${HEADERS}"
 else
     existing_device_archive="${OUTPUT}/ios-arm64/libMapLibreBridge.a"
     existing_simulator_archive="${OUTPUT}/ios-arm64_x86_64-simulator/libMapLibreBridge.a"
-    verify_reusable_ios_library "${existing_device_archive}" arm64
-    verify_reusable_ios_library "${existing_simulator_archive}" arm64 x86_64
+    existing_device_headers="${OUTPUT}/ios-arm64/Headers"
+    existing_simulator_headers="${OUTPUT}/ios-arm64_x86_64-simulator/Headers"
+    verify_reusable_ios_slice \
+        "${existing_device_archive}" \
+        "${existing_device_headers}" \
+        arm64
+    verify_reusable_ios_slice \
+        "${existing_simulator_archive}" \
+        "${existing_simulator_headers}" \
+        arm64 x86_64
 
     ios_staging_root="$(mktemp -d -t maplibre-darwin-ios)"
     trap 'rm -rf "${ios_staging_root}"' EXIT
     device_archive="${ios_staging_root}/iphoneos/libMapLibreBridge.a"
     simulator_archive="${ios_staging_root}/iphonesimulator/libMapLibreBridge.a"
+    device_headers="${ios_staging_root}/iphoneos/Headers"
+    simulator_headers="${ios_staging_root}/iphonesimulator/Headers"
     mkdir -p \
         "$(dirname "${device_archive}")" \
         "$(dirname "${simulator_archive}")"
     cp "${existing_device_archive}" "${device_archive}"
     cp "${existing_simulator_archive}" "${simulator_archive}"
+    cp -R "${existing_device_headers}" "${device_headers}"
+    cp -R "${existing_simulator_headers}" "${simulator_headers}"
 fi
 
 if [[ "${MODE}" == all || "${MODE}" == macos ]]; then
@@ -95,9 +114,9 @@ rm -rf "${OUTPUT}"
 xcframework_args=(
     -create-xcframework
     -library "${device_archive}"
-    -headers "${HEADERS}"
+    -headers "${device_headers}"
     -library "${simulator_archive}"
-    -headers "${HEADERS}"
+    -headers "${simulator_headers}"
 )
 expected_slice_count=2
 if [[ "${MODE}" != ios ]]; then

--- a/native/scripts/package_darwin.sh
+++ b/native/scripts/package_darwin.sh
@@ -11,7 +11,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=packaging/darwin_common.sh
 source "${SCRIPT_DIR}/packaging/darwin_common.sh"
 
-require_tools xcodebuild
+require_tools xcodebuild xcrun
 require_darwin_sources
 
 MODE="${1:-all}"
@@ -29,12 +29,39 @@ MACOS_PACKAGE_ROOT="${PROJECT_ROOT}/build-macos-fluttergpu-package"
 HEADERS="${DARWIN_PACKAGE_ROOT}/Headers"
 OUTPUT="${DARWIN_PACKAGE_ROOT}/Frameworks/MapLibreBridge.xcframework"
 
+verify_reusable_ios_library() {
+    local library="$1"
+    shift
+    if [[ ! -f "${library}" ]]; then
+        echo "error: existing iOS slice is missing: ${library}" >&2
+        exit 1
+    fi
+
+    local architectures
+    architectures="$(xcrun lipo -archs "${library}")"
+    if [[ "$(wc -w <<<"${architectures}" | tr -d ' ')" -ne "$#" ]]; then
+        echo "error: unexpected architectures in ${library}: ${architectures}" >&2
+        exit 1
+    fi
+
+    local expected
+    for expected in "$@"; do
+        if ! grep -qw "${expected}" <<<"${architectures}"; then
+            echo "error: ${library} is missing ${expected}" >&2
+            exit 1
+        fi
+    done
+}
+
 if [[ "${MODE}" == all || "${MODE}" == ios ]]; then
     "${SCRIPT_DIR}/build_ios.sh" all
     device_archive="${IOS_PACKAGE_ROOT}/iphoneos/libMapLibreBridge.a"
     simulator_archive="${IOS_PACKAGE_ROOT}/iphonesimulator/libMapLibreBridge.a"
 else
-    "${PROJECT_ROOT}/tool/ci/verify_darwin_artifact.sh" ios
+    existing_device_archive="${OUTPUT}/ios-arm64/libMapLibreBridge.a"
+    existing_simulator_archive="${OUTPUT}/ios-arm64_x86_64-simulator/libMapLibreBridge.a"
+    verify_reusable_ios_library "${existing_device_archive}" arm64
+    verify_reusable_ios_library "${existing_simulator_archive}" arm64 x86_64
 
     ios_staging_root="$(mktemp -d -t maplibre-darwin-ios)"
     trap 'rm -rf "${ios_staging_root}"' EXIT
@@ -43,12 +70,8 @@ else
     mkdir -p \
         "$(dirname "${device_archive}")" \
         "$(dirname "${simulator_archive}")"
-    cp \
-        "${OUTPUT}/ios-arm64/libMapLibreBridge.a" \
-        "${device_archive}"
-    cp \
-        "${OUTPUT}/ios-arm64_x86_64-simulator/libMapLibreBridge.a" \
-        "${simulator_archive}"
+    cp "${existing_device_archive}" "${device_archive}"
+    cp "${existing_simulator_archive}" "${simulator_archive}"
 fi
 
 if [[ "${MODE}" == all || "${MODE}" == macos ]]; then

--- a/test/darwin_packaging_mode_test.dart
+++ b/test/darwin_packaging_mode_test.dart
@@ -13,21 +13,25 @@ void main() {
           'macOS-only packaging must not require existing iOS binaries to '
           'export every symbol from the current source tree',
     );
-    expect(script, contains('verify_reusable_ios_library()'));
-    expect(
-      script,
-      contains(
-        'verify_reusable_ios_library "\${existing_device_archive}" arm64',
-      ),
-    );
-    expect(
-      script,
-      contains(
-        'verify_reusable_ios_library "\${existing_simulator_archive}" '
-        'arm64 x86_64',
-      ),
-    );
+    expect(script, contains('verify_reusable_ios_slice()'));
     expect(script, contains('xcrun lipo -archs'));
+    expect(
+      script,
+      contains(
+        'existing_device_headers="\${OUTPUT}/ios-arm64/Headers"',
+      ),
+    );
+    expect(
+      script,
+      contains(
+        'existing_simulator_headers=' 
+        '"\${OUTPUT}/ios-arm64_x86_64-simulator/Headers"',
+      ),
+    );
+    expect(script, contains('cp -R "\${existing_device_headers}"'));
+    expect(script, contains('cp -R "\${existing_simulator_headers}"'));
+    expect(script, contains('-headers "\${device_headers}"'));
+    expect(script, contains('-headers "\${simulator_headers}"'));
     expect(script, contains('"\${SCRIPT_DIR}/build_macos.sh" universal'));
   });
 }

--- a/test/darwin_packaging_mode_test.dart
+++ b/test/darwin_packaging_mode_test.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('macOS packaging reuses existing iOS slices without ABI revalidation', () {
+  test('macOS packaging reuses existing iOS slices', () {
     final script = File('native/scripts/package_darwin.sh').readAsStringSync();
 
     expect(
@@ -17,14 +17,12 @@ void main() {
     expect(script, contains('xcrun lipo -archs'));
     expect(
       script,
-      contains(
-        'existing_device_headers="\${OUTPUT}/ios-arm64/Headers"',
-      ),
+      contains('existing_device_headers="\${OUTPUT}/ios-arm64/Headers"'),
     );
     expect(
       script,
       contains(
-        'existing_simulator_headers=' 
+        'existing_simulator_headers='
         '"\${OUTPUT}/ios-arm64_x86_64-simulator/Headers"',
       ),
     );

--- a/test/darwin_packaging_mode_test.dart
+++ b/test/darwin_packaging_mode_test.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('macOS packaging reuses existing iOS slices without ABI revalidation', () {
+    final script = File('native/scripts/package_darwin.sh').readAsStringSync();
+
+    expect(
+      script,
+      isNot(contains('verify_darwin_artifact.sh" ios')),
+      reason:
+          'macOS-only packaging must not require existing iOS binaries to '
+          'export every symbol from the current source tree',
+    );
+    expect(script, contains('verify_reusable_ios_library()'));
+    expect(
+      script,
+      contains(
+        'verify_reusable_ios_library "\${existing_device_archive}" arm64',
+      ),
+    );
+    expect(
+      script,
+      contains(
+        'verify_reusable_ios_library "\${existing_simulator_archive}" '
+        'arm64 x86_64',
+      ),
+    );
+    expect(script, contains('xcrun lipo -archs'));
+    expect(script, contains('"\${SCRIPT_DIR}/build_macos.sh" universal'));
+  });
+}


### PR DESCRIPTION
## Summary

- make `package_darwin.sh macos` reuse the existing iOS device/simulator slices instead of rebuilding or strictly re-verifying them against the current source tree
- validate reused iOS archives by required architectures and packaged headers before staging them into the rebuilt XCFramework
- keep `all` and `ios` modes building fresh iOS artifacts as before
- add a regression test covering the macOS-only packaging path

## Why

The macOS-only mode previously depended on validation of the already-packaged iOS artifact against the current native source tree. That can fail when the source changes before the iOS artifact is rebuilt, even though the goal of `macos` mode is only to rebuild the macOS slice.

This change lets macOS-only packaging preserve the existing valid iOS slices, build a fresh universal macOS slice, and recreate the combined XCFramework.

## Validation

- verifies the reused iOS device slice is `arm64`
- verifies the reused iOS simulator slice is `arm64 x86_64`
- verifies required packaged headers exist
- checks the resulting XCFramework contains the expected slice count
- adds `test/darwin_packaging_mode_test.dart`
