### PR TITLE
perf(gpu): reuse persistent rendering resources

### DIFF
--- a/lib/src/frame/draw_flags.dart
+++ b/lib/src/frame/draw_flags.dart
@@ -4,7 +4,8 @@
 // strides and masks must match the Flutter GPU shaders.
 import '../native/draw_command.dart';
 
-/// DrawCommand flag bits matching command_export::DrawCommand::Flags.
+/// DrawCommand flag bits matching command_export::DrawCommand::Flags plus
+/// bridge-owned transport flags that never reach the shader-facing masks.
 ///
 /// Data-driven bits are grouped per layer type and the group masks are shifted
 /// down to the shader-facing mask by the helpers below, so the shift amounts
@@ -34,6 +35,19 @@ abstract final class DrawCommandFlags {
   static const int fillOutlineOpacityDataDriven = 1 << 21;
   static const int depthTest = 1 << 22;
   static const int depthWrite = 1 << 23;
+
+  /// Legacy bridge-only marker: a data-driven fill-extrusion vertex buffer was
+  /// expanded from the packed 44-byte source layout to the old 56-byte float
+  /// layout. New native builds keep the 44-byte layout packed, but Dart keeps
+  /// this marker so already-packaged native artifacts remain compatible.
+  static const int fillExtrusionGpuReady = 1 << 24;
+
+  /// Bridge-only marker: a line-family vertex buffer has already expanded its
+  /// packed layout prefix to float32. Older/current bridge artifacts can export
+  /// 24-byte constant or 120-byte DD vertices. Constant-line Flutter GPU
+  /// shaders now consume 8-byte packed vertices, so 24-byte compatibility data
+  /// is packed back in Dart before upload; DD keeps the 120-byte layout.
+  static const int lineGpuReady = 1 << 25;
 
   /// Bit position of the lowest bit in each data-driven group. The helpers
   /// shift by these so a mask and its shift stay defined in one place.
@@ -126,15 +140,22 @@ int fillOutlineVertexStride(int flags) =>
 bool fillExtrusionUsesDataDrivenPipeline(int flags) =>
     (flags & DrawCommandFlags.fillExtrusionDataDriven) != 0;
 
+/// Whether this command uses the legacy bridge-expanded 56-byte FE DD layout.
+bool fillExtrusionUsesExpandedGpuLayout(int flags) =>
+    fillExtrusionUsesDataDrivenPipeline(flags) &&
+    (flags & DrawCommandFlags.fillExtrusionGpuReady) != 0;
+
 /// One-bit mask consumed by FillExtrusionDDVertex (bit0=color).
 int fillExtrusionDataDrivenMask(int flags) =>
     (flags & DrawCommandFlags.fillExtrusionColorDataDriven) >>
     DrawCommandFlags.fillExtrusionColorDataDrivenShift;
 
-/// Exported fill-extrusion stride. The normalized DD layout always contains
-/// base, height, and packed-color ranges even when only one is data-driven.
-int fillExtrusionVertexStride(int flags) =>
-    fillExtrusionUsesDataDrivenPipeline(flags) ? 44 : 12;
+/// Exported fill-extrusion stride. Command Export's normalized DD layout is 44
+/// bytes. Older bridge artifacts can instead mark a 56-byte expanded layout.
+int fillExtrusionVertexStride(int flags) {
+  if (!fillExtrusionUsesDataDrivenPipeline(flags)) return 12;
+  return fillExtrusionUsesExpandedGpuLayout(flags) ? 56 : 44;
+}
 
 /// Whether fill extrusion needs a depth prepass for [opacity].
 ///
@@ -155,7 +176,7 @@ int circleDataDrivenMask(int flags) =>
 int circleVertexStride(int flags) =>
     circleUsesDataDrivenPipeline(flags) ? 76 : 4;
 
-/// Whether a line-family command needs the normalized 88-byte pipeline.
+/// Whether a line-family command needs the normalized data-driven pipeline.
 bool lineUsesDataDrivenPipeline(int flags) =>
     (flags & DrawCommandFlags.lineDataDrivenMask) != 0;
 
@@ -165,26 +186,40 @@ int lineDataDrivenMask(int flags) =>
     (flags & DrawCommandFlags.lineDataDrivenMask) >>
     DrawCommandFlags.lineDataDrivenShift;
 
-/// Exported line-family vertex stride for the command flags.
-int lineVertexStride(int flags) => lineUsesDataDrivenPipeline(flags) ? 88 : 8;
+/// Exported line-family stride. Command Export emits packed 8/88-byte layouts.
+/// Bridge-expanded compatibility layouts remain 24/120 bytes when bit25 is set.
+int lineVertexStride(int flags) {
+  final dataDriven = lineUsesDataDrivenPipeline(flags);
+  if ((flags & DrawCommandFlags.lineGpuReady) != 0) {
+    return dataDriven ? 120 : 24;
+  }
+  return dataDriven ? 88 : 8;
+}
 
 /// Vertex stride consumed by Flutter GPU after packed integer attributes have
 /// been expanded to numeric floats for Impeller's OpenGLES backend.
-int gpuVertexStride(int shader, int flags) => switch (shader) {
-  ShaderType.fill => fillVertexStride(flags) + 4,
-  ShaderType.fillOutline ||
-  ShaderType.background ||
-  ShaderType.clippingMask ||
-  ShaderType.backgroundPattern => 8,
-  ShaderType.circle => circleVertexStride(flags) + 4,
-  ShaderType.fillExtrusion =>
-    fillExtrusionUsesDataDrivenPipeline(flags) ? 56 : 24,
-  ShaderType.line ||
-  ShaderType.lineSDF ||
-  ShaderType.lineGradient ||
-  ShaderType.linePattern => lineUsesDataDrivenPipeline(flags) ? 120 : 24,
-  ShaderType.fillOutlineTriangulated =>
-    fillOutlineUsesDataDrivenPipeline(flags) ? 48 : 24,
-  ShaderType.raster => 16,
-  _ => throw ArgumentError.value(shader, 'shader', 'Unsupported shader type'),
-};
+int gpuVertexStride(int shader, int flags) {
+  final usesMergedLayout =
+      drawCommandIsCrossTileMerged(flags) &&
+      (shader == ShaderType.background ||
+          (shader == ShaderType.fill && !fillUsesDataDrivenPipeline(flags)));
+  if (usesMergedLayout) return mergedVertexStride;
+  return switch (shader) {
+    ShaderType.fill => fillVertexStride(flags) + 4,
+    ShaderType.fillOutline ||
+    ShaderType.background ||
+    ShaderType.clippingMask ||
+    ShaderType.backgroundPattern => 8,
+    ShaderType.circle => circleVertexStride(flags) + 4,
+    ShaderType.fillExtrusion =>
+      fillExtrusionUsesDataDrivenPipeline(flags) ? 56 : 24,
+    ShaderType.line ||
+    ShaderType.lineSDF ||
+    ShaderType.lineGradient ||
+    ShaderType.linePattern => lineUsesDataDrivenPipeline(flags) ? 120 : 24,
+    ShaderType.fillOutlineTriangulated =>
+      fillOutlineUsesDataDrivenPipeline(flags) ? 48 : 24,
+    ShaderType.raster => 16,
+    _ => throw ArgumentError.value(shader, 'shader', 'Unsupported shader type'),
+  };
+}

--- a/lib/src/frame/pipeline_key.dart
+++ b/lib/src/frame/pipeline_key.dart
@@ -24,6 +24,8 @@ enum RenderPipelineKey {
   fillExtrusionDataDriven,
   fillExtrusionDepth,
   fillExtrusionDataDrivenDepth,
+  fillExtrusionExpandedDataDriven,
+  fillExtrusionExpandedDataDrivenDepth,
   line,
   lineDataDriven,
   lineSdf,
@@ -74,7 +76,9 @@ RenderPipelineKey pipelineKeyFor({required int shader, required int flags}) =>
       ShaderType.backgroundPattern => RenderPipelineKey.backgroundPattern,
       ShaderType.clippingMask => RenderPipelineKey.clippingMask,
       ShaderType.fillExtrusion =>
-        fillExtrusionUsesDataDrivenPipeline(flags)
+        fillExtrusionUsesExpandedGpuLayout(flags)
+            ? RenderPipelineKey.fillExtrusionExpandedDataDriven
+            : fillExtrusionUsesDataDrivenPipeline(flags)
             ? RenderPipelineKey.fillExtrusionDataDriven
             : RenderPipelineKey.fillExtrusion,
       _ =>
@@ -94,6 +98,8 @@ RenderPipelineKey? depthPipelineKeyFor({
   required int flags,
 }) => shader != ShaderType.fillExtrusion
     ? null
+    : fillExtrusionUsesExpandedGpuLayout(flags)
+    ? RenderPipelineKey.fillExtrusionExpandedDataDrivenDepth
     : fillExtrusionUsesDataDrivenPipeline(flags)
     ? RenderPipelineKey.fillExtrusionDataDrivenDepth
     : RenderPipelineKey.fillExtrusionDepth;

--- a/lib/src/frame/vertex_repack.dart
+++ b/lib/src/frame/vertex_repack.dart
@@ -1,11 +1,7 @@
-// Converts MapLibre's packed vertex layouts into the float-only layouts the
-// Flutter GPU pipelines declare.
-//
-// Split out of the renderer because it is pure byte math over a source buffer:
-// it needs no GPU context and is covered directly by unit tests.
-//
-// Not annotated @visibleForTesting: this is the render layer's own API, and
-// lib/src is already outside the package's public surface.
+// Converts the remaining MapLibre packed vertex layouts into the layouts their
+// Flutter GPU pipelines consume. Fill, triangulated fill-outline, packed FE,
+// and constant line vertices now bypass this file when source and GPU strides
+// already match.
 import 'dart:typed_data';
 
 import '../native/draw_command.dart';
@@ -59,6 +55,168 @@ void _writeUnsignedShortsAsFloats(
   }
 }
 
+/// Compatibility path for old bridge artifacts that expanded constant lines
+/// to six float32 values. The values are exact integer conversions of the
+/// original short2 + uchar4 layout, so packing them back is lossless.
+Uint8List _packExpandedConstantLineVertices(
+  Uint8List source, {
+  required int vertexCount,
+}) {
+  final target = Uint8List(vertexCount * 8);
+  final input = ByteData.sublistView(source);
+  final output = ByteData.sublistView(target);
+  for (var vertex = 0; vertex < vertexCount; vertex += 1) {
+    final sourceOffset = vertex * 24;
+    final targetOffset = vertex * 8;
+    output
+      ..setInt16(
+        targetOffset,
+        input.getFloat32(sourceOffset, Endian.little).toInt(),
+        Endian.little,
+      )
+      ..setInt16(
+        targetOffset + 2,
+        input.getFloat32(sourceOffset + 4, Endian.little).toInt(),
+        Endian.little,
+      );
+    for (var index = 0; index < 4; index += 1) {
+      output.setUint8(
+        targetOffset + 4 + index,
+        input.getFloat32(sourceOffset + 8 + index * 4, Endian.little).toInt(),
+      );
+    }
+  }
+  return target;
+}
+
+Uint8List _repackPositionPrefixVertices(
+  Uint8List source, {
+  required int vertexCount,
+  required int sourceStride,
+  required int targetStride,
+}) {
+  final target = Uint8List(vertexCount * targetStride);
+  if (vertexCount == 0) return target;
+
+  if (Endian.host == Endian.little && source.offsetInBytes % 4 == 0) {
+    final sourceLength = vertexCount * sourceStride;
+    final signed = Int16List.view(
+      source.buffer,
+      source.offsetInBytes,
+      sourceLength ~/ 2,
+    );
+    final sourceWords = Uint32List.view(
+      source.buffer,
+      source.offsetInBytes,
+      sourceLength ~/ 4,
+    );
+    final output = Float32List.view(target.buffer);
+    final outputWords = Uint32List.view(target.buffer);
+    final sourceHalvesPerVertex = sourceStride ~/ 2;
+    final sourceWordsPerVertex = sourceStride ~/ 4;
+    final targetFloatsPerVertex = targetStride ~/ 4;
+
+    for (var vertex = 0; vertex < vertexCount; vertex += 1) {
+      final sourceHalf = vertex * sourceHalvesPerVertex;
+      final sourceWord = vertex * sourceWordsPerVertex;
+      final targetFloat = vertex * targetFloatsPerVertex;
+      output[targetFloat] = signed[sourceHalf].toDouble();
+      output[targetFloat + 1] = signed[sourceHalf + 1].toDouble();
+      for (var word = 1; word < sourceWordsPerVertex; word += 1) {
+        outputWords[targetFloat + word + 1] = sourceWords[sourceWord + word];
+      }
+    }
+    return target;
+  }
+
+  final sourceData = ByteData.sublistView(source);
+  final targetData = ByteData.sublistView(target);
+  for (var vertex = 0; vertex < vertexCount; vertex += 1) {
+    final sourceOffset = vertex * sourceStride;
+    final targetOffset = vertex * targetStride;
+    _writeShortsAsFloats(sourceData, sourceOffset, targetData, targetOffset, 2);
+    if (sourceStride > 4) {
+      target.setRange(
+        targetOffset + 8,
+        targetOffset + targetStride,
+        source,
+        sourceOffset + 4,
+      );
+    }
+  }
+  return target;
+}
+
+Uint8List _repackFillOutlineTriangulatedVertices(
+  Uint8List source, {
+  required int vertexCount,
+  required int sourceStride,
+  required int targetStride,
+}) {
+  final target = Uint8List(vertexCount * targetStride);
+  if (vertexCount == 0) return target;
+
+  if (Endian.host == Endian.little && source.offsetInBytes % 4 == 0) {
+    final sourceLength = vertexCount * sourceStride;
+    final signed = Int16List.view(
+      source.buffer,
+      source.offsetInBytes,
+      sourceLength ~/ 2,
+    );
+    final sourceWords = Uint32List.view(
+      source.buffer,
+      source.offsetInBytes,
+      sourceLength ~/ 4,
+    );
+    final output = Float32List.view(target.buffer);
+    final outputWords = Uint32List.view(target.buffer);
+    final sourceHalvesPerVertex = sourceStride ~/ 2;
+    final sourceWordsPerVertex = sourceStride ~/ 4;
+    final targetFloatsPerVertex = targetStride ~/ 4;
+
+    for (var vertex = 0; vertex < vertexCount; vertex += 1) {
+      final sourceOffset = vertex * sourceStride;
+      final sourceHalf = vertex * sourceHalvesPerVertex;
+      final sourceWord = vertex * sourceWordsPerVertex;
+      final targetFloat = vertex * targetFloatsPerVertex;
+      output[targetFloat] = signed[sourceHalf].toDouble();
+      output[targetFloat + 1] = signed[sourceHalf + 1].toDouble();
+      output[targetFloat + 2] = source[sourceOffset + 4].toDouble();
+      output[targetFloat + 3] = source[sourceOffset + 5].toDouble();
+      output[targetFloat + 4] = source[sourceOffset + 6].toDouble();
+      output[targetFloat + 5] = source[sourceOffset + 7].toDouble();
+      for (var word = 2; word < sourceWordsPerVertex; word += 1) {
+        outputWords[targetFloat + word + 4] = sourceWords[sourceWord + word];
+      }
+    }
+    return target;
+  }
+
+  final sourceData = ByteData.sublistView(source);
+  final targetData = ByteData.sublistView(target);
+  for (var vertex = 0; vertex < vertexCount; vertex += 1) {
+    final sourceOffset = vertex * sourceStride;
+    final targetOffset = vertex * targetStride;
+    _writeShortsAsFloats(sourceData, sourceOffset, targetData, targetOffset, 2);
+    _writeBytesAsFloats(
+      sourceData,
+      sourceOffset + 4,
+      targetData,
+      targetOffset + 8,
+      4,
+    );
+    if (sourceStride > 8) {
+      target.setRange(
+        targetOffset + 24,
+        targetOffset + targetStride,
+        source,
+        sourceOffset + 8,
+      );
+    }
+  }
+  return target;
+}
+
 Uint8List _repackFillExtrusionVertices(
   Uint8List source, {
   required int vertexCount,
@@ -68,9 +226,6 @@ Uint8List _repackFillExtrusionVertices(
   final target = Uint8List(vertexCount * targetStride);
   if (vertexCount == 0) return target;
 
-  // Native command buffers are naturally aligned and every supported Flutter
-  // GPU target is little-endian. Typed views avoid six ByteData getter/setter
-  // pairs per building vertex on the zoom-boundary cold path.
   if (Endian.host == Endian.little && source.offsetInBytes.isEven) {
     final sourceLength = vertexCount * sourceStride;
     final signed = Int16List.view(
@@ -111,7 +266,6 @@ Uint8List _repackFillExtrusionVertices(
     return target;
   }
 
-  // Defensive fallback for an unaligned view or a future big-endian target.
   final sourceData = ByteData.sublistView(source);
   final targetData = ByteData.sublistView(target);
   for (var vertex = 0; vertex < vertexCount; vertex += 1) {
@@ -144,10 +298,6 @@ Uint8List _repackFillExtrusionVertices(
   return target;
 }
 
-/// Converts MapLibre's compact short/byte vertex layouts to float-only stage
-/// inputs. Impeller OpenGLES binds attributes with `glVertexAttribPointer` and
-/// does not support 32-bit integer stage inputs, so passing packed words as
-/// float bit patterns would be unsafe for NaN and subnormal encodings.
 Uint8List repackVertexDataForGpu(
   Uint8List source, {
   required int vertexCount,
@@ -163,8 +313,40 @@ Uint8List repackVertexDataForGpu(
   }
 
   final targetStride = gpuVertexStride(shader, flags);
+  if (sourceStride == targetStride) return source;
+
+  if (isLineShader(shader) &&
+      !lineUsesDataDrivenPipeline(flags) &&
+      sourceStride == 24 &&
+      targetStride == 8) {
+    return _packExpandedConstantLineVertices(source, vertexCount: vertexCount);
+  }
+
   if (shader == ShaderType.fillExtrusion) {
     return _repackFillExtrusionVertices(
+      source,
+      vertexCount: vertexCount,
+      sourceStride: sourceStride,
+      targetStride: targetStride,
+    );
+  }
+
+  if (shader == ShaderType.fillOutlineTriangulated) {
+    return _repackFillOutlineTriangulatedVertices(
+      source,
+      vertexCount: vertexCount,
+      sourceStride: sourceStride,
+      targetStride: targetStride,
+    );
+  }
+
+  if (shader == ShaderType.fill ||
+      shader == ShaderType.fillOutline ||
+      shader == ShaderType.background ||
+      shader == ShaderType.clippingMask ||
+      shader == ShaderType.backgroundPattern ||
+      shader == ShaderType.circle) {
+    return _repackPositionPrefixVertices(
       source,
       vertexCount: vertexCount,
       sourceStride: sourceStride,
@@ -180,7 +362,7 @@ Uint8List repackVertexDataForGpu(
     final sourceOffset = vertex * sourceStride;
     final targetOffset = vertex * targetStride;
 
-    if (isLineShader(shader) || shader == ShaderType.fillOutlineTriangulated) {
+    if (isLineShader(shader)) {
       _writeShortsAsFloats(
         sourceData,
         sourceOffset,
@@ -196,20 +378,7 @@ Uint8List repackVertexDataForGpu(
         4,
       );
 
-      if (shader == ShaderType.fillOutlineTriangulated) {
-        if (sourceStride > 8) {
-          target.setRange(
-            targetOffset + 24,
-            targetOffset + targetStride,
-            source,
-            sourceOffset + 8,
-          );
-        }
-        continue;
-      }
-
       if (sourceStride > 8) {
-        // Color plus six scalar ranges are already float data.
         target.setRange(
           targetOffset + 24,
           targetOffset + 88,
@@ -252,17 +421,7 @@ Uint8List repackVertexDataForGpu(
       continue;
     }
 
-    // Fill, outline, background, circle, clipping mask, and background
-    // pattern all begin with one packed signed-short pair.
-    _writeShortsAsFloats(sourceData, sourceOffset, targetData, targetOffset, 2);
-    if (sourceStride > 4) {
-      target.setRange(
-        targetOffset + 8,
-        targetOffset + targetStride,
-        source,
-        sourceOffset + 4,
-      );
-    }
+    throw ArgumentError.value(shader, 'shader', 'Unsupported shader type');
   }
   return target;
 }

--- a/lib/src/gpu/persistent_buffer_pool.dart
+++ b/lib/src/gpu/persistent_buffer_pool.dart
@@ -1,0 +1,459 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_gpu/gpu.dart' as gpu;
+
+const int _defaultPageBytes = 1024 * 1024;
+const int _defaultMaxPageBytes = 192 * 1024 * 1024;
+const int _defaultMaxAllocationBytes = 256 * 1024;
+const int _defaultAlignmentBytes = 16;
+const int _defaultQuarantineFrames = 4;
+
+/// Whether [bytes] is small enough to share a persistent upload page.
+@visibleForTesting
+bool gpuPersistentBufferPoolEligible(
+  int bytes, {
+  int maxAllocationBytes = _defaultMaxAllocationBytes,
+}) {
+  if (bytes < 0) {
+    throw RangeError.value(bytes, 'bytes', 'must not be negative');
+  }
+  if (maxAllocationBytes <= 0) {
+    throw ArgumentError.value(
+      maxAllocationBytes,
+      'maxAllocationBytes',
+      'must be positive',
+    );
+  }
+  return bytes > 0 && bytes <= maxAllocationBytes;
+}
+
+/// Rounded storage reserved inside a persistent upload page.
+@visibleForTesting
+int gpuPersistentBufferPoolReservedBytes(
+  int bytes, {
+  int alignmentBytes = _defaultAlignmentBytes,
+}) {
+  if (bytes < 0) {
+    throw RangeError.value(bytes, 'bytes', 'must not be negative');
+  }
+  if (alignmentBytes <= 0) {
+    throw ArgumentError.value(
+      alignmentBytes,
+      'alignmentBytes',
+      'must be positive',
+    );
+  }
+  if (bytes == 0) return 0;
+  return ((bytes + alignmentBytes - 1) ~/ alignmentBytes) * alignmentBytes;
+}
+
+/// Whether another persistent page fits inside the physical pool cap.
+@visibleForTesting
+bool gpuPersistentBufferPoolCanAddPage({
+  required int currentPageBytes,
+  required int pageBytes,
+  required int maxPageBytes,
+}) {
+  if (currentPageBytes < 0 || pageBytes <= 0 || maxPageBytes < pageBytes) {
+    throw ArgumentError('Invalid persistent GPU buffer page budget');
+  }
+
+  return currentPageBytes <= maxPageBytes - pageBytes;
+}
+
+/// Whether the largest pooled allocation still fits after alignment.
+@visibleForTesting
+bool gpuPersistentBufferPoolMaxAllocationFitsPage({
+  required int pageBytes,
+  required int maxAllocationBytes,
+  required int alignmentBytes,
+}) {
+  if (pageBytes <= 0 || maxAllocationBytes <= 0 || alignmentBytes <= 0) {
+    throw ArgumentError('Invalid persistent GPU buffer allocation bounds');
+  }
+
+  return gpuPersistentBufferPoolReservedBytes(
+        maxAllocationBytes,
+        alignmentBytes: alignmentBytes,
+      ) <=
+      pageBytes;
+}
+
+/// Interval activity and current physical occupancy of the persistent pool.
+final class GpuPersistentBufferPoolSnapshot {
+  const GpuPersistentBufferPoolSnapshot({
+    required this.pageCount,
+    required this.pageBytes,
+    required this.writeCount,
+    required this.writeBytes,
+    required this.pageAllocationCount,
+    required this.reusedRangeCount,
+  });
+
+  final int pageCount;
+  final int pageBytes;
+  final int writeCount;
+  final int writeBytes;
+  final int pageAllocationCount;
+  final int reusedRangeCount;
+}
+
+/// One immutable cached range inside a host-visible persistent page.
+///
+/// Call [release] only after the cache no longer owns the range. The allocator
+/// quarantines it for the configured in-flight frame count before allowing an
+/// overwrite.
+final class GpuPersistentBufferAllocation {
+  GpuPersistentBufferAllocation._(
+    this.buffer,
+    this.offsetInBytes,
+    this.lengthInBytes,
+    this._reservedBytes,
+    this._page,
+    this._quarantineFrames,
+  );
+
+  final gpu.DeviceBuffer buffer;
+  final int offsetInBytes;
+  final int lengthInBytes;
+  final int _reservedBytes;
+  final _GpuPersistentBufferPage _page;
+  final int _quarantineFrames;
+  bool _released = false;
+
+  void release(int frame) {
+    if (_released) return;
+    _released = true;
+    _page.release(
+      offsetInBytes,
+      _reservedBytes,
+      readyFrame: frame + _quarantineFrames,
+    );
+  }
+}
+
+/// A persistent range allocator for cached vertex/index uploads.
+///
+/// Payloads up to 256 KiB are packed into 1 MiB host-visible pages, capped at
+/// 192 MiB total. Freed ranges sit in a four-frame quarantine before entering
+/// the page free-list, so submitted draws cannot observe later overwrites.
+/// Larger payloads and cap overflow use dedicated buffers outside this pool.
+final class GpuPersistentBufferPool {
+  GpuPersistentBufferPool({
+    gpu.GpuContext? context,
+    this.pageBytes = _defaultPageBytes,
+    this.maxPageBytes = _defaultMaxPageBytes,
+    this.maxAllocationBytes = _defaultMaxAllocationBytes,
+    this.alignmentBytes = _defaultAlignmentBytes,
+    this.quarantineFrames = _defaultQuarantineFrames,
+  }) : _context = context ?? gpu.gpuContext {
+    if (pageBytes <= 0 ||
+        maxAllocationBytes <= 0 ||
+        alignmentBytes <= 0 ||
+        !gpuPersistentBufferPoolMaxAllocationFitsPage(
+          pageBytes: pageBytes,
+          maxAllocationBytes: maxAllocationBytes,
+          alignmentBytes: alignmentBytes,
+        ) ||
+        maxPageBytes < pageBytes ||
+        quarantineFrames < 0) {
+      throw ArgumentError('Invalid persistent GPU buffer pool configuration');
+    }
+  }
+
+  final gpu.GpuContext _context;
+  final int pageBytes;
+  final int maxPageBytes;
+  final int maxAllocationBytes;
+  final int alignmentBytes;
+  final int quarantineFrames;
+  final List<_GpuPersistentBufferPage> _pages = [];
+
+  // One monotonic clock is shared by every allocation so diagnostics do not
+  // allocate a Stopwatch per upload and perturb the small-buffer hot path.
+  final Stopwatch _timingClock = Stopwatch()..start();
+  int _searchMicros = 0;
+  int _searchMaxMicros = 0;
+  int _pageAllocationMicros = 0;
+  int _pageAllocationMaxMicros = 0;
+  int _overwriteMicros = 0;
+  int _overwriteMaxMicros = 0;
+  int _flushMicros = 0;
+  int _flushMaxMicros = 0;
+
+  int _writeCount = 0;
+  int _writeBytes = 0;
+  int _pageAllocationCount = 0;
+  int _reusedRangeCount = 0;
+
+  /// Packs [bytes] into a persistent page, or returns null for large payloads.
+  GpuPersistentBufferAllocation? allocate(
+    Uint8List bytes, {
+    required int frame,
+  }) {
+    final byteLength = bytes.lengthInBytes;
+    if (!gpuPersistentBufferPoolEligible(
+      byteLength,
+      maxAllocationBytes: maxAllocationBytes,
+    )) {
+      return null;
+    }
+    final reservedBytes = gpuPersistentBufferPoolReservedBytes(
+      byteLength,
+      alignmentBytes: alignmentBytes,
+    );
+
+    final searchStart = _timingClock.elapsedMicroseconds;
+    _GpuPersistentBufferPage? selected;
+    int? offset;
+    var reusedRange = false;
+    for (final page in _pages) {
+      final allocation = page.allocate(reservedBytes);
+      if (allocation == null) continue;
+      selected = page;
+      offset = allocation.offset;
+      reusedRange = allocation.reusedRange;
+      break;
+    }
+    final searchMicros = _timingClock.elapsedMicroseconds - searchStart;
+    _searchMicros += searchMicros;
+    if (searchMicros > _searchMaxMicros) _searchMaxMicros = searchMicros;
+
+    if (selected == null) {
+      if (!gpuPersistentBufferPoolCanAddPage(
+        currentPageBytes: _pages.length * pageBytes,
+        pageBytes: pageBytes,
+        maxPageBytes: maxPageBytes,
+      )) {
+        return null;
+      }
+      final pageAllocationStart = _timingClock.elapsedMicroseconds;
+      selected = _GpuPersistentBufferPage(
+        _context.createDeviceBuffer(gpu.StorageMode.hostVisible, pageBytes),
+        pageBytes,
+      );
+      final pageAllocationMicros =
+          _timingClock.elapsedMicroseconds - pageAllocationStart;
+      _pageAllocationMicros += pageAllocationMicros;
+      if (pageAllocationMicros > _pageAllocationMaxMicros) {
+        _pageAllocationMaxMicros = pageAllocationMicros;
+      }
+      _pages.add(selected);
+      _pageAllocationCount += 1;
+      final allocation = selected.allocate(reservedBytes)!;
+      offset = allocation.offset;
+    }
+
+    final data = ByteData.sublistView(bytes);
+    final overwriteStart = _timingClock.elapsedMicroseconds;
+    final success = selected.buffer.overwrite(
+      data,
+      destinationOffsetInBytes: offset!,
+    );
+    final overwriteMicros = _timingClock.elapsedMicroseconds - overwriteStart;
+    _overwriteMicros += overwriteMicros;
+    if (overwriteMicros > _overwriteMaxMicros) {
+      _overwriteMaxMicros = overwriteMicros;
+    }
+    if (!success) {
+      selected.release(offset, reservedBytes, readyFrame: frame);
+      selected.reclaim(frame);
+      throw StateError(
+        'Failed to write persistent GPU buffer range '
+        '(offset=$offset, length=$byteLength)',
+      );
+    }
+
+    final flushStart = _timingClock.elapsedMicroseconds;
+    selected.buffer.flush(offsetInBytes: offset, lengthInBytes: byteLength);
+    final flushMicros = _timingClock.elapsedMicroseconds - flushStart;
+    _flushMicros += flushMicros;
+    if (flushMicros > _flushMaxMicros) _flushMaxMicros = flushMicros;
+
+    _writeCount += 1;
+    _writeBytes += byteLength;
+    if (reusedRange) _reusedRangeCount += 1;
+
+    return GpuPersistentBufferAllocation._(
+      selected.buffer,
+      offset,
+      byteLength,
+      reservedBytes,
+      selected,
+      quarantineFrames,
+    );
+  }
+
+  /// Advances quarantine and drops fully unused pages, retaining one spare.
+  void beginFrame(int frame) {
+    for (final page in _pages) {
+      page.reclaim(frame);
+    }
+    var keptSpare = false;
+    _pages.removeWhere((page) {
+      if (!page.fullyFree) return false;
+      if (!keptSpare) {
+        keptSpare = true;
+        page.reset();
+        return false;
+      }
+      return true;
+    });
+  }
+
+  void _logTimingAndReset() {
+    if (_writeCount == 0 && _pageAllocationCount == 0) {
+      debugPrint('[GpuBufferPoolTiming] none');
+    } else {
+      String metric(int count, int total, int maximum) {
+        if (count == 0) return '0/-/-/-';
+        final average = (total / count).toStringAsFixed(0);
+        return '$count/${total}us/${average}us/${maximum}us';
+      }
+
+      debugPrint(
+        '[GpuBufferPoolTiming] '
+        'search=${metric(_writeCount, _searchMicros, _searchMaxMicros)} '
+        'newPage=${metric(_pageAllocationCount, _pageAllocationMicros, _pageAllocationMaxMicros)} '
+        'overwrite=${metric(_writeCount, _overwriteMicros, _overwriteMaxMicros)} '
+        'flush=${metric(_writeCount, _flushMicros, _flushMaxMicros)}',
+      );
+    }
+    _searchMicros = 0;
+    _searchMaxMicros = 0;
+    _pageAllocationMicros = 0;
+    _pageAllocationMaxMicros = 0;
+    _overwriteMicros = 0;
+    _overwriteMaxMicros = 0;
+    _flushMicros = 0;
+    _flushMaxMicros = 0;
+  }
+
+  /// Returns interval activity and resets only the interval counters.
+  GpuPersistentBufferPoolSnapshot takeSnapshotAndReset() {
+    final snapshot = GpuPersistentBufferPoolSnapshot(
+      pageCount: _pages.length,
+      pageBytes: _pages.length * pageBytes,
+      writeCount: _writeCount,
+      writeBytes: _writeBytes,
+      pageAllocationCount: _pageAllocationCount,
+      reusedRangeCount: _reusedRangeCount,
+    );
+    _logTimingAndReset();
+    _writeCount = 0;
+    _writeBytes = 0;
+    _pageAllocationCount = 0;
+    _reusedRangeCount = 0;
+    return snapshot;
+  }
+
+  void dispose() {
+    _pages.clear();
+    _writeCount = 0;
+    _writeBytes = 0;
+    _pageAllocationCount = 0;
+    _reusedRangeCount = 0;
+    _searchMicros = 0;
+    _searchMaxMicros = 0;
+    _pageAllocationMicros = 0;
+    _pageAllocationMaxMicros = 0;
+    _overwriteMicros = 0;
+    _overwriteMaxMicros = 0;
+    _flushMicros = 0;
+    _flushMaxMicros = 0;
+  }
+}
+
+final class _GpuBufferRange {
+  _GpuBufferRange(this.offset, this.length);
+
+  int offset;
+  int length;
+}
+
+final class _GpuPendingBufferRange extends _GpuBufferRange {
+  _GpuPendingBufferRange(super.offset, super.length, this.readyFrame);
+
+  final int readyFrame;
+}
+
+final class _GpuPersistentBufferPage {
+  _GpuPersistentBufferPage(this.buffer, this.lengthInBytes);
+
+  final gpu.DeviceBuffer buffer;
+  final int lengthInBytes;
+  int _cursor = 0;
+  int _liveAllocations = 0;
+  final List<_GpuBufferRange> _freeRanges = [];
+  final List<_GpuPendingBufferRange> _pendingRanges = [];
+
+  bool get fullyFree => _liveAllocations == 0 && _pendingRanges.isEmpty;
+
+  ({int offset, bool reusedRange})? allocate(int reservedBytes) {
+    for (var index = 0; index < _freeRanges.length; index += 1) {
+      final range = _freeRanges[index];
+      if (range.length < reservedBytes) continue;
+      final offset = range.offset;
+      if (range.length == reservedBytes) {
+        _freeRanges.removeAt(index);
+      } else {
+        range
+          ..offset += reservedBytes
+          ..length -= reservedBytes;
+      }
+      _liveAllocations += 1;
+      return (offset: offset, reusedRange: true);
+    }
+    if (_cursor + reservedBytes > lengthInBytes) return null;
+    final offset = _cursor;
+    _cursor += reservedBytes;
+    _liveAllocations += 1;
+    return (offset: offset, reusedRange: false);
+  }
+
+  void release(int offset, int length, {required int readyFrame}) {
+    if (_liveAllocations <= 0) {
+      throw StateError('Persistent GPU buffer page release underflow');
+    }
+    _liveAllocations -= 1;
+    _pendingRanges.add(_GpuPendingBufferRange(offset, length, readyFrame));
+  }
+
+  void reclaim(int frame) {
+    if (_pendingRanges.isEmpty) {
+      if (fullyFree) reset();
+      return;
+    }
+    var changed = false;
+    _pendingRanges.removeWhere((range) {
+      if (range.readyFrame > frame) return false;
+      _freeRanges.add(_GpuBufferRange(range.offset, range.length));
+      changed = true;
+      return true;
+    });
+    if (changed) _coalesceFreeRanges();
+    if (fullyFree) reset();
+  }
+
+  void reset() {
+    if (!fullyFree) return;
+    _cursor = 0;
+    _freeRanges.clear();
+  }
+
+  void _coalesceFreeRanges() {
+    if (_freeRanges.length < 2) return;
+    _freeRanges.sort((left, right) => left.offset.compareTo(right.offset));
+    var write = 0;
+    for (var read = 1; read < _freeRanges.length; read += 1) {
+      final current = _freeRanges[write];
+      final next = _freeRanges[read];
+      if (current.offset + current.length == next.offset) {
+        current.length += next.length;
+      } else {
+        write += 1;
+        if (write != read) _freeRanges[write] = next;
+      }
+    }
+    _freeRanges.removeRange(write + 1, _freeRanges.length);
+  }
+}

--- a/lib/src/gpu/pipeline_registry.dart
+++ b/lib/src/gpu/pipeline_registry.dart
@@ -195,8 +195,7 @@ const Map<RenderPipelineKey, PipelineSpec> _pipelineSpecs = {
     mapGlobal: true,
     image: false,
   ),
-  // Both fill extrusion UBOs belong to the vertex shader. The fragment shader
-  // declares no uniform slots.
+  // New native builds upload the original packed 12/44-byte FE vertices.
   RenderPipelineKey.fillExtrusion: (
     vertex: 'FillExtrusionVertex',
     fragment: 'FillExtrusionFragment',
@@ -209,7 +208,6 @@ const Map<RenderPipelineKey, PipelineSpec> _pipelineSpecs = {
     mapGlobal: false,
     image: false,
   ),
-  // Data-driven base, height, and color variant.
   RenderPipelineKey.fillExtrusionDataDriven: (
     vertex: 'FillExtrusionDDVertex',
     fragment: 'FillExtrusionFragment',
@@ -222,9 +220,6 @@ const Map<RenderPipelineKey, PipelineSpec> _pipelineSpecs = {
     mapGlobal: false,
     image: false,
   ),
-  // MapLibre renders translucent extrusions depth-only before their color
-  // pass. A transparent premultiplied output leaves the color attachment
-  // unchanged while Flutter GPU records the same depth prepass.
   RenderPipelineKey.fillExtrusionDepth: (
     vertex: 'FillExtrusionVertex',
     fragment: 'FillExtrusionDepthFragment',
@@ -239,6 +234,32 @@ const Map<RenderPipelineKey, PipelineSpec> _pipelineSpecs = {
   ),
   RenderPipelineKey.fillExtrusionDataDrivenDepth: (
     vertex: 'FillExtrusionDDVertex',
+    fragment: 'FillExtrusionDepthFragment',
+    drawable: _fillExtrusionDrawable,
+    vertexProps: _fillExtrusionProps,
+    fragmentProps: null,
+    tileProps: null,
+    fragmentDrawable: false,
+    vertexTileProps: false,
+    mapGlobal: false,
+    image: false,
+  ),
+  // Compatibility with already-packaged native artifacts that set bit24 and
+  // expose the old 56-byte float-expanded DD layout.
+  RenderPipelineKey.fillExtrusionExpandedDataDriven: (
+    vertex: 'FillExtrusionExpandedDDVertex',
+    fragment: 'FillExtrusionFragment',
+    drawable: _fillExtrusionDrawable,
+    vertexProps: _fillExtrusionProps,
+    fragmentProps: null,
+    tileProps: null,
+    fragmentDrawable: false,
+    vertexTileProps: false,
+    mapGlobal: false,
+    image: false,
+  ),
+  RenderPipelineKey.fillExtrusionExpandedDataDrivenDepth: (
+    vertex: 'FillExtrusionExpandedDDVertex',
     fragment: 'FillExtrusionDepthFragment',
     drawable: _fillExtrusionDrawable,
     vertexProps: _fillExtrusionProps,
@@ -389,6 +410,8 @@ class MapPipelineRegistry {
     this[RenderPipelineKey.fillExtrusionDepth];
     this[RenderPipelineKey.fillExtrusionDataDriven];
     this[RenderPipelineKey.fillExtrusionDataDrivenDepth];
+    this[RenderPipelineKey.fillExtrusionExpandedDataDriven];
+    this[RenderPipelineKey.fillExtrusionExpandedDataDrivenDepth];
   }
 
   ResolvedPipeline _create(PipelineSpec spec) {

--- a/lib/src/gpu/prepared_graph.dart
+++ b/lib/src/gpu/prepared_graph.dart
@@ -1,0 +1,601 @@
+import 'dart:typed_data';
+
+import '../frame/draw_command_admission.dart';
+import '../frame/ubo_abi.dart';
+import '../native/abi_generated.dart';
+
+const int _topologyFingerprintMask = 0xffffffffffffffff;
+const int _topologyFingerprintOffset = 0xcbf29ce484222325;
+const int _topologyFingerprintPrime = 0x100000001b3;
+
+int _mixTopologyFingerprint(int hash, int value) =>
+    ((hash ^ (value & _topologyFingerprintMask)) * _topologyFingerprintPrime) &
+    _topologyFingerprintMask;
+
+/// The first stable-field difference that prevented prepared-graph reuse.
+enum PreparedGraphTopologyMismatchReason {
+  nonReusable,
+  commandCount,
+  commandStride,
+  commandBytes,
+  shader,
+  drawMode,
+  flags,
+  layer,
+  subLayer,
+  stencil,
+  admission,
+  unknown,
+}
+
+/// Carries the active graph's mismatch through template-cache probing.
+///
+/// Template candidates also call [PreparedGraphKey.matches]. Their mismatches
+/// are deliberately hidden by [PreparedGraphTemplateCache.takeMatching], so a
+/// later full rebuild reports the active graph difference rather than the last
+/// rejected template candidate.
+final class PreparedGraphTopologyDiagnostics {
+  PreparedGraphTopologyDiagnostics._();
+
+  static PreparedGraphTopologyMismatchReason? _pendingMismatch;
+
+  static PreparedGraphTopologyMismatchReason? consumePendingMismatch() {
+    final mismatch = _pendingMismatch;
+    _pendingMismatch = null;
+    return mismatch;
+  }
+
+  static void clearPendingMismatch() {
+    _pendingMismatch = null;
+  }
+}
+
+/// Structural state of one native command in a persistent preparation graph.
+///
+/// Per-frame uniforms, geometry sizes, resource identities, stencil references,
+/// and native addresses are refreshed without rebuilding this value.
+final class PreparedCommandTopology {
+  const PreparedCommandTopology._({
+    required this.admission,
+    required this.active,
+    required this.shader,
+    required this.drawMode,
+    required this.flags,
+    required this.layer,
+    required this.subLayerIndex,
+    required this.stencilMode,
+  });
+
+  factory PreparedCommandTopology.capture(
+    ByteData data,
+    int offset, {
+    required bool active,
+  }) {
+    final shader = data.getUint32(
+      offset + DrawCommandAbi.shaderType,
+      Endian.little,
+    );
+    final stencilMode = data.getUint32(
+      offset + DrawCommandAbi.stencilMode,
+      Endian.little,
+    );
+
+    return PreparedCommandTopology._(
+      admission: _commandAdmission(data, offset, shader, stencilMode),
+      active: active,
+      shader: shader,
+      drawMode: data.getUint32(offset + DrawCommandAbi.drawMode, Endian.little),
+      flags: data.getUint32(offset + DrawCommandAbi.flags, Endian.little),
+      layer: data.getUint32(offset + DrawCommandAbi.layerIndex, Endian.little),
+      subLayerIndex: data.getInt32(
+        offset + DrawCommandAbi.subLayerIndex,
+        Endian.little,
+      ),
+      stencilMode: stencilMode,
+    );
+  }
+
+  final DrawCommandAdmission admission;
+
+  /// Whether the renderer admitted this command when the graph was built.
+  final bool active;
+  final int shader;
+  final int drawMode;
+  final int flags;
+  final int layer;
+  final int subLayerIndex;
+  final int stencilMode;
+
+  int appendFamilyFingerprint(int hash) {
+    hash = _mixTopologyFingerprint(hash, shader);
+    hash = _mixTopologyFingerprint(hash, drawMode);
+    hash = _mixTopologyFingerprint(hash, flags);
+    hash = _mixTopologyFingerprint(hash, layer);
+    hash = _mixTopologyFingerprint(hash, subLayerIndex);
+    return _mixTopologyFingerprint(hash, stencilMode);
+  }
+
+  bool sameTopologyAs(PreparedCommandTopology other) =>
+      admission == other.admission &&
+      active == other.active &&
+      shader == other.shader &&
+      drawMode == other.drawMode &&
+      flags == other.flags &&
+      layer == other.layer &&
+      subLayerIndex == other.subLayerIndex &&
+      stencilMode == other.stencilMode;
+
+  /// Returns the first field at [offset] that prevents graph-node reuse.
+  PreparedGraphTopologyMismatchReason? firstMismatch(
+    ByteData data,
+    int offset,
+  ) {
+    final nextShader = data.getUint32(
+      offset + DrawCommandAbi.shaderType,
+      Endian.little,
+    );
+    if (shader != nextShader) {
+      return PreparedGraphTopologyMismatchReason.shader;
+    }
+    final nextDrawMode = data.getUint32(
+      offset + DrawCommandAbi.drawMode,
+      Endian.little,
+    );
+    if (drawMode != nextDrawMode) {
+      return PreparedGraphTopologyMismatchReason.drawMode;
+    }
+    final nextFlags = data.getUint32(
+      offset + DrawCommandAbi.flags,
+      Endian.little,
+    );
+    if (flags != nextFlags) {
+      return PreparedGraphTopologyMismatchReason.flags;
+    }
+    final nextLayer = data.getUint32(
+      offset + DrawCommandAbi.layerIndex,
+      Endian.little,
+    );
+    if (layer != nextLayer) {
+      return PreparedGraphTopologyMismatchReason.layer;
+    }
+    final nextSubLayer = data.getInt32(
+      offset + DrawCommandAbi.subLayerIndex,
+      Endian.little,
+    );
+    if (subLayerIndex != nextSubLayer) {
+      return PreparedGraphTopologyMismatchReason.subLayer;
+    }
+    final nextStencilMode = data.getUint32(
+      offset + DrawCommandAbi.stencilMode,
+      Endian.little,
+    );
+    if (stencilMode != nextStencilMode) {
+      return PreparedGraphTopologyMismatchReason.stencil;
+    }
+    if (admission !=
+        _commandAdmission(data, offset, nextShader, nextStencilMode)) {
+      return PreparedGraphTopologyMismatchReason.admission;
+    }
+
+    return null;
+  }
+
+  /// Whether the command at [offset] can reuse this graph node.
+  bool matches(ByteData data, int offset) =>
+      firstMismatch(data, offset) == null;
+}
+
+DrawCommandAdmission _commandAdmission(
+  ByteData data,
+  int offset,
+  int shader,
+  int stencilMode,
+) => admitDrawCommand(
+  shader: shader,
+  stencilMode: stencilMode,
+  vertexCount: data.getUint32(
+    offset + DrawCommandAbi.vertexCount,
+    Endian.little,
+  ),
+  indexCount: data.getUint32(offset + DrawCommandAbi.indexCount, Endian.little),
+  vertexDataAddress: data.getUint64(
+    offset + DrawCommandAbi.vertexData,
+    Endian.little,
+  ),
+  indexDataAddress: data.getUint64(
+    offset + DrawCommandAbi.indexData,
+    Endian.little,
+  ),
+  drawableMatrixM00: data.getFloat32(
+    offset + DrawCommandAbi.drawableUBO,
+    Endian.little,
+  ),
+  drawableMatrixM11: data.getFloat32(
+    offset +
+        DrawCommandAbi.drawableUBO +
+        RendererUboAbi.drawableMatrixM11Offset,
+    Endian.little,
+  ),
+);
+
+int _topologyFamilyFingerprintFromCommands(
+  List<PreparedCommandTopology> commands,
+) {
+  var hash = _topologyFingerprintOffset;
+  for (final command in commands) {
+    hash = command.appendFamilyFingerprint(hash);
+  }
+  return hash;
+}
+
+int _topologyFamilyFingerprintFromBytes(
+  ByteData data,
+  int commandCount,
+  int commandStride,
+) {
+  var hash = _topologyFingerprintOffset;
+  for (var index = 0; index < commandCount; index += 1) {
+    final offset = index * commandStride;
+    hash = _mixTopologyFingerprint(
+      hash,
+      data.getUint32(offset + DrawCommandAbi.shaderType, Endian.little),
+    );
+    hash = _mixTopologyFingerprint(
+      hash,
+      data.getUint32(offset + DrawCommandAbi.drawMode, Endian.little),
+    );
+    hash = _mixTopologyFingerprint(
+      hash,
+      data.getUint32(offset + DrawCommandAbi.flags, Endian.little),
+    );
+    hash = _mixTopologyFingerprint(
+      hash,
+      data.getUint32(offset + DrawCommandAbi.layerIndex, Endian.little),
+    );
+    hash = _mixTopologyFingerprint(
+      hash,
+      data.getInt32(offset + DrawCommandAbi.subLayerIndex, Endian.little),
+    );
+    hash = _mixTopologyFingerprint(
+      hash,
+      data.getUint32(offset + DrawCommandAbi.stencilMode, Endian.little),
+    );
+  }
+  return hash;
+}
+
+/// Exact structural identity of a decoded native command stream.
+final class PreparedGraphKey {
+  PreparedGraphKey._({
+    required this.commandCount,
+    required this.commandStride,
+    required this.commands,
+    required this.reusable,
+    required this.familyFingerprint,
+  });
+
+  /// Captures graph topology without retaining native memory.
+  factory PreparedGraphKey.capture({
+    required Uint8List commandBytes,
+    required int commandCount,
+    required int commandStride,
+    required Iterable<int> activeCommandOffsets,
+  }) {
+    if (commandCount < 0 ||
+        commandStride != DrawCommandAbi.size ||
+        commandBytes.lengthInBytes < commandCount * commandStride) {
+      throw ArgumentError('Invalid DrawCommand block');
+    }
+    final activeOffsets = Set<int>.of(activeCommandOffsets);
+    final data = ByteData.sublistView(commandBytes);
+    final commands = List<PreparedCommandTopology>.generate(commandCount, (
+      index,
+    ) {
+      final offset = index * commandStride;
+
+      return PreparedCommandTopology.capture(
+        data,
+        offset,
+        active: activeOffsets.contains(offset),
+      );
+    }, growable: false);
+    final reusable = commands.every(
+      (command) =>
+          command.admission == DrawCommandAdmission.drop || command.active,
+    );
+
+    return PreparedGraphKey._(
+      commandCount: commandCount,
+      commandStride: commandStride,
+      commands: List<PreparedCommandTopology>.unmodifiable(commands),
+      reusable: reusable,
+      familyFingerprint: _topologyFamilyFingerprintFromCommands(commands),
+    );
+  }
+
+  /// Creates a key that always requires a graph rebuild.
+  factory PreparedGraphKey.nonReusable({
+    required int commandCount,
+    required int commandStride,
+  }) => PreparedGraphKey._(
+    commandCount: commandCount,
+    commandStride: commandStride,
+    commands: const <PreparedCommandTopology>[],
+    reusable: false,
+    familyFingerprint: 0,
+  );
+
+  final int commandCount;
+  final int commandStride;
+  final List<PreparedCommandTopology> commands;
+
+  /// Fingerprint of command structure excluding admission/active state.
+  final int familyFingerprint;
+
+  /// Whether every otherwise-renderable command became a graph node.
+  final bool reusable;
+
+  bool sameTopologyAs(PreparedGraphKey other) {
+    if (commandCount != other.commandCount ||
+        commandStride != other.commandStride ||
+        familyFingerprint != other.familyFingerprint ||
+        reusable != other.reusable ||
+        commands.length != other.commands.length) {
+      return false;
+    }
+    for (var index = 0; index < commands.length; index += 1) {
+      if (!commands[index].sameTopologyAs(other.commands[index])) return false;
+    }
+    return true;
+  }
+
+  /// Returns the first stable-field difference from this retained graph.
+  PreparedGraphTopologyMismatchReason? firstMismatch({
+    required Uint8List commandBytes,
+    required int commandCount,
+    required int commandStride,
+  }) {
+    if (!reusable) {
+      return PreparedGraphTopologyMismatchReason.nonReusable;
+    }
+    if (commandCount != this.commandCount) {
+      return PreparedGraphTopologyMismatchReason.commandCount;
+    }
+    if (commandStride != this.commandStride) {
+      return PreparedGraphTopologyMismatchReason.commandStride;
+    }
+    if (commandBytes.lengthInBytes < commandCount * commandStride) {
+      return PreparedGraphTopologyMismatchReason.commandBytes;
+    }
+    final data = ByteData.sublistView(commandBytes);
+    for (var index = 0; index < commands.length; index += 1) {
+      final mismatch = commands[index].firstMismatch(
+        data,
+        index * commandStride,
+      );
+      if (mismatch != null) return mismatch;
+    }
+
+    return null;
+  }
+
+  /// Whether [commandBytes] has exactly the same stable work description.
+  bool matches({
+    required Uint8List commandBytes,
+    required int commandCount,
+    required int commandStride,
+  }) {
+    final mismatch = firstMismatch(
+      commandBytes: commandBytes,
+      commandCount: commandCount,
+      commandStride: commandStride,
+    );
+    PreparedGraphTopologyDiagnostics._pendingMismatch = mismatch;
+    return mismatch == null;
+  }
+}
+
+/// One cached graph topology and its renderer-owned structural payload.
+typedef PreparedGraphTemplateCacheEntry<T> = ({PreparedGraphKey key, T value});
+
+typedef _PreparedGraphTemplateBucketKey = ({
+  int commandCount,
+  int commandStride,
+  int familyFingerprint,
+});
+
+final class _PreparedGraphTemplateCacheValue<T> {
+  const _PreparedGraphTemplateCacheValue({
+    required this.bucketKey,
+    required this.key,
+    required this.value,
+  });
+
+  final _PreparedGraphTemplateBucketKey bucketKey;
+  final PreparedGraphKey key;
+  final T value;
+}
+
+/// Small LRU of previously decoded graph topologies.
+final class PreparedGraphTemplateCache<T> {
+  PreparedGraphTemplateCache({this.capacity = 4}) {
+    if (capacity <= 0) {
+      throw RangeError.value(capacity, 'capacity', 'must be positive');
+    }
+  }
+
+  final int capacity;
+  final Map<
+    _PreparedGraphTemplateBucketKey,
+    List<_PreparedGraphTemplateCacheValue<T>>
+  >
+  _buckets = {};
+  final List<_PreparedGraphTemplateCacheValue<T>> _recency = [];
+
+  int get length => _recency.length;
+
+  /// Remembers one reusable graph as the most recently displaced topology.
+  void remember({required PreparedGraphKey key, required T value}) {
+    if (!key.reusable) return;
+    final bucketKey = (
+      commandCount: key.commandCount,
+      commandStride: key.commandStride,
+      familyFingerprint: key.familyFingerprint,
+    );
+    final entries = _buckets.putIfAbsent(
+      bucketKey,
+      () => <_PreparedGraphTemplateCacheValue<T>>[],
+    );
+    for (var index = entries.length - 1; index >= 0; index -= 1) {
+      final entry = entries[index];
+      if (!entry.key.sameTopologyAs(key)) continue;
+      entries.removeAt(index);
+      _recency.remove(entry);
+    }
+    final entry = _PreparedGraphTemplateCacheValue(
+      bucketKey: bucketKey,
+      key: key,
+      value: value,
+    );
+    entries.insert(0, entry);
+    _recency.insert(0, entry);
+    if (_recency.length > capacity) {
+      final oldest = _recency.removeLast();
+      final oldestBucket = _buckets[oldest.bucketKey]!;
+      oldestBucket.remove(oldest);
+      if (oldestBucket.isEmpty) _buckets.remove(oldest.bucketKey);
+    }
+  }
+
+  /// Removes and returns the first cached topology matching this command block.
+  PreparedGraphTemplateCacheEntry<T>? takeMatching({
+    required Uint8List commandBytes,
+    required int commandCount,
+    required int commandStride,
+  }) {
+    final preservedMismatch = PreparedGraphTopologyDiagnostics._pendingMismatch;
+    try {
+      if (commandCount < 0 ||
+          commandStride != DrawCommandAbi.size ||
+          commandBytes.lengthInBytes < commandCount * commandStride) {
+        return null;
+      }
+      final data = ByteData.sublistView(commandBytes);
+      final bucketKey = (
+        commandCount: commandCount,
+        commandStride: commandStride,
+        familyFingerprint: _topologyFamilyFingerprintFromBytes(
+          data,
+          commandCount,
+          commandStride,
+        ),
+      );
+      final entries = _buckets[bucketKey];
+      if (entries == null) return null;
+      for (var index = 0; index < entries.length; index += 1) {
+        final entry = entries[index];
+        if (entry.key.matches(
+          commandBytes: commandBytes,
+          commandCount: commandCount,
+          commandStride: commandStride,
+        )) {
+          entries.removeAt(index);
+          _recency.remove(entry);
+          if (entries.isEmpty) _buckets.remove(bucketKey);
+          return (key: entry.key, value: entry.value);
+        }
+      }
+      return null;
+    } finally {
+      PreparedGraphTopologyDiagnostics._pendingMismatch = preservedMismatch;
+    }
+  }
+
+  void clear() {
+    _buckets.clear();
+    _recency.clear();
+  }
+}
+
+/// Timing totals for persistent graph reuse over one logging interval.
+final class PreparedGraphTimingSnapshot {
+  const PreparedGraphTimingSnapshot({
+    required this.hitCount,
+    required this.rebuildCount,
+    required this.hitMicros,
+    required this.rebuildMicros,
+  });
+
+  final int hitCount;
+  final int rebuildCount;
+  final int hitMicros;
+  final int rebuildMicros;
+
+  int get sampleCount => hitCount + rebuildCount;
+
+  double get hitRate => sampleCount == 0 ? 0 : hitCount / sampleCount;
+
+  double? get averageHitMicros => hitCount == 0 ? null : hitMicros / hitCount;
+
+  double? get averageRebuildMicros =>
+      rebuildCount == 0 ? null : rebuildMicros / rebuildCount;
+}
+
+/// Accumulates graph reuse and rebuild timing until the next renderer log.
+final class PreparedGraphTimingMetrics {
+  int _hitCount = 0;
+  int _rebuildCount = 0;
+  int _hitMicros = 0;
+  int _rebuildMicros = 0;
+
+  void record({required bool reused, required int micros}) {
+    if (micros < 0) {
+      throw RangeError.value(micros, 'micros', 'must not be negative');
+    }
+    if (reused) {
+      _hitCount += 1;
+      _hitMicros += micros;
+    } else {
+      _rebuildCount += 1;
+      _rebuildMicros += micros;
+    }
+  }
+
+  PreparedGraphTimingSnapshot takeSnapshotAndReset() {
+    final snapshot = PreparedGraphTimingSnapshot(
+      hitCount: _hitCount,
+      rebuildCount: _rebuildCount,
+      hitMicros: _hitMicros,
+      rebuildMicros: _rebuildMicros,
+    );
+    _hitCount = 0;
+    _rebuildCount = 0;
+    _hitMicros = 0;
+    _rebuildMicros = 0;
+
+    return snapshot;
+  }
+}
+
+/// Stable decoded GPU work retained across native frame generations.
+final class PreparedGraph<TEntry, TPartition> {
+  PreparedGraph({
+    required this.key,
+    required this.entries,
+    required this.partitions,
+    required this.uniformAlignment,
+    required this.uniformCursor,
+    required this.hasMapGlobalUniform,
+    required this.commandCount,
+    required this.lastFillExtrusionLayerIndex,
+  });
+
+  final PreparedGraphKey key;
+  final List<TEntry> entries;
+  final List<TPartition> partitions;
+  final int uniformAlignment;
+  final int uniformCursor;
+  final bool hasMapGlobalUniform;
+  final int commandCount;
+  final int? lastFillExtrusionLayerIndex;
+}

--- a/lib/src/gpu/prepared_graph_metrics.dart
+++ b/lib/src/gpu/prepared_graph_metrics.dart
@@ -1,0 +1,239 @@
+import 'package:flutter/foundation.dart';
+
+import 'prepared_graph.dart';
+
+/// Why a persistent prepared graph could not be reused for one native frame.
+enum PreparedGraphRebuildReason {
+  /// No previous graph existed yet.
+  noGraph,
+
+  /// The stable command topology no longer matched the retained graph.
+  topologyMismatch,
+
+  /// Topology matched, but refreshing dynamic resources failed.
+  refreshFailed,
+}
+
+String _topologyMismatchLabel(PreparedGraphTopologyMismatchReason reason) =>
+    switch (reason) {
+      PreparedGraphTopologyMismatchReason.nonReusable => 'nonReusable',
+      PreparedGraphTopologyMismatchReason.commandCount => 'commandCount',
+      PreparedGraphTopologyMismatchReason.commandStride => 'commandStride',
+      PreparedGraphTopologyMismatchReason.commandBytes => 'commandBytes',
+      PreparedGraphTopologyMismatchReason.shader => 'shader',
+      PreparedGraphTopologyMismatchReason.drawMode => 'drawMode',
+      PreparedGraphTopologyMismatchReason.flags => 'flags',
+      PreparedGraphTopologyMismatchReason.layer => 'layer',
+      PreparedGraphTopologyMismatchReason.subLayer => 'subLayer',
+      PreparedGraphTopologyMismatchReason.stencil => 'stencil',
+      PreparedGraphTopologyMismatchReason.admission => 'admission',
+      PreparedGraphTopologyMismatchReason.unknown => 'unknown',
+    };
+
+/// Detailed persistent-graph timing totals over one renderer logging interval.
+final class PreparedGraphDetailedTimingSnapshot {
+  const PreparedGraphDetailedTimingSnapshot({
+    required this.totals,
+    required this.hitMaxMicros,
+    required this.rebuildMaxMicros,
+    required this.validationCount,
+    required this.validationMicros,
+    required this.refreshCount,
+    required this.refreshMicros,
+    required this.decodeCount,
+    required this.decodeMicros,
+    required this.captureCount,
+    required this.captureMicros,
+    required this.noGraphRebuildCount,
+    required this.topologyMismatchRebuildCount,
+    required this.refreshFailedRebuildCount,
+    required this.topologyMismatchReasonCounts,
+  });
+
+  final PreparedGraphTimingSnapshot totals;
+  final int hitMaxMicros;
+  final int rebuildMaxMicros;
+  final int validationCount;
+  final int validationMicros;
+  final int refreshCount;
+  final int refreshMicros;
+  final int decodeCount;
+  final int decodeMicros;
+  final int captureCount;
+  final int captureMicros;
+  final int noGraphRebuildCount;
+  final int topologyMismatchRebuildCount;
+  final int refreshFailedRebuildCount;
+  final List<int> topologyMismatchReasonCounts;
+
+  int topologyMismatchCount(PreparedGraphTopologyMismatchReason reason) =>
+      topologyMismatchReasonCounts[reason.index];
+
+  double? get averageValidationMicros =>
+      validationCount == 0 ? null : validationMicros / validationCount;
+
+  double? get averageRefreshMicros =>
+      refreshCount == 0 ? null : refreshMicros / refreshCount;
+
+  double? get averageDecodeMicros =>
+      decodeCount == 0 ? null : decodeMicros / decodeCount;
+
+  double? get averageCaptureMicros =>
+      captureCount == 0 ? null : captureMicros / captureCount;
+}
+
+/// Accumulates total and per-phase timing for persistent graph preparation.
+final class PreparedGraphDetailedTimingMetrics {
+  final PreparedGraphTimingMetrics _totals = PreparedGraphTimingMetrics();
+  final List<int> _topologyMismatchReasonCounts = List<int>.filled(
+    PreparedGraphTopologyMismatchReason.values.length,
+    0,
+  );
+  int _hitMaxMicros = 0;
+  int _rebuildMaxMicros = 0;
+  int _validationCount = 0;
+  int _validationMicros = 0;
+  int _refreshCount = 0;
+  int _refreshMicros = 0;
+  int _decodeCount = 0;
+  int _decodeMicros = 0;
+  int _captureCount = 0;
+  int _captureMicros = 0;
+  int _noGraphRebuildCount = 0;
+  int _topologyMismatchRebuildCount = 0;
+  int _refreshFailedRebuildCount = 0;
+
+  void recordHit({
+    required int totalMicros,
+    required int validationMicros,
+    required int refreshMicros,
+  }) {
+    _checkMicros('totalMicros', totalMicros);
+    _checkMicros('validationMicros', validationMicros);
+    _checkMicros('refreshMicros', refreshMicros);
+    PreparedGraphTopologyDiagnostics.clearPendingMismatch();
+    _totals.record(reused: true, micros: totalMicros);
+    if (totalMicros > _hitMaxMicros) _hitMaxMicros = totalMicros;
+    _recordValidation(validationMicros);
+    _recordRefresh(refreshMicros);
+  }
+
+  void recordRebuild({
+    required int totalMicros,
+    required PreparedGraphRebuildReason reason,
+    int? validationMicros,
+    int? refreshMicros,
+    required int decodeMicros,
+    required int captureMicros,
+  }) {
+    _checkMicros('totalMicros', totalMicros);
+    if (validationMicros != null) {
+      _checkMicros('validationMicros', validationMicros);
+    }
+    if (refreshMicros != null) {
+      _checkMicros('refreshMicros', refreshMicros);
+    }
+    _checkMicros('decodeMicros', decodeMicros);
+    _checkMicros('captureMicros', captureMicros);
+    _totals.record(reused: false, micros: totalMicros);
+    if (totalMicros > _rebuildMaxMicros) _rebuildMaxMicros = totalMicros;
+    if (validationMicros != null) _recordValidation(validationMicros);
+    if (refreshMicros != null) _recordRefresh(refreshMicros);
+    _decodeCount += 1;
+    _decodeMicros += decodeMicros;
+    _captureCount += 1;
+    _captureMicros += captureMicros;
+    switch (reason) {
+      case PreparedGraphRebuildReason.noGraph:
+        PreparedGraphTopologyDiagnostics.clearPendingMismatch();
+        _noGraphRebuildCount += 1;
+        break;
+      case PreparedGraphRebuildReason.topologyMismatch:
+        _topologyMismatchRebuildCount += 1;
+        final mismatch =
+            PreparedGraphTopologyDiagnostics.consumePendingMismatch() ??
+            PreparedGraphTopologyMismatchReason.unknown;
+        _topologyMismatchReasonCounts[mismatch.index] += 1;
+        break;
+      case PreparedGraphRebuildReason.refreshFailed:
+        PreparedGraphTopologyDiagnostics.clearPendingMismatch();
+        _refreshFailedRebuildCount += 1;
+        break;
+    }
+  }
+
+  PreparedGraphDetailedTimingSnapshot takeSnapshotAndReset() {
+    final mismatchCounts = List<int>.unmodifiable(
+      _topologyMismatchReasonCounts,
+    );
+    final snapshot = PreparedGraphDetailedTimingSnapshot(
+      totals: _totals.takeSnapshotAndReset(),
+      hitMaxMicros: _hitMaxMicros,
+      rebuildMaxMicros: _rebuildMaxMicros,
+      validationCount: _validationCount,
+      validationMicros: _validationMicros,
+      refreshCount: _refreshCount,
+      refreshMicros: _refreshMicros,
+      decodeCount: _decodeCount,
+      decodeMicros: _decodeMicros,
+      captureCount: _captureCount,
+      captureMicros: _captureMicros,
+      noGraphRebuildCount: _noGraphRebuildCount,
+      topologyMismatchRebuildCount: _topologyMismatchRebuildCount,
+      refreshFailedRebuildCount: _refreshFailedRebuildCount,
+      topologyMismatchReasonCounts: mismatchCounts,
+    );
+    _logTopologyMismatchCounts(mismatchCounts);
+    _hitMaxMicros = 0;
+    _rebuildMaxMicros = 0;
+    _validationCount = 0;
+    _validationMicros = 0;
+    _refreshCount = 0;
+    _refreshMicros = 0;
+    _decodeCount = 0;
+    _decodeMicros = 0;
+    _captureCount = 0;
+    _captureMicros = 0;
+    _noGraphRebuildCount = 0;
+    _topologyMismatchRebuildCount = 0;
+    _refreshFailedRebuildCount = 0;
+    for (
+      var index = 0;
+      index < _topologyMismatchReasonCounts.length;
+      index += 1
+    ) {
+      _topologyMismatchReasonCounts[index] = 0;
+    }
+
+    return snapshot;
+  }
+
+  void _logTopologyMismatchCounts(List<int> counts) {
+    var total = 0;
+    final parts = <String>[];
+    for (final reason in PreparedGraphTopologyMismatchReason.values) {
+      final count = counts[reason.index];
+      if (count == 0) continue;
+      total += count;
+      parts.add('${_topologyMismatchLabel(reason)}:$count');
+    }
+    if (total == 0) return;
+    debugPrint('[GpuGraphMismatch] total=$total ${parts.join(' ')}');
+  }
+
+  void _recordValidation(int micros) {
+    _validationCount += 1;
+    _validationMicros += micros;
+  }
+
+  void _recordRefresh(int micros) {
+    _refreshCount += 1;
+    _refreshMicros += micros;
+  }
+
+  static void _checkMicros(String name, int micros) {
+    if (micros < 0) {
+      throw RangeError.value(micros, name, 'must not be negative');
+    }
+  }
+}

--- a/lib/src/gpu/renderer.dart
+++ b/lib/src/gpu/renderer.dart
@@ -9,6 +9,8 @@ import 'draw_entry.dart';
 import 'frame_binder.dart';
 import 'pass_executor.dart';
 import 'pipeline_registry.dart';
+import 'prepared_graph.dart';
+import 'prepared_graph_metrics.dart';
 import 'render_context.dart';
 import 'resource_cache.dart';
 import '../native/abi_generated.dart';
@@ -144,6 +146,13 @@ typedef _FrameDecode = ({
   int? lastFillExtrusionLayerIndex,
 });
 
+typedef _CommandView = ({
+  Uint8List commandBytes,
+  ByteData commandData,
+  int commandCount,
+  int commandStride,
+});
+
 typedef _FrameDrawResult = ({int drawCount, int renderPassCount});
 
 /// One native style layer interval assigned to a compositing stratum.
@@ -167,29 +176,36 @@ final class _PreparedDrawPartition {
   bool needsMainDepthStencil = false;
 }
 
-/// Decoded and uploaded GPU work shared by every stratum of one native frame.
+final class _PreparedGraphState {
+  _PreparedGraphState(this.graph);
+
+  final PreparedGraph<DrawEntry, _PreparedDrawPartition> graph;
+  List<GpuStyleLayerRange> layerRanges = const <GpuStyleLayerRange>[];
+}
+
+/// Per-frame bindings that replay one persistent decoded GPU graph.
 ///
-/// The value remains valid until its renderer prepares a different frame.
+/// The graph survives native frame generations while its structural command
+/// topology remains unchanged. Uniforms and frame-owned resources are refreshed
+/// before this value is created.
 final class GpuPreparedFrame {
   GpuPreparedFrame._({
     required this._key,
-    required this._partitions,
-    required this.layerRanges,
+    required this._graphState,
     required this.binder,
     required this.uniformData,
-    required this.commandCount,
-    required this.lastFillExtrusionLayerIndex,
     required this.shouldLog,
     required this.uboMicros,
   });
 
   final _PreparedFrameKey _key;
-  final List<_PreparedDrawPartition> _partitions;
-  List<GpuStyleLayerRange> layerRanges;
+  final _PreparedGraphState _graphState;
+  List<GpuStyleLayerRange> get layerRanges => _graphState.layerRanges;
   final FrameBinder? binder;
   final ByteData uniformData;
-  final int commandCount;
-  final int? lastFillExtrusionLayerIndex;
+  int get commandCount => _graphState.graph.commandCount;
+  int? get lastFillExtrusionLayerIndex =>
+      _graphState.graph.lastFillExtrusionLayerIndex;
   bool shouldLog;
   final int uboMicros;
   int drawCount = 0;
@@ -199,7 +215,7 @@ final class GpuPreparedFrame {
   bool hasCommandsInStratum(int stratumIndex) =>
       stratumIndex >= 0 &&
       stratumIndex < layerRanges.length &&
-      _partitions[stratumIndex].entries.isNotEmpty;
+      _graphState.graph.partitions[stratumIndex].entries.isNotEmpty;
 }
 
 /// Whether a native style layer belongs to one compositing stratum.
@@ -419,6 +435,11 @@ class GpuFrameRenderer {
   final List<List<DrawEntry>> _preparedPartitionEntries = [];
   final List<bool> _preparedPartitionNeedsClippingMasks = [];
   final List<bool> _preparedPartitionNeedsStencilClear = [];
+  final PreparedGraphDetailedTimingMetrics _preparedGraphTiming =
+      PreparedGraphDetailedTimingMetrics();
+  final PreparedGraphTemplateCache<Object?> _preparedGraphTemplates =
+      PreparedGraphTemplateCache<Object?>(capacity: 4);
+  _PreparedGraphState? _preparedGraph;
   GpuPreparedFrame? _preparedFrame;
   bool _resourceFrameNeedsFinalization = false;
   bool _resourceCacheNeedsEviction = false;
@@ -567,16 +588,26 @@ class GpuFrameRenderer {
     );
     var cached = _resourceCache.vertexBuffer(cacheKey);
     if (cached != null) return cached;
+    final source = _nativeBytes(dataAddress, vertexCount * sourceStride);
+    final repackStopwatch = Stopwatch()..start();
     final vertices = repackVertexDataForGpu(
-      _nativeBytes(dataAddress, vertexCount * sourceStride),
+      source,
       vertexCount: vertexCount,
       sourceStride: sourceStride,
       shader: shader,
       flags: flags,
     );
-    cached = _uploadBuffer(
+    _resourceCache.timingMetrics.recordRepack(
+      micros: repackStopwatch.elapsedMicroseconds,
+    );
+    final uploadStopwatch = Stopwatch()..start();
+    cached = _resourceCache.uploadCachedBuffer(
       vertices,
       isFillExtrusion: shader == ShaderType.fillExtrusion,
+    );
+    _resourceCache.timingMetrics.recordVertexUpload(
+      micros: uploadStopwatch.elapsedMicroseconds,
+      bytes: vertices.lengthInBytes,
     );
     _resourceCache.storeVertexBuffer(cacheKey, cached);
 
@@ -597,17 +628,33 @@ class GpuFrameRenderer {
     );
     var cached = _resourceCache.indexBuffer(cacheKey);
     if (cached != null) return cached;
-    cached = _uploadBuffer(
-      _nativeBytes(dataAddress, vertexCount * 2),
+    final bytes = _nativeBytes(dataAddress, vertexCount * 2);
+    final uploadStopwatch = Stopwatch()..start();
+    cached = _resourceCache.uploadCachedBuffer(
+      bytes,
       isFillExtrusion: shader == ShaderType.fillExtrusion,
+    );
+    _resourceCache.timingMetrics.recordIndexUpload(
+      micros: uploadStopwatch.elapsedMicroseconds,
+      bytes: bytes.lengthInBytes,
     );
     _resourceCache.storeIndexBuffer(cacheKey, cached);
 
     return cached;
   }
 
-  GpuBufferEntry _frameIndexBuffer(int dataAddress, int byteLength) =>
-      _uploadBuffer(_nativeBytes(dataAddress, byteLength));
+  GpuBufferEntry _frameIndexBuffer(int dataAddress, int byteLength) {
+    final bytes = _nativeBytes(dataAddress, byteLength);
+    final uploadStopwatch = Stopwatch()..start();
+    final uploaded = _uploadBuffer(bytes);
+    _resourceCache.timingMetrics.recordIndexUpload(
+      micros: uploadStopwatch.elapsedMicroseconds,
+      bytes: bytes.lengthInBytes,
+      frameOwned: true,
+    );
+
+    return uploaded;
+  }
 
   GpuBufferEntry _frameVertexBuffer(
     int dataAddress,
@@ -617,19 +664,31 @@ class GpuFrameRenderer {
     int flags,
   ) {
     final source = _nativeBytes(dataAddress, vertexCount * sourceStride);
-
-    // Skip repacking when the exported and GPU vertex layouts already match.
-    return _uploadBuffer(
-      sourceStride == gpuVertexStride(shader, flags)
-          ? source
-          : repackVertexDataForGpu(
-              source,
-              vertexCount: vertexCount,
-              sourceStride: sourceStride,
-              shader: shader,
-              flags: flags,
-            ),
+    Uint8List vertices;
+    if (sourceStride == gpuVertexStride(shader, flags)) {
+      vertices = source;
+    } else {
+      final repackStopwatch = Stopwatch()..start();
+      vertices = repackVertexDataForGpu(
+        source,
+        vertexCount: vertexCount,
+        sourceStride: sourceStride,
+        shader: shader,
+        flags: flags,
+      );
+      _resourceCache.timingMetrics.recordRepack(
+        micros: repackStopwatch.elapsedMicroseconds,
+      );
+    }
+    final uploadStopwatch = Stopwatch()..start();
+    final uploaded = _uploadBuffer(vertices);
+    _resourceCache.timingMetrics.recordVertexUpload(
+      micros: uploadStopwatch.elapsedMicroseconds,
+      bytes: vertices.lengthInBytes,
+      frameOwned: true,
     );
+
+    return uploaded;
   }
 
   /// Gets or creates a GPU texture for exported native pixel data.
@@ -653,6 +712,7 @@ class GpuFrameRenderer {
     final cached = _resourceCache.texture(cacheKey);
     if (cached != null) return cached.texture;
     try {
+      final uploadStopwatch = Stopwatch()..start();
       final texture = gpu.gpuContext.createTexture(
         gpu.StorageMode.hostVisible,
         width,
@@ -663,12 +723,17 @@ class GpuFrameRenderer {
         enableRenderTargetUsage: false,
         enableShaderReadUsage: true,
       );
+      final byteLength = width * height * channels;
       final bytes = Pointer<Uint8>.fromAddress(dataAddress)
-          .asTypedList(width * height * channels);
+          .asTypedList(byteLength);
       texture.overwrite(ByteData.sublistView(bytes));
+      _resourceCache.timingMetrics.recordTextureUpload(
+        micros: uploadStopwatch.elapsedMicroseconds,
+        bytes: byteLength,
+      );
       _resourceCache.storeTexture(
         cacheKey,
-        GpuTextureEntry(texture, width * height * channels),
+        GpuTextureEntry(texture, byteLength),
       );
 
       return texture;
@@ -736,7 +801,7 @@ class GpuFrameRenderer {
     }
   }
 
-  /// Decodes, resolves, packs, and uploads one native frame for all strata.
+  /// Refreshes one native frame and reuses its persistent graph when safe.
   GpuPreparedFrame prepareFrame({
     required FrameCommandMetadata frameMetadata,
     required int physicalWidth,
@@ -772,7 +837,7 @@ class GpuFrameRenderer {
     if (current != null && current._key == key) {
       if (advanceResourceFrame) beginFrameReplay();
       if (!_sameLayerRanges(current.layerRanges, layerRanges)) {
-        _partitionPreparedEntries(current, layerRanges);
+        _partitionPreparedEntries(current._graphState, layerRanges);
       }
 
       return current;
@@ -783,12 +848,146 @@ class GpuFrameRenderer {
     final shouldLog = _logSw.elapsedMilliseconds >= 1000;
     if (shouldLog) _logSw.reset();
     final stopwatch = Stopwatch()..start();
-    final decoded = _decodeCommands(frameMetadata, shouldLog: shouldLog);
-    final decodeMicros = stopwatch.elapsedMicroseconds;
+    var graphState = _preparedGraph;
+    var reusedGraph = false;
+    var rebuildReason = PreparedGraphRebuildReason.noGraph;
+    int? validationMicros;
+    int? refreshMicros;
+    var decodeMicros = 0;
+    var captureMicros = 0;
+    _FrameDecode? decoded;
+    if (graphState != null) {
+      final validationStart = stopwatch.elapsedMicroseconds;
+      final view = _commandView(frameMetadata, shouldLog: shouldLog);
+      final graph = graphState.graph;
+      final topologyMatches =
+          view != null &&
+          graph.key.matches(
+            commandBytes: view.commandBytes,
+            commandCount: view.commandCount,
+            commandStride: view.commandStride,
+          );
+      PreparedGraphKey? cachedTopology;
+      if (!topologyMatches && view != null) {
+        _preparedGraphTemplates.remember(key: graph.key, value: null);
+        cachedTopology = _preparedGraphTemplates
+            .takeMatching(
+              commandBytes: view.commandBytes,
+              commandCount: view.commandCount,
+              commandStride: view.commandStride,
+            )
+            ?.key;
+      }
+      validationMicros = stopwatch.elapsedMicroseconds - validationStart;
+      if (topologyMatches) {
+        final activeView = view;
+        final refreshStart = stopwatch.elapsedMicroseconds;
+        final refreshed = _refreshPreparedEntries(
+          graph.entries,
+          activeView.commandData,
+          shouldLog: shouldLog,
+        );
+        refreshMicros = stopwatch.elapsedMicroseconds - refreshStart;
+        if (refreshed) {
+          reusedGraph = true;
+          decoded = (
+            commandBytes: activeView.commandBytes,
+            commandData: activeView.commandData,
+            commandCount: graph.commandCount,
+            uniformAlignment: graph.uniformAlignment,
+            uniformCursor: graph.uniformCursor,
+            hasMapGlobalUniform: graph.hasMapGlobalUniform,
+            lastFillExtrusionLayerIndex: graph.lastFillExtrusionLayerIndex,
+          );
+        } else {
+          rebuildReason = PreparedGraphRebuildReason.refreshFailed;
+        }
+      } else if (cachedTopology != null) {
+        final activeView = view!;
+        final refreshStart = stopwatch.elapsedMicroseconds;
+        final restored = _restorePreparedGraphTemplate(
+          cachedTopology,
+          activeView.commandData,
+          shouldLog: shouldLog,
+        );
+        refreshMicros = stopwatch.elapsedMicroseconds - refreshStart;
+        if (restored != null) {
+          graphState = restored;
+          reusedGraph = true;
+          final restoredGraph = restored.graph;
+          decoded = (
+            commandBytes: activeView.commandBytes,
+            commandData: activeView.commandData,
+            commandCount: restoredGraph.commandCount,
+            uniformAlignment: restoredGraph.uniformAlignment,
+            uniformCursor: restoredGraph.uniformCursor,
+            hasMapGlobalUniform: restoredGraph.hasMapGlobalUniform,
+            lastFillExtrusionLayerIndex:
+                restoredGraph.lastFillExtrusionLayerIndex,
+          );
+        } else {
+          rebuildReason = PreparedGraphRebuildReason.refreshFailed;
+        }
+      } else {
+        rebuildReason = PreparedGraphRebuildReason.topologyMismatch;
+      }
+    }
+    if (!reusedGraph) {
+      final decodeStart = stopwatch.elapsedMicroseconds;
+      _resetPreparedGraphStorage();
+      decoded = _decodeCommands(frameMetadata, shouldLog: shouldLog);
+      decodeMicros = stopwatch.elapsedMicroseconds - decodeStart;
+      final captureStart = stopwatch.elapsedMicroseconds;
+      final graphKey = decoded == null
+          ? PreparedGraphKey.nonReusable(
+              commandCount: frameMetadata.commandCount,
+              commandStride: frameMetadata.commandStride,
+            )
+          : PreparedGraphKey.capture(
+              commandBytes: decoded.commandBytes,
+              commandCount: decoded.commandCount,
+              commandStride: frameMetadata.commandStride,
+              activeCommandOffsets: _drawEntries.map(
+                (entry) => entry.commandOffset,
+              ),
+            );
+      final graph = PreparedGraph<DrawEntry, _PreparedDrawPartition>(
+        key: graphKey,
+        entries: _drawEntries,
+        partitions: _preparedPartitions,
+        uniformAlignment:
+            decoded?.uniformAlignment ??
+            RendererUboAbi.minimumUniformByteAlignment,
+        uniformCursor: decoded?.uniformCursor ?? 0,
+        hasMapGlobalUniform: decoded?.hasMapGlobalUniform ?? false,
+        commandCount: decoded?.commandCount ?? frameMetadata.commandCount,
+        lastFillExtrusionLayerIndex: decoded?.lastFillExtrusionLayerIndex,
+      );
+      graphState = _PreparedGraphState(graph);
+      _preparedGraph = graphState;
+      captureMicros = stopwatch.elapsedMicroseconds - captureStart;
+    }
+    final graphPrepareMicros = stopwatch.elapsedMicroseconds;
+    if (reusedGraph) {
+      _preparedGraphTiming.recordHit(
+        totalMicros: graphPrepareMicros,
+        validationMicros: validationMicros!,
+        refreshMicros: refreshMicros!,
+      );
+    } else {
+      _preparedGraphTiming.recordRebuild(
+        totalMicros: graphPrepareMicros,
+        reason: rebuildReason,
+        validationMicros: validationMicros,
+        refreshMicros: refreshMicros,
+        decodeMicros: decodeMicros,
+        captureMicros: captureMicros,
+      );
+    }
     FrameBinder? binder;
     var uniformData = ByteData(0);
     var uboMicros = 0;
-    if (decoded != null && _drawEntries.isNotEmpty) {
+    if (decoded != null && graphState!.graph.entries.isNotEmpty) {
       final layout = layoutFrameUniforms(
         drawableCursor: decoded.uniformCursor,
         alignment: decoded.uniformAlignment,
@@ -806,7 +1005,7 @@ class GpuFrameRenderer {
         logicalHeight: logicalHeight,
         hasMapGlobal: decoded.hasMapGlobalUniform,
       );
-      uboMicros = stopwatch.elapsedMicroseconds - decodeMicros;
+      uboMicros = stopwatch.elapsedMicroseconds - graphPrepareMicros;
       final uniformBuffer = _uploadUniforms(uniformLength);
       binder = FrameBinder(
         pipelines: _pipelines,
@@ -816,21 +1015,23 @@ class GpuFrameRenderer {
         // HostBuffer ring. Never retain those through pooled draw entries.
         cacheUniformViews: uniformLength <= _uniformHost!.blockLengthInBytes,
       );
-      _prepareEntryPipelineState(uniformData);
+      _prepareEntryPipelineState(
+        uniformData,
+        initializePipelines: !reusedGraph,
+      );
     }
     final prepared = GpuPreparedFrame._(
       key: key,
-      partitions: _preparedPartitions,
-      layerRanges: const <GpuStyleLayerRange>[],
+      graphState: graphState!,
       binder: binder,
       uniformData: uniformData,
-      commandCount: decoded?.commandCount ?? frameMetadata.commandCount,
-      lastFillExtrusionLayerIndex: decoded?.lastFillExtrusionLayerIndex,
       shouldLog: shouldLog,
       uboMicros: uboMicros,
     );
     _preparedFrame = prepared;
-    _partitionPreparedEntries(prepared, layerRanges);
+    if (!_sameLayerRanges(graphState.layerRanges, layerRanges)) {
+      _partitionPreparedEntries(graphState, layerRanges);
+    }
 
     return prepared;
   }
@@ -889,7 +1090,7 @@ class GpuFrameRenderer {
         'stratumIndex',
       );
     }
-    final partition = preparedFrame._partitions[stratumIndex];
+    final partition = preparedFrame._graphState.graph.partitions[stratumIndex];
     final range = partition.range;
     final effectiveMapCallback =
         gpuMapRenderCallback != null &&
@@ -1026,12 +1227,14 @@ class GpuFrameRenderer {
     if (prepared != null && prepared.shouldLog) {
       prepared.shouldLog = false;
       _logFrameSummary(
-        entries: _drawEntries,
+        entries: prepared._graphState.graph.entries,
         commandCount: prepared.commandCount,
         drawCount: prepared.drawCount,
         renderPassCount: prepared.renderPassCount,
         uboMicros: prepared.uboMicros,
+        graphTiming: _preparedGraphTiming.takeSnapshotAndReset(),
       );
+      _logResourceSummary();
     }
     if (evictResourceCaches) _resourceCache.evictCaches();
   }
@@ -1046,25 +1249,114 @@ class GpuFrameRenderer {
     prepared.renderPassCount = 0;
   }
 
-  /// Initializes scratch storage for a new prepared frame.
+  /// Starts per-frame resources without discarding stable graph state.
   void _beginPreparedFrame({required bool advanceResourceFrame}) {
     if (advanceResourceFrame) _resourceCache.beginFrame();
     _resourceFrameNeedsFinalization = true;
     _resourceCacheNeedsEviction = true;
     _preparedFrame = null;
     _sharedDepthStencilInitialized = false;
-    for (final partition in _preparedPartitions) {
-      partition.entries.clear();
-      partition.needsMainDepthStencil = false;
-    }
-    _drawEntries.clear();
-    _drawEntryPoolCursor = 0;
     final uniformHost = _uniformHost;
     if (uniformHost == null) {
       _uniformHost = gpu.gpuContext.createHostBuffer();
     } else {
       uniformHost.reset();
     }
+  }
+
+  /// Clears topology-owned storage before decoding a different graph.
+  void _resetPreparedGraphStorage() {
+    _preparedGraph = null;
+    for (final partition in _preparedPartitions) {
+      partition.entries.clear();
+      partition.needsMainDepthStencil = false;
+    }
+    _drawEntries.clear();
+    _drawEntryPoolCursor = 0;
+  }
+
+  _PreparedGraphState? _restorePreparedGraphTemplate(
+    PreparedGraphKey key,
+    ByteData commandData, {
+    required bool shouldLog,
+  }) {
+    if (!key.reusable) return null;
+    _resetPreparedGraphStorage();
+    final backendAlignment = gpu.gpuContext.minimumUniformByteAlignment;
+    final uniformAlignment =
+        backendAlignment < RendererUboAbi.minimumUniformByteAlignment
+        ? RendererUboAbi.minimumUniformByteAlignment
+        : backendAlignment;
+    var uniformCursor = 0;
+    var lineCommandCount = 0;
+    var hasTriangulatedOutline = false;
+    int? lastFillExtrusionLayerIndex;
+    for (var index = 0; index < key.commands.length; index += 1) {
+      final topology = key.commands[index];
+      if (topology.shader == ShaderType.fillExtrusion) {
+        lastFillExtrusionLayerIndex = topology.layer;
+      }
+      if (!topology.active) continue;
+      final entry = _acquireDrawEntry(
+        index * key.commandStride,
+        topology.shader,
+        topology.drawMode,
+        topology.flags,
+        topology.layer,
+        0,
+        0,
+        null,
+        null,
+        null,
+        TextureFilterType.linear,
+        0,
+        topology.stencilMode,
+        topology.subLayerIndex,
+      );
+      entry.pipelineKey = topology.stencilMode == StencilModeType.clear
+          ? null
+          : pipelineKeyFor(shader: topology.shader, flags: topology.flags);
+      entry.depthPipelineKey = depthPipelineKeyFor(
+        shader: topology.shader,
+        flags: topology.flags,
+      );
+      _drawEntries.add(entry);
+      if (topology.stencilMode == StencilModeType.clear) continue;
+      if (isLineShader(topology.shader)) lineCommandCount += 1;
+      if (topology.shader == ShaderType.fillOutlineTriangulated) {
+        hasTriangulatedOutline = true;
+      }
+      uniformCursor = _assignUniformRanges(
+        entry,
+        uniformCursor,
+        uniformAlignment,
+      );
+    }
+    _releaseUnusedDrawEntries();
+    if (!_refreshPreparedEntries(
+      _drawEntries,
+      commandData,
+      shouldLog: shouldLog,
+    )) {
+      _resetPreparedGraphStorage();
+      return null;
+    }
+    final graph = PreparedGraph<DrawEntry, _PreparedDrawPartition>(
+      key: key,
+      entries: _drawEntries,
+      partitions: _preparedPartitions,
+      uniformAlignment: uniformAlignment,
+      uniformCursor: uniformCursor,
+      hasMapGlobalUniform: frameNeedsMapGlobalUniform(
+        lineCommandCount: lineCommandCount,
+        hasTriangulatedOutline: hasTriangulatedOutline,
+      ),
+      commandCount: key.commandCount,
+      lastFillExtrusionLayerIndex: lastFillExtrusionLayerIndex,
+    );
+    final state = _PreparedGraphState(graph);
+    _preparedGraph = state;
+    return state;
   }
 
   static bool _sameLayerRanges(
@@ -1081,7 +1373,7 @@ class GpuFrameRenderer {
   }
 
   void _partitionPreparedEntries(
-    GpuPreparedFrame prepared,
+    _PreparedGraphState preparedGraph,
     List<GpuStyleLayerRange> layerRanges,
   ) {
     if (!gpuStyleLayerRangesAreOrdered(layerRanges)) {
@@ -1105,7 +1397,7 @@ class GpuFrameRenderer {
       _preparedPartitions[index].range = layerRanges[index];
     }
     partitionDrawEntriesByStyleLayerRanges(
-      entries: _drawEntries,
+      entries: preparedGraph.graph.entries,
       ranges: layerRanges,
       partitions: _preparedPartitionEntries,
       clippingMaskPartitions: _preparedPartitionNeedsClippingMasks,
@@ -1126,18 +1418,25 @@ class GpuFrameRenderer {
         }
       }
     }
-    prepared.layerRanges = List<GpuStyleLayerRange>.unmodifiable(layerRanges);
+    preparedGraph.layerRanges = List<GpuStyleLayerRange>.unmodifiable(
+      layerRanges,
+    );
   }
 
-  void _prepareEntryPipelineState(ByteData uniformData) {
+  void _prepareEntryPipelineState(
+    ByteData uniformData, {
+    required bool initializePipelines,
+  }) {
     for (final entry in _drawEntries) {
-      entry.pipelineKey = entry.stencilMode == StencilModeType.clear
-          ? null
-          : pipelineKeyFor(shader: entry.shader, flags: entry.flags);
-      entry.depthPipelineKey = depthPipelineKeyFor(
-        shader: entry.shader,
-        flags: entry.flags,
-      );
+      if (initializePipelines) {
+        entry.pipelineKey = entry.stencilMode == StencilModeType.clear
+            ? null
+            : pipelineKeyFor(shader: entry.shader, flags: entry.flags);
+        entry.depthPipelineKey = depthPipelineKeyFor(
+          shader: entry.shader,
+          flags: entry.flags,
+        );
+      }
       entry.fillExtrusionOpacity =
           entry.shader == ShaderType.fillExtrusion &&
               entry.stencilMode != StencilModeType.clear
@@ -1150,29 +1449,19 @@ class GpuFrameRenderer {
     }
   }
 
-  /// Reads the native command buffer into pooled [DrawEntry] values.
-  ///
-  /// Returns null when the native command block is unavailable or invalid.
-  ///
-  /// Also assigns each entry its uniform ranges, since their offsets run
-  /// consecutively in decode order.
-  _FrameDecode? _decodeCommands(
-    FrameCommandMetadata frameMetadata, {
+  _CommandView? _commandView(
+    FrameCommandMetadata metadata, {
     required bool shouldLog,
   }) {
-    final entries = _drawEntries;
-    final metadata = frameMetadata;
     final commandCount = metadata.commandCount;
     if (commandCount <= 0) {
       _clearCommandViews();
-      _releaseUnusedDrawEntries();
 
       return null;
     }
     final commandsPointer = metadata.commands;
     if (commandsPointer == nullptr) {
       _clearCommandViews();
-      _releaseUnusedDrawEntries();
 
       return null;
     }
@@ -1184,7 +1473,6 @@ class GpuFrameRenderer {
         );
       }
       _clearCommandViews();
-      _releaseUnusedDrawEntries();
 
       return null;
     }
@@ -1199,8 +1487,176 @@ class GpuFrameRenderer {
       );
       _commandData = ByteData.sublistView(_commandBytes);
     }
-    final commandBytes = _commandBytes;
-    final commandData = _commandData;
+
+    return (
+      commandBytes: _commandBytes,
+      commandData: _commandData,
+      commandCount: commandCount,
+      commandStride: stride,
+    );
+  }
+
+  bool _refreshPreparedEntries(
+    List<DrawEntry> entries,
+    ByteData commandData, {
+    required bool shouldLog,
+  }) {
+    for (final entry in entries) {
+      final offset = entry.commandOffset;
+      entry.stencilReference = commandData.getUint32(
+        offset + DrawCommandAbi.stencilReference,
+        Endian.little,
+      );
+      if (entry.stencilMode == StencilModeType.clear) continue;
+
+      final vertexCount = commandData.getUint32(
+        offset + DrawCommandAbi.vertexCount,
+        Endian.little,
+      );
+      final indexCount = commandData.getUint32(
+        offset + DrawCommandAbi.indexCount,
+        Endian.little,
+      );
+      final vertexStride = commandData.getUint32(
+        offset + DrawCommandAbi.vertexStride,
+        Endian.little,
+      );
+      final isMerged = drawCommandIsCrossTileMerged(entry.flags);
+      final expectedStride = nativeVertexStride(
+        shader: entry.shader,
+        flags: entry.flags,
+        merged: isMerged,
+      );
+      if (vertexStride != expectedStride) {
+        if (shouldLog) {
+          debugPrint(
+            '[GpuRenderer] prepared graph vertex stride mismatch: '
+            'shader=${entry.shader} flags=${entry.flags} '
+            'exported=$vertexStride expected=$expectedStride',
+          );
+        }
+
+        return false;
+      }
+      final vertexDataAddress = commandData.getUint64(
+        offset + DrawCommandAbi.vertexData,
+        Endian.little,
+      );
+      final indexDataAddress = commandData.getUint64(
+        offset + DrawCommandAbi.indexData,
+        Endian.little,
+      );
+      entry
+        ..vertexCount = vertexCount
+        ..indexCount = indexCount
+        ..vertexBuffer = isMerged
+            ? _frameVertexBuffer(
+                vertexDataAddress,
+                vertexCount,
+                vertexStride,
+                entry.shader,
+                entry.flags,
+              )
+            : _cachedVertexBuffer(
+                commandData.getUint32(
+                  offset + DrawCommandAbi.bufferId,
+                  Endian.little,
+                ),
+                commandData.getUint32(
+                  offset + DrawCommandAbi.bufferVersion,
+                  Endian.little,
+                ),
+                vertexDataAddress,
+                vertexCount,
+                vertexStride,
+                entry.shader,
+                entry.flags,
+              )
+        ..indexBuffer = isMerged
+            ? _frameIndexBuffer(indexDataAddress, indexCount * 2)
+            : _cachedIndexBuffer(
+                commandData.getUint32(
+                  offset + DrawCommandAbi.bufferId,
+                  Endian.little,
+                ),
+                commandData.getUint32(
+                  offset + DrawCommandAbi.bufferVersion,
+                  Endian.little,
+                ),
+                indexDataAddress,
+                indexCount,
+                entry.shader,
+              );
+
+      gpu.Texture? commandTexture;
+      final textureChannels = commandData.getUint32(
+        offset + DrawCommandAbi.texChannels,
+        Endian.little,
+      );
+      if (textureChannels > 0) {
+        commandTexture = _textureForCommand(
+          commandData.getUint32(offset + DrawCommandAbi.texId, Endian.little),
+          commandData.getUint32(
+            offset + DrawCommandAbi.texVersion,
+            Endian.little,
+          ),
+          commandData.getUint64(offset + DrawCommandAbi.texData, Endian.little),
+          commandData.getUint32(
+            offset + DrawCommandAbi.texWidth,
+            Endian.little,
+          ),
+          commandData.getUint32(
+            offset + DrawCommandAbi.texHeight,
+            Endian.little,
+          ),
+          textureChannels,
+        );
+        if (commandTexture == null &&
+            shaderRequiresUploadedTexture(entry.shader)) {
+          if (shouldLog) {
+            debugPrint(
+              '[GpuRenderer] prepared graph texture refresh failed: '
+              'shader=${entry.shader}',
+            );
+          }
+
+          return false;
+        }
+      } else if (shaderRequiresTextureData(entry.shader)) {
+        return false;
+      }
+      entry
+        ..texture = commandTexture
+        ..textureFilter = commandData.getUint32(
+          offset + DrawCommandAbi.texFilter,
+          Endian.little,
+        );
+    }
+
+    return true;
+  }
+
+  /// Reads the native command buffer into pooled [DrawEntry] values.
+  ///
+  /// Returns null when the native command block is unavailable or invalid.
+  ///
+  /// Also assigns each entry its uniform ranges, since their offsets run
+  /// consecutively in decode order.
+  _FrameDecode? _decodeCommands(
+    FrameCommandMetadata frameMetadata, {
+    required bool shouldLog,
+  }) {
+    final entries = _drawEntries;
+    final view = _commandView(frameMetadata, shouldLog: shouldLog);
+    if (view == null) {
+      _releaseUnusedDrawEntries();
+
+      return null;
+    }
+    final commandBytes = view.commandBytes;
+    final commandData = view.commandData;
+    final commandCount = view.commandCount;
+    final stride = view.commandStride;
     final backendAlignment = gpu.gpuContext.minimumUniformByteAlignment;
     final uniformAlignment =
         backendAlignment < RendererUboAbi.minimumUniformByteAlignment
@@ -1834,13 +2290,15 @@ class GpuFrameRenderer {
 
   /// Prints one line of per-frame counts, at most once a second.
   ///
-  /// Counts admitted entries rather than every native command.
+  /// Counts admitted entries rather than every native command. Persistent graph
+  /// timings aggregate every newly prepared native frame since the last log.
   void _logFrameSummary({
     required List<DrawEntry> entries,
     required int commandCount,
     required int drawCount,
     required int renderPassCount,
     required int uboMicros,
+    required PreparedGraphDetailedTimingSnapshot graphTiming,
   }) {
     int nFill = 0,
         nFE = 0,
@@ -1877,12 +2335,78 @@ class GpuFrameRenderer {
       if (drawCommandIsCrossTileMerged(entry.flags)) nMerged++;
       totalVerts += entry.vertexCount;
     }
+    String averageMicros(double? value) =>
+        value == null ? '-' : '${value.toStringAsFixed(0)}us';
+    String maxMicros(int count, int value) => count == 0 ? '-' : '${value}us';
+    final totals = graphTiming.totals;
+    final graphHitRate = (totals.hitRate * 100).toStringAsFixed(1);
     debugPrint(
       '[GpuRenderer] z=${zoom.toStringAsFixed(2)} n=$commandCount '
       'draws=$drawCount passes=$renderPassCount '
       'bg=$nBg fill=$nFill line=$nLine sdf=$nSdf grad=$nGrad pat=$nPat '
       'circle=$nCircle raster=$nRaster fe=$nFE merged=$nMerged '
-      'verts=${totalVerts ~/ 1000}K ubo=${uboMicros}us',
+      'verts=${totalVerts ~/ 1000}K '
+      'graph=${totals.hitCount}/${totals.sampleCount}($graphHitRate%) '
+      'graphHit=${averageMicros(totals.averageHitMicros)} '
+      'graphRebuild=${averageMicros(totals.averageRebuildMicros)} '
+      'ubo=${uboMicros}us',
+    );
+    debugPrint(
+      '[GpuGraph] hitMax=${maxMicros(totals.hitCount, graphTiming.hitMaxMicros)} '
+      'rebuildMax=${maxMicros(totals.rebuildCount, graphTiming.rebuildMaxMicros)} '
+      'validate=${averageMicros(graphTiming.averageValidationMicros)} '
+      'refresh=${averageMicros(graphTiming.averageRefreshMicros)} '
+      'decode=${averageMicros(graphTiming.averageDecodeMicros)} '
+      'capture=${averageMicros(graphTiming.averageCaptureMicros)} '
+      'rebuildCause=noGraph:${graphTiming.noGraphRebuildCount} '
+      'topology:${graphTiming.topologyMismatchRebuildCount} '
+      'refresh:${graphTiming.refreshFailedRebuildCount}',
+    );
+  }
+
+  void _logResourceSummary() {
+    final timing = _resourceCache.timingMetrics.takeSnapshotAndReset();
+    final cache = _resourceCache.sizeSnapshot;
+    final pool = _resourceCache.takeBufferPoolSnapshotAndReset();
+    String lookup(int hits, int misses) =>
+        '$hits/${hits + misses}(miss=$misses)';
+    String average(double? micros) =>
+        micros == null ? '-' : '${micros.toStringAsFixed(0)}us';
+    String maximum(int count, int micros) => count == 0 ? '-' : '${micros}us';
+    String megabytes(int bytes) =>
+        '${(bytes / (1024 * 1024)).toStringAsFixed(1)}MB';
+
+    debugPrint(
+      '[GpuResource] vertex=${lookup(timing.vertexCacheHits, timing.vertexCacheMisses)} '
+      'index=${lookup(timing.indexCacheHits, timing.indexCacheMisses)} '
+      'texture=${lookup(timing.textureCacheHits, timing.textureCacheMisses)} '
+      'cache=v:${cache.vertexCount}/${megabytes(cache.vertexBytes)} '
+      'i:${cache.indexCount}/${megabytes(cache.indexBytes)} '
+      't:${cache.textureCount}/${megabytes(cache.textureBytes)} '
+      'total=${megabytes(cache.totalBytes)} '
+      'evict=expiry:${timing.expiryEvictionCount}/${megabytes(timing.expiryEvictionBytes)} '
+      'budget:${timing.budgetEvictionCount}/${megabytes(timing.budgetEvictionBytes)}',
+    );
+    debugPrint(
+      '[GpuUpload] repack=${timing.repackCount}/${average(timing.averageRepackMicros)} '
+      'max=${maximum(timing.repackCount, timing.repackMaxMicros)} '
+      'vertex=${timing.vertexUploadCount}/${megabytes(timing.vertexUploadBytes)}/'
+      '${average(timing.averageVertexUploadMicros)}/'
+      '${maximum(timing.vertexUploadCount, timing.vertexUploadMaxMicros)} '
+      'index=${timing.indexUploadCount}/${megabytes(timing.indexUploadBytes)}/'
+      '${average(timing.averageIndexUploadMicros)}/'
+      '${maximum(timing.indexUploadCount, timing.indexUploadMaxMicros)} '
+      'texture=${timing.textureUploadCount}/${megabytes(timing.textureUploadBytes)}/'
+      '${average(timing.averageTextureUploadMicros)}/'
+      '${maximum(timing.textureUploadCount, timing.textureUploadMaxMicros)} '
+      'frameOwned=v:${timing.frameVertexUploadCount}/'
+      '${megabytes(timing.frameVertexUploadBytes)} '
+      'i:${timing.frameIndexUploadCount}/${megabytes(timing.frameIndexUploadBytes)}',
+    );
+    debugPrint(
+      '[GpuBufferPool] pages=${pool.pageCount}/${megabytes(pool.pageBytes)} '
+      'writes=${pool.writeCount}/${megabytes(pool.writeBytes)} '
+      'newPages=${pool.pageAllocationCount} reuse=${pool.reusedRangeCount}',
     );
   }
 
@@ -1890,6 +2414,8 @@ class GpuFrameRenderer {
   void dispose() {
     _resourceCache.dispose();
     _uniformHost = null;
+    _preparedGraph = null;
+    _preparedGraphTemplates.clear();
     _preparedFrame = null;
     _resourceFrameNeedsFinalization = false;
     _resourceCacheNeedsEviction = false;

--- a/lib/src/gpu/resource_cache.dart
+++ b/lib/src/gpu/resource_cache.dart
@@ -1,6 +1,11 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_gpu/gpu.dart' as gpu;
 
+import '../native/draw_command.dart';
+import 'persistent_buffer_pool.dart';
+import 'resource_metrics.dart';
+import 'resource_miss_tracker.dart';
+
 /// Values that uniquely identify repacked vertex data in the GPU cache.
 typedef GpuVertexBufferCacheKey = ({
   int bufferId,
@@ -40,6 +45,76 @@ final class _IndexBufferBudgetKey extends _BufferBudgetKey {
 
 typedef _BudgetEntry = ({int lastUsed, int bytes});
 
+enum _GpuCacheClass { line, fillExtrusion, other, indexBuffer, texture }
+
+enum GpuCacheExpiryReason { superseded, unused }
+
+final class _EvictionClassTotals {
+  int count = 0;
+  int bytes = 0;
+}
+
+_GpuCacheClass _gpuCacheClassForShader(int shader) => switch (shader) {
+  ShaderType.line ||
+  ShaderType.lineSDF ||
+  ShaderType.lineGradient ||
+  ShaderType.linePattern => _GpuCacheClass.line,
+  ShaderType.fillExtrusion => _GpuCacheClass.fillExtrusion,
+  _ => _GpuCacheClass.other,
+};
+
+const _gpuBridgePreparedBufferIdNamespace = 0x80000000;
+
+bool _isBridgePreparedVertexKey(GpuVertexBufferCacheKey key) =>
+    (key.bufferId & _gpuBridgePreparedBufferIdNamespace) != 0 &&
+    key.sourceStride == key.gpuStride &&
+    (_gpuCacheClassForShader(key.shader) == _GpuCacheClass.line ||
+        key.shader == ShaderType.fillExtrusion);
+
+/// Normalizes bridge-prepared vertex keys to their stable segment identity.
+///
+/// New bridge artifacts assign a high-bit bufferId to each prepared line or
+/// fill-extrusion segment and preserve command_export's bufferVersion. The
+/// expanded CPU vector may move when the native bridge cache is recreated, but
+/// that pointer is no longer part of the content identity. Older artifacts keep
+/// ordinary bufferIds and therefore retain strict pointer-based cache keys.
+@visibleForTesting
+GpuVertexBufferCacheKey gpuCanonicalVertexBufferCacheKey(
+  GpuVertexBufferCacheKey key,
+) {
+  if (!_isBridgePreparedVertexKey(key) || key.dataAddress == 0) return key;
+
+  return (
+    bufferId: key.bufferId,
+    bufferVersion: key.bufferVersion,
+    dataAddress: 0,
+    vertexCount: key.vertexCount,
+    sourceStride: key.sourceStride,
+    shader: key.shader,
+    gpuStride: key.gpuStride,
+  );
+}
+
+/// Normalizes prepared index keys to their stable segment identity.
+///
+/// High-bit buffer IDs are reserved for bridge/native segment identities whose
+/// index contents are versioned independently of the backing CPU allocation.
+@visibleForTesting
+GpuIndexBufferCacheKey gpuCanonicalIndexBufferCacheKey(
+  GpuIndexBufferCacheKey key,
+) {
+  if ((key.bufferId & _gpuBridgePreparedBufferIdNamespace) == 0 ||
+      key.dataAddress == 0) {
+    return key;
+  }
+
+  return (
+    bufferId: key.bufferId,
+    bufferVersion: key.bufferVersion,
+    dataAddress: 0,
+  );
+}
+
 /// A cached device buffer and the metadata used to manage its lifetime.
 class GpuBufferEntry {
   /// The cached GPU buffer.
@@ -48,16 +123,21 @@ class GpuBufferEntry {
   /// Number of bytes available through [view].
   final int lengthInBytes;
 
+  /// Byte offset of this entry inside [buffer].
+  final int offsetInBytes;
+
   /// Whether this buffer uses the fill extrusion retention policy.
   final bool isFillExtrusion;
+
+  GpuPersistentBufferAllocation? _pooledAllocation;
 
   /// Frame in which this entry was most recently requested.
   int lastUsed = 0;
 
-  /// A view covering the complete [buffer].
+  /// A view covering this entry's range inside [buffer].
   late final gpu.BufferView view = gpu.BufferView(
     buffer,
-    offsetInBytes: 0,
+    offsetInBytes: offsetInBytes,
     lengthInBytes: lengthInBytes,
   );
 
@@ -66,7 +146,16 @@ class GpuBufferEntry {
     this.buffer,
     this.lengthInBytes, {
     this.isFillExtrusion = false,
+    this.offsetInBytes = 0,
+    this._pooledAllocation,
   });
+
+  void _releasePooledAllocation(int frame) {
+    final allocation = _pooledAllocation;
+    if (allocation == null) return;
+    _pooledAllocation = null;
+    allocation.release(frame);
+  }
 }
 
 /// A cached texture and the metadata used to manage its lifetime.
@@ -84,12 +173,43 @@ class GpuTextureEntry {
   GpuTextureEntry(this.texture, this.lengthInBytes);
 }
 
+/// Current cache occupancy sampled when the renderer emits its periodic log.
+final class GpuResourceCacheSizeSnapshot {
+  const GpuResourceCacheSizeSnapshot({
+    required this.vertexCount,
+    required this.vertexBytes,
+    required this.indexCount,
+    required this.indexBytes,
+    required this.textureCount,
+    required this.textureBytes,
+  });
+
+  final int vertexCount;
+  final int vertexBytes;
+  final int indexCount;
+  final int indexBytes;
+  final int textureCount;
+  final int textureBytes;
+
+  int get totalBytes => vertexBytes + indexBytes + textureBytes;
+}
+
 const _gpuFramesInFlight = 4;
 const _gpuUnusedRetentionFrames = 60;
-const _gpuFillExtrusionUnusedRetentionFrames = 600;
-const _gpuBufferCacheBudgetBytes = 64 * 1024 * 1024;
-const _gpuFillExtrusionBufferCacheBudgetBytes = 64 * 1024 * 1024;
+const _gpuRegularBufferUnusedRetentionFrames = 1800;
+const _gpuLineUnusedRetentionFrames = 1800;
+const _gpuFillExtrusionUnusedRetentionFrames = 1800;
+const _gpuRegularMinBufferCacheBudgetBytes = 64 * 1024 * 1024;
+const _gpuRegularMaxBufferCacheBudgetBytes = 96 * 1024 * 1024;
+const _gpuRegularBudgetGrowthStepBytes = 8 * 1024 * 1024;
+const _gpuRegularBudgetWorkingSetFrames = 8;
+const _gpuRegularBudgetIdleShrinkFrames = 1800;
+const _gpuFillExtrusionMinBufferCacheBudgetBytes = 64 * 1024 * 1024;
+const _gpuFillExtrusionMaxBufferCacheBudgetBytes = 96 * 1024 * 1024;
+const _gpuFillExtrusionBudgetWorkingSetFrames = 8;
+const _gpuFillExtrusionBudgetIdleShrinkFrames = 120;
 const _gpuTextureCacheBudgetBytes = 64 * 1024 * 1024;
+const _gpuEvictionClassLogFrames = 60;
 
 /// Whether expiry maintenance is due on [frame].
 @visibleForTesting
@@ -97,6 +217,25 @@ bool gpuCacheExpiryMaintenanceDue(
   int frame, {
   int interval = _gpuFramesInFlight,
 }) => frame % interval == 0;
+
+/// Classifies why a cache entry is eligible for expiry on [frame].
+///
+/// Superseded generations take precedence over age when both rules match, so
+/// diagnostics attribute four-frame generation retirement consistently.
+@visibleForTesting
+GpuCacheExpiryReason? gpuCacheEntryExpiryReason({
+  required int frame,
+  required int lastUsed,
+  required bool superseded,
+  int unusedRetentionFrames = _gpuUnusedRetentionFrames,
+}) {
+  final age = frame - lastUsed;
+  if (superseded && age >= _gpuFramesInFlight) {
+    return GpuCacheExpiryReason.superseded;
+  }
+  if (age >= unusedRetentionFrames) return GpuCacheExpiryReason.unused;
+  return null;
+}
 
 /// Whether a cache entry can be removed on [frame].
 ///
@@ -108,11 +247,121 @@ bool gpuCacheEntryExpired({
   required int lastUsed,
   required bool superseded,
   int unusedRetentionFrames = _gpuUnusedRetentionFrames,
-}) {
-  final age = frame - lastUsed;
+}) =>
+    gpuCacheEntryExpiryReason(
+      frame: frame,
+      lastUsed: lastUsed,
+      superseded: superseded,
+      unusedRetentionFrames: unusedRetentionFrames,
+    ) !=
+    null;
 
-  return age >= unusedRetentionFrames ||
-      (superseded && age >= _gpuFramesInFlight);
+/// Retention used for one cached vertex buffer when it is not superseded.
+///
+/// Cached geometry gets a thirty-second reuse window. The adaptive regular and
+/// fill-extrusion byte budgets remain authoritative, so active memory pressure
+/// can still evict old entries before this time limit is reached.
+@visibleForTesting
+int gpuVertexUnusedRetentionFrames(int shader, {bool isFillExtrusion = false}) {
+  if (isFillExtrusion || shader == ShaderType.fillExtrusion) {
+    return _gpuFillExtrusionUnusedRetentionFrames;
+  }
+  if (_gpuCacheClassForShader(shader) == _GpuCacheClass.line) {
+    return _gpuLineUnusedRetentionFrames;
+  }
+  return _gpuRegularBufferUnusedRetentionFrames;
+}
+
+/// Retention used for one cached index buffer when it is not superseded.
+@visibleForTesting
+int gpuIndexUnusedRetentionFrames({bool isFillExtrusion = false}) =>
+    isFillExtrusion
+    ? _gpuFillExtrusionUnusedRetentionFrames
+    : _gpuRegularBufferUnusedRetentionFrames;
+
+/// Chooses the pressure-driven regular buffer budget for [residentBytes].
+///
+/// The floor preserves the previous 64 MiB behavior. When retained geometry
+/// needs more space, grow in 8 MiB steps up to 96 MiB instead of immediately
+/// evicting reusable compact line/fill/index buffers.
+@visibleForTesting
+int gpuRegularBufferBudgetForResidentBytes(
+  int residentBytes, {
+  int minBytes = _gpuRegularMinBufferCacheBudgetBytes,
+  int maxBytes = _gpuRegularMaxBufferCacheBudgetBytes,
+  int growthStepBytes = _gpuRegularBudgetGrowthStepBytes,
+}) {
+  if (residentBytes < 0) {
+    throw RangeError.value(
+      residentBytes,
+      'residentBytes',
+      'must not be negative',
+    );
+  }
+  if (minBytes < 0 || maxBytes < minBytes || growthStepBytes <= 0) {
+    throw ArgumentError('Invalid regular buffer cache budget bounds');
+  }
+  if (residentBytes <= minBytes) return minBytes;
+  if (residentBytes >= maxBytes) return maxBytes;
+  final rounded =
+      ((residentBytes + growthStepBytes - 1) ~/ growthStepBytes) *
+      growthStepBytes;
+  if (rounded < minBytes) return minBytes;
+  if (rounded > maxBytes) return maxBytes;
+  return rounded;
+}
+
+/// Chooses the fill-extrusion buffer budget from its recently visible working
+/// set. Two working sets worth of space keeps adjacent zoom-level tiles warm
+/// while panning or zooming. The clamp bounds memory use on unusually dense
+/// scenes.
+@visibleForTesting
+int gpuFillExtrusionBudgetForWorkingSetBytes(
+  int recentWorkingSetBytes, {
+  int minBytes = _gpuFillExtrusionMinBufferCacheBudgetBytes,
+  int maxBytes = _gpuFillExtrusionMaxBufferCacheBudgetBytes,
+}) {
+  if (recentWorkingSetBytes < 0) {
+    throw RangeError.value(
+      recentWorkingSetBytes,
+      'recentWorkingSetBytes',
+      'must not be negative',
+    );
+  }
+  if (minBytes < 0 || maxBytes < minBytes) {
+    throw ArgumentError('Invalid fill-extrusion cache budget bounds');
+  }
+  final targetBytes = recentWorkingSetBytes * 2;
+  if (targetBytes < minBytes) return minBytes;
+  if (targetBytes > maxBytes) return maxBytes;
+  return targetBytes;
+}
+
+/// Applies hysteresis to the fill-extrusion budget.
+///
+/// The budget grows immediately when the visible working set needs more room,
+/// but does not shrink while fill-extrusion geometry is still active. After a
+/// sustained period without recent fill-extrusion use it may fall back to the
+/// target budget, normally the 64 MiB floor.
+@visibleForTesting
+int gpuFillExtrusionBudgetWithHysteresis({
+  required int currentBudgetBytes,
+  required int targetBudgetBytes,
+  required bool hasRecentWorkingSet,
+  required int framesSinceRecentUse,
+  int idleShrinkFrames = _gpuFillExtrusionBudgetIdleShrinkFrames,
+}) {
+  if (currentBudgetBytes < 0 ||
+      targetBudgetBytes < 0 ||
+      framesSinceRecentUse < 0 ||
+      idleShrinkFrames < 0) {
+    throw ArgumentError('Fill-extrusion budget inputs must be non-negative');
+  }
+  if (targetBudgetBytes > currentBudgetBytes) return targetBudgetBytes;
+  if (hasRecentWorkingSet || framesSinceRecentUse < idleShrinkFrames) {
+    return currentBudgetBytes;
+  }
+  return targetBudgetBytes;
 }
 
 /// Selects entries to remove until the remaining size does not exceed
@@ -151,6 +400,13 @@ List<K> gpuCacheBudgetVictims<K>(
   return victims;
 }
 
+/// Whether budget enforcement must run again after protected entries age.
+@visibleForTesting
+bool gpuCacheBudgetNeedsRetry({
+  required int residentBytes,
+  required int maxBytes,
+}) => residentBytes > maxBytes;
+
 /// Removes expired versions from [cache].
 ///
 /// For each resource ID, the most recently used version is treated as current.
@@ -162,6 +418,9 @@ void evictExpiredCacheVersions<K, V>(
   required int Function(K key) versionOf,
   required int Function(V value) lastUsedOf,
   int Function(V value)? unusedRetentionFramesOf,
+  int Function(K key, V value)? unusedRetentionFramesForEntry,
+  void Function(K key, V value)? onEvict,
+  void Function(K key, V value, GpuCacheExpiryReason reason)? onEvictReason,
 }) {
   final latestVersion = <int, int>{};
   final latestUse = <int, int>{};
@@ -173,15 +432,21 @@ void evictExpiredCacheVersions<K, V>(
       latestVersion[id] = versionOf(entry.key);
     }
   }
-  cache.removeWhere(
-    (key, value) => gpuCacheEntryExpired(
+  cache.removeWhere((key, value) {
+    final reason = gpuCacheEntryExpiryReason(
       frame: frame,
       lastUsed: lastUsedOf(value),
       superseded: versionOf(key) != latestVersion[idOf(key)],
       unusedRetentionFrames:
-          unusedRetentionFramesOf?.call(value) ?? _gpuUnusedRetentionFrames,
-    ),
-  );
+          unusedRetentionFramesForEntry?.call(key, value) ??
+          unusedRetentionFramesOf?.call(value) ??
+          _gpuUnusedRetentionFrames,
+    );
+    if (reason == null) return false;
+    onEvict?.call(key, value);
+    onEvictReason?.call(key, value, reason);
+    return true;
+  });
 }
 
 /// Caches GPU buffers and textures across rendered frames.
@@ -200,53 +465,199 @@ class GpuResourceCache {
   // changes the version when pixel contents change so stale data is not reused.
   final Map<GpuTextureCacheKey, GpuTextureEntry> _textureCache = {};
 
+  /// Interval metrics shared with the renderer's repack/upload instrumentation.
+  final GpuResourceTimingMetrics timingMetrics = GpuResourceTimingMetrics();
+  final GpuPersistentBufferPool _bufferPool = GpuPersistentBufferPool();
+  final GpuCacheMissTracker<GpuVertexBufferCacheKey>
+  _fillExtrusionVertexMissTracker =
+      GpuCacheMissTracker<GpuVertexBufferCacheKey>(
+        idOf: (key) => key.bufferId,
+        versionOf: (key) => key.bufferVersion,
+      );
+  final GpuCacheMissTracker<GpuIndexBufferCacheKey>
+  _fillExtrusionIndexMissTracker = GpuCacheMissTracker<GpuIndexBufferCacheKey>(
+    idOf: (key) => key.bufferId,
+    versionOf: (key) => key.bufferVersion,
+  );
+
+  final Map<_GpuCacheClass, _EvictionClassTotals> _expiryEvictionsByClass = {};
+  final Map<_GpuCacheClass, _EvictionClassTotals> _budgetEvictionsByClass = {};
+  final Map<GpuCacheExpiryReason, _EvictionClassTotals>
+  _expiryEvictionsByReason = {};
   var _frame = 0;
+  var _evictionClassLogFrame = 0;
+  var _regularBufferBudgetBytes = _gpuRegularMinBufferCacheBudgetBytes;
+  var _lastRegularBufferBudgetGrowthFrame = 0;
+  var _fillExtrusionBudgetBytes = _gpuFillExtrusionMinBufferCacheBudgetBytes;
+  var _lastFillExtrusionRecentUseFrame = 0;
   var _budgetDirty = false;
+
+  /// Current cache sizes. This walks the maps only when the periodic log asks.
+  GpuResourceCacheSizeSnapshot get sizeSnapshot => GpuResourceCacheSizeSnapshot(
+    vertexCount: _vertexCache.length,
+    vertexBytes: _vertexCache.values.fold<int>(
+      0,
+      (total, entry) => total + entry.lengthInBytes,
+    ),
+    indexCount: _indexCache.length,
+    indexBytes: _indexCache.values.fold<int>(
+      0,
+      (total, entry) => total + entry.lengthInBytes,
+    ),
+    textureCount: _textureCache.length,
+    textureBytes: _textureCache.values.fold<int>(
+      0,
+      (total, entry) => total + entry.lengthInBytes,
+    ),
+  );
+
+  /// Uploads a cache-owned buffer, pooling payloads up to 256 KiB.
+  GpuBufferEntry uploadCachedBuffer(
+    Uint8List bytes, {
+    bool isFillExtrusion = false,
+  }) {
+    final allocation = _bufferPool.allocate(bytes, frame: _frame);
+    if (allocation != null) {
+      return GpuBufferEntry(
+        allocation.buffer,
+        bytes.lengthInBytes,
+        isFillExtrusion: isFillExtrusion,
+        offsetInBytes: allocation.offsetInBytes,
+        pooledAllocation: allocation,
+      );
+    }
+    return GpuBufferEntry(
+      gpu.gpuContext.createDeviceBufferWithCopy(ByteData.sublistView(bytes)),
+      bytes.lengthInBytes,
+      isFillExtrusion: isFillExtrusion,
+    );
+  }
+
+  /// Returns interval allocation activity for the persistent small-buffer pool.
+  GpuPersistentBufferPoolSnapshot takeBufferPoolSnapshotAndReset() {
+    final snapshot = _bufferPool.takeSnapshotAndReset();
+    logGpuFillExtrusionMissClasses(
+      vertex: _fillExtrusionVertexMissTracker.takeSnapshotAndReset(),
+      index: _fillExtrusionIndexMissTracker.takeSnapshotAndReset(),
+    );
+    return snapshot;
+  }
 
   /// Advances the frame used for cache lifetime tracking.
   void beginFrame() {
     _frame += 1;
+    _bufferPool.beginFrame(_frame);
+    if (_regularBufferBudgetBytes > _gpuRegularMinBufferCacheBudgetBytes &&
+        _frame - _lastRegularBufferBudgetGrowthFrame ==
+            _gpuRegularBudgetIdleShrinkFrames) {
+      _budgetDirty = true;
+    }
+    if (_fillExtrusionBudgetBytes >
+            _gpuFillExtrusionMinBufferCacheBudgetBytes &&
+        _frame - _lastFillExtrusionRecentUseFrame ==
+            _gpuFillExtrusionBudgetIdleShrinkFrames) {
+      _budgetDirty = true;
+    }
   }
 
   /// Returns the vertex buffer for [key] and marks it as used this frame.
   GpuBufferEntry? vertexBuffer(GpuVertexBufferCacheKey key) {
-    final entry = _vertexCache[key];
-    if (entry != null) entry.lastUsed = _frame;
+    final cacheKey = gpuCanonicalVertexBufferCacheKey(key);
+    final entry = _vertexCache[cacheKey];
+    timingMetrics.recordVertexLookup(
+      hit: entry != null,
+      shader: key.shader,
+      sourceStride: key.sourceStride,
+      gpuStride: key.gpuStride,
+      vertexCount: key.vertexCount,
+    );
+    if (key.shader == ShaderType.fillExtrusion) {
+      _fillExtrusionVertexMissTracker.recordLookup(
+        key: cacheKey,
+        hit: entry != null,
+      );
+    }
+    if (entry != null) {
+      entry.lastUsed = _frame;
+      if (key.shader == ShaderType.fillExtrusion) {
+        _lastFillExtrusionRecentUseFrame = _frame;
+      }
+    }
 
     return entry;
   }
 
   /// Stores a vertex buffer under [key].
   void storeVertexBuffer(GpuVertexBufferCacheKey key, GpuBufferEntry entry) {
+    final cacheKey = gpuCanonicalVertexBufferCacheKey(key);
     entry.lastUsed = _frame;
-    _vertexCache[key] = entry;
+    if (key.shader == ShaderType.fillExtrusion) {
+      _lastFillExtrusionRecentUseFrame = _frame;
+      _fillExtrusionVertexMissTracker.recordStore(
+        key: cacheKey,
+        bytes: entry.lengthInBytes,
+        classify: true,
+      );
+    }
+    final previous = _vertexCache[cacheKey];
+    if (previous != null && !identical(previous, entry)) {
+      previous._releasePooledAllocation(_frame);
+    }
+    _vertexCache[cacheKey] = entry;
     _budgetDirty = true;
   }
 
   /// Returns the index buffer for [key] and marks it as used this frame.
   GpuBufferEntry? indexBuffer(GpuIndexBufferCacheKey key) {
-    final entry = _indexCache[key];
-    if (entry != null) entry.lastUsed = _frame;
+    final cacheKey = gpuCanonicalIndexBufferCacheKey(key);
+    final entry = _indexCache[cacheKey];
+    timingMetrics.recordIndexLookup(hit: entry != null);
+    if (entry == null || entry.isFillExtrusion) {
+      _fillExtrusionIndexMissTracker.recordLookup(
+        key: cacheKey,
+        hit: entry != null,
+      );
+    }
+    if (entry != null) {
+      entry.lastUsed = _frame;
+      if (entry.isFillExtrusion) {
+        _lastFillExtrusionRecentUseFrame = _frame;
+      }
+    }
 
     return entry;
   }
 
   /// Stores an index buffer under [key].
   void storeIndexBuffer(GpuIndexBufferCacheKey key, GpuBufferEntry entry) {
+    final cacheKey = gpuCanonicalIndexBufferCacheKey(key);
     entry.lastUsed = _frame;
-    _indexCache[key] = entry;
+    _fillExtrusionIndexMissTracker.recordStore(
+      key: cacheKey,
+      bytes: entry.lengthInBytes,
+      classify: entry.isFillExtrusion,
+    );
+    if (entry.isFillExtrusion) {
+      _lastFillExtrusionRecentUseFrame = _frame;
+    }
+    final previous = _indexCache[cacheKey];
+    if (previous != null && !identical(previous, entry)) {
+      previous._releasePooledAllocation(_frame);
+    }
+    _indexCache[cacheKey] = entry;
     _budgetDirty = true;
   }
 
   /// Returns the texture for [key] and marks it as used this frame.
   GpuTextureEntry? texture(GpuTextureCacheKey key) {
     final entry = _textureCache[key];
+    timingMetrics.recordTextureLookup(hit: entry != null);
     if (entry != null) entry.lastUsed = _frame;
 
     return entry;
   }
 
-  /// Stores a texture under [key].
+  /// Stores a texture under [key] and marks it as used this frame.
   void storeTexture(GpuTextureCacheKey key, GpuTextureEntry entry) {
     entry.lastUsed = _frame;
     _textureCache[key] = entry;
@@ -258,15 +669,71 @@ class GpuResourceCache {
     // Superseded resources must survive the frames already in flight, so
     // expiry maintenance runs at the same cadence.
     if (gpuCacheExpiryMaintenanceDue(_frame)) {
+      var expiredCount = 0;
+      var expiredBytes = 0;
+      void recordVertexExpiry(
+        GpuVertexBufferCacheKey key,
+        GpuBufferEntry value,
+      ) {
+        value._releasePooledAllocation(_frame);
+        if (value.isFillExtrusion) {
+          _fillExtrusionVertexMissTracker.recordEviction(
+            key: key,
+            kind: GpuCacheEvictionKind.expiry,
+          );
+        }
+        expiredCount += 1;
+        expiredBytes += value.lengthInBytes;
+        _recordEvictionClass(
+          _expiryEvictionsByClass,
+          _gpuCacheClassForShader(key.shader),
+          value.lengthInBytes,
+        );
+      }
+
+      void recordIndexExpiry(GpuIndexBufferCacheKey key, GpuBufferEntry value) {
+        value._releasePooledAllocation(_frame);
+        if (value.isFillExtrusion) {
+          _fillExtrusionIndexMissTracker.recordEviction(
+            key: key,
+            kind: GpuCacheEvictionKind.expiry,
+          );
+        }
+        expiredCount += 1;
+        expiredBytes += value.lengthInBytes;
+        _recordEvictionClass(
+          _expiryEvictionsByClass,
+          value.isFillExtrusion
+              ? _GpuCacheClass.fillExtrusion
+              : _GpuCacheClass.indexBuffer,
+          value.lengthInBytes,
+        );
+      }
+
+      void recordTextureExpiry(GpuTextureCacheKey key, GpuTextureEntry value) {
+        expiredCount += 1;
+        expiredBytes += value.lengthInBytes;
+        _recordEvictionClass(
+          _expiryEvictionsByClass,
+          _GpuCacheClass.texture,
+          value.lengthInBytes,
+        );
+      }
+
       evictExpiredCacheVersions(
         _vertexCache,
         frame: _frame,
         idOf: (key) => key.bufferId,
         versionOf: (key) => key.bufferVersion,
         lastUsedOf: (value) => value.lastUsed,
-        unusedRetentionFramesOf: (value) => value.isFillExtrusion
-            ? _gpuFillExtrusionUnusedRetentionFrames
-            : _gpuUnusedRetentionFrames,
+        unusedRetentionFramesForEntry: (key, value) =>
+            gpuVertexUnusedRetentionFrames(
+              key.shader,
+              isFillExtrusion: value.isFillExtrusion,
+            ),
+        onEvict: recordVertexExpiry,
+        onEvictReason: (_, value, reason) =>
+            _recordExpiryReason(reason, value.lengthInBytes),
       );
       evictExpiredCacheVersions(
         _indexCache,
@@ -274,9 +741,12 @@ class GpuResourceCache {
         idOf: (key) => key.bufferId,
         versionOf: (key) => key.bufferVersion,
         lastUsedOf: (value) => value.lastUsed,
-        unusedRetentionFramesOf: (value) => value.isFillExtrusion
-            ? _gpuFillExtrusionUnusedRetentionFrames
-            : _gpuUnusedRetentionFrames,
+        unusedRetentionFramesOf: (value) => gpuIndexUnusedRetentionFrames(
+          isFillExtrusion: value.isFillExtrusion,
+        ),
+        onEvict: recordIndexExpiry,
+        onEvictReason: (_, value, reason) =>
+            _recordExpiryReason(reason, value.lengthInBytes),
       );
       evictExpiredCacheVersions(
         _textureCache,
@@ -284,40 +754,95 @@ class GpuResourceCache {
         idOf: (key) => key.textureId,
         versionOf: (key) => key.textureVersion,
         lastUsedOf: (value) => value.lastUsed,
+        onEvict: recordTextureExpiry,
+        onEvictReason: (_, value, reason) =>
+            _recordExpiryReason(reason, value.lengthInBytes),
       );
+      if (expiredCount > 0) {
+        timingMetrics.recordExpiryEvictions(
+          count: expiredCount,
+          bytes: expiredBytes,
+        );
+      }
     }
 
     // Cached bytes can increase only when a resource is stored. Count without
     // allocating, then build sortable victim maps only when a limit is
     // actually exceeded.
-    if (!_budgetDirty) return;
+    if (!_budgetDirty) {
+      _logEvictionClassesIfDue();
+      return;
+    }
     _budgetDirty = false;
     var regularBufferBytes = 0;
+    var recentRegularBufferBytes = 0;
     var fillExtrusionBufferBytes = 0;
+    var recentFillExtrusionBufferBytes = 0;
     for (final entry in _vertexCache.values) {
       if (entry.isFillExtrusion) {
         fillExtrusionBufferBytes += entry.lengthInBytes;
+        if (_frame - entry.lastUsed < _gpuFillExtrusionBudgetWorkingSetFrames) {
+          recentFillExtrusionBufferBytes += entry.lengthInBytes;
+        }
       } else {
         regularBufferBytes += entry.lengthInBytes;
+        if (_frame - entry.lastUsed < _gpuRegularBudgetWorkingSetFrames) {
+          recentRegularBufferBytes += entry.lengthInBytes;
+        }
       }
     }
     for (final entry in _indexCache.values) {
       if (entry.isFillExtrusion) {
         fillExtrusionBufferBytes += entry.lengthInBytes;
+        if (_frame - entry.lastUsed < _gpuFillExtrusionBudgetWorkingSetFrames) {
+          recentFillExtrusionBufferBytes += entry.lengthInBytes;
+        }
       } else {
         regularBufferBytes += entry.lengthInBytes;
+        if (_frame - entry.lastUsed < _gpuRegularBudgetWorkingSetFrames) {
+          recentRegularBufferBytes += entry.lengthInBytes;
+        }
       }
     }
-    if (regularBufferBytes > _gpuBufferCacheBudgetBytes) {
-      _evictBufferBudget(
+
+    final regularTargetBudgetBytes = gpuRegularBufferBudgetForResidentBytes(
+      regularBufferBytes,
+    );
+    if (regularTargetBudgetBytes > _regularBufferBudgetBytes) {
+      _regularBufferBudgetBytes = regularTargetBudgetBytes;
+      _lastRegularBufferBudgetGrowthFrame = _frame;
+    } else if (_regularBufferBudgetBytes >
+            _gpuRegularMinBufferCacheBudgetBytes &&
+        _frame - _lastRegularBufferBudgetGrowthFrame >=
+            _gpuRegularBudgetIdleShrinkFrames &&
+        recentRegularBufferBytes <= _gpuRegularMinBufferCacheBudgetBytes) {
+      _regularBufferBudgetBytes = _gpuRegularMinBufferCacheBudgetBytes;
+    }
+    if (regularBufferBytes > _regularBufferBudgetBytes) {
+      regularBufferBytes -= _evictBufferBudget(
         _bufferBudgetEntries(isFillExtrusion: false),
-        maxBytes: _gpuBufferCacheBudgetBytes,
+        maxBytes: _regularBufferBudgetBytes,
       );
     }
-    if (fillExtrusionBufferBytes > _gpuFillExtrusionBufferCacheBudgetBytes) {
-      _evictBufferBudget(
+
+    final hasRecentFillExtrusionWorkingSet = recentFillExtrusionBufferBytes > 0;
+    if (hasRecentFillExtrusionWorkingSet) {
+      _lastFillExtrusionRecentUseFrame = _frame;
+    }
+    final fillExtrusionTargetBudgetBytes =
+        gpuFillExtrusionBudgetForWorkingSetBytes(
+          recentFillExtrusionBufferBytes,
+        );
+    _fillExtrusionBudgetBytes = gpuFillExtrusionBudgetWithHysteresis(
+      currentBudgetBytes: _fillExtrusionBudgetBytes,
+      targetBudgetBytes: fillExtrusionTargetBudgetBytes,
+      hasRecentWorkingSet: hasRecentFillExtrusionWorkingSet,
+      framesSinceRecentUse: _frame - _lastFillExtrusionRecentUseFrame,
+    );
+    if (fillExtrusionBufferBytes > _fillExtrusionBudgetBytes) {
+      fillExtrusionBufferBytes -= _evictBufferBudget(
         _bufferBudgetEntries(isFillExtrusion: true),
-        maxBytes: _gpuFillExtrusionBufferCacheBudgetBytes,
+        maxBytes: _fillExtrusionBudgetBytes,
       );
     }
 
@@ -338,9 +863,32 @@ class GpuResourceCache {
         currentFrame: _frame,
         maxBytes: _gpuTextureCacheBudgetBytes,
       )) {
-        _textureCache.remove(key);
+        final removed = _textureCache.remove(key);
+        if (removed != null) {
+          textureBytes -= removed.lengthInBytes;
+          timingMetrics.recordBudgetEviction(bytes: removed.lengthInBytes);
+          _recordEvictionClass(
+            _budgetEvictionsByClass,
+            _GpuCacheClass.texture,
+            removed.lengthInBytes,
+          );
+        }
       }
     }
+    _budgetDirty =
+        gpuCacheBudgetNeedsRetry(
+          residentBytes: regularBufferBytes,
+          maxBytes: _regularBufferBudgetBytes,
+        ) ||
+        gpuCacheBudgetNeedsRetry(
+          residentBytes: fillExtrusionBufferBytes,
+          maxBytes: _fillExtrusionBudgetBytes,
+        ) ||
+        gpuCacheBudgetNeedsRetry(
+          residentBytes: textureBytes,
+          maxBytes: _gpuTextureCacheBudgetBytes,
+        );
+    _logEvictionClassesIfDue();
   }
 
   Map<_BufferBudgetKey, _BudgetEntry> _bufferBudgetEntries({
@@ -360,29 +908,154 @@ class GpuResourceCache {
         ),
   };
 
-  void _evictBufferBudget(
+  int _evictBufferBudget(
     Map<_BufferBudgetKey, _BudgetEntry> entries, {
     required int maxBytes,
   }) {
+    var removedBytes = 0;
     for (final key in gpuCacheBudgetVictims(
       entries,
       currentFrame: _frame,
       maxBytes: maxBytes,
     )) {
+      GpuBufferEntry? removed;
+      _GpuCacheClass resourceClass;
       switch (key) {
         case _VertexBufferBudgetKey(:final cacheKey):
-          _vertexCache.remove(cacheKey);
+          resourceClass = _gpuCacheClassForShader(cacheKey.shader);
+          removed = _vertexCache.remove(cacheKey);
         case _IndexBufferBudgetKey(:final cacheKey):
-          _indexCache.remove(cacheKey);
+          final existing = _indexCache[cacheKey];
+          resourceClass = existing?.isFillExtrusion == true
+              ? _GpuCacheClass.fillExtrusion
+              : _GpuCacheClass.indexBuffer;
+          removed = _indexCache.remove(cacheKey);
+      }
+      if (removed != null) {
+        removedBytes += removed.lengthInBytes;
+        switch (key) {
+          case _VertexBufferBudgetKey(:final cacheKey):
+            if (removed.isFillExtrusion) {
+              _fillExtrusionVertexMissTracker.recordEviction(
+                key: cacheKey,
+                kind: GpuCacheEvictionKind.budget,
+              );
+            }
+          case _IndexBufferBudgetKey(:final cacheKey):
+            if (removed.isFillExtrusion) {
+              _fillExtrusionIndexMissTracker.recordEviction(
+                key: cacheKey,
+                kind: GpuCacheEvictionKind.budget,
+              );
+            }
+        }
+        removed._releasePooledAllocation(_frame);
+        timingMetrics.recordBudgetEviction(bytes: removed.lengthInBytes);
+        _recordEvictionClass(
+          _budgetEvictionsByClass,
+          resourceClass,
+          removed.lengthInBytes,
+        );
       }
     }
+
+    return removedBytes;
+  }
+
+  void _recordEvictionClass(
+    Map<_GpuCacheClass, _EvictionClassTotals> totals,
+    _GpuCacheClass resourceClass,
+    int bytes,
+  ) {
+    final value = totals.putIfAbsent(resourceClass, _EvictionClassTotals.new);
+    value
+      ..count += 1
+      ..bytes += bytes;
+  }
+
+  void _recordExpiryReason(GpuCacheExpiryReason reason, int bytes) {
+    final value = _expiryEvictionsByReason.putIfAbsent(
+      reason,
+      _EvictionClassTotals.new,
+    );
+    value
+      ..count += 1
+      ..bytes += bytes;
+  }
+
+  void _logEvictionClassesIfDue() {
+    if (_frame - _evictionClassLogFrame < _gpuEvictionClassLogFrames) return;
+    _evictionClassLogFrame = _frame;
+    if (_expiryEvictionsByClass.isEmpty && _budgetEvictionsByClass.isEmpty) {
+      return;
+    }
+
+    String megabytes(int bytes) =>
+        '${(bytes / (1024 * 1024)).toStringAsFixed(1)}MB';
+    String className(_GpuCacheClass resourceClass) => switch (resourceClass) {
+      _GpuCacheClass.line => 'line',
+      _GpuCacheClass.fillExtrusion => 'fe',
+      _GpuCacheClass.other => 'other',
+      _GpuCacheClass.indexBuffer => 'idx',
+      _GpuCacheClass.texture => 'tex',
+    };
+    String describe(Map<_GpuCacheClass, _EvictionClassTotals> totals) {
+      final values = <String>[];
+      for (final resourceClass in _GpuCacheClass.values) {
+        final value = totals[resourceClass];
+        if (value == null || value.count == 0) continue;
+        values.add(
+          '${className(resourceClass)}:${value.count}/${megabytes(value.bytes)}',
+        );
+      }
+      return values.isEmpty ? 'none' : values.join(' ');
+    }
+
+    String describeReasons() {
+      final values = <String>[];
+      for (final reason in GpuCacheExpiryReason.values) {
+        final value = _expiryEvictionsByReason[reason];
+        if (value == null || value.count == 0) continue;
+        final name = switch (reason) {
+          GpuCacheExpiryReason.superseded => 'superseded',
+          GpuCacheExpiryReason.unused => 'age',
+        };
+        values.add('$name:${value.count}/${megabytes(value.bytes)}');
+      }
+      return values.isEmpty ? 'none' : values.join(' ');
+    }
+
+    debugPrint(
+      '[GpuEvictClass] expiry=${describe(_expiryEvictionsByClass)} '
+      'budget=${describe(_budgetEvictionsByClass)} '
+      'reason=${describeReasons()}',
+    );
+    _expiryEvictionsByClass.clear();
+    _budgetEvictionsByClass.clear();
+    _expiryEvictionsByReason.clear();
   }
 
   /// Removes every cached resource reference.
   void dispose() {
+    for (final entry in _vertexCache.values) {
+      entry._releasePooledAllocation(_frame);
+    }
+    for (final entry in _indexCache.values) {
+      entry._releasePooledAllocation(_frame);
+    }
     _vertexCache.clear();
     _indexCache.clear();
     _textureCache.clear();
+    _bufferPool.dispose();
+    _fillExtrusionVertexMissTracker.clear();
+    _fillExtrusionIndexMissTracker.clear();
+    _expiryEvictionsByClass.clear();
+    _budgetEvictionsByClass.clear();
+    _expiryEvictionsByReason.clear();
+    _regularBufferBudgetBytes = _gpuRegularMinBufferCacheBudgetBytes;
+    _lastRegularBufferBudgetGrowthFrame = 0;
+    _fillExtrusionBudgetBytes = _gpuFillExtrusionMinBufferCacheBudgetBytes;
+    _lastFillExtrusionRecentUseFrame = 0;
     _budgetDirty = false;
   }
 }

--- a/lib/src/gpu/resource_metrics.dart
+++ b/lib/src/gpu/resource_metrics.dart
@@ -1,0 +1,497 @@
+import 'package:flutter/foundation.dart';
+
+import '../native/draw_command.dart';
+
+typedef GpuRepackLayoutKey = ({int shader, int sourceStride, int gpuStride});
+
+/// Repack cost attributed to one shader and source/GPU vertex layout pair.
+final class GpuRepackLayoutSnapshot {
+  const GpuRepackLayoutSnapshot({
+    required this.shader,
+    required this.sourceStride,
+    required this.gpuStride,
+    required this.count,
+    required this.micros,
+    required this.maxMicros,
+    required this.inputBytes,
+    required this.outputBytes,
+  });
+
+  final int shader;
+  final int sourceStride;
+  final int gpuStride;
+  final int count;
+  final int micros;
+  final int maxMicros;
+  final int inputBytes;
+  final int outputBytes;
+
+  double get averageMicros => micros / count;
+}
+
+final class _GpuRepackLayoutTotals {
+  int count = 0;
+  int micros = 0;
+  int maxMicros = 0;
+  int inputBytes = 0;
+  int outputBytes = 0;
+}
+
+enum GpuUploadSizeClass { small, medium, large }
+
+/// Classifies one upload by payload size for allocation-cost attribution.
+@visibleForTesting
+GpuUploadSizeClass gpuUploadSizeClassForBytes(int bytes) {
+  if (bytes < 0) {
+    throw RangeError.value(bytes, 'bytes', 'must not be negative');
+  }
+  if (bytes <= 16 * 1024) return GpuUploadSizeClass.small;
+  if (bytes <= 256 * 1024) return GpuUploadSizeClass.medium;
+  return GpuUploadSizeClass.large;
+}
+
+final class _GpuUploadSizeTotals {
+  int count = 0;
+  int micros = 0;
+  int maxMicros = 0;
+  int bytes = 0;
+}
+
+/// Aggregated GPU resource-cache and upload activity for one logging interval.
+final class GpuResourceTimingSnapshot {
+  const GpuResourceTimingSnapshot({
+    required this.vertexCacheHits,
+    required this.vertexCacheMisses,
+    required this.indexCacheHits,
+    required this.indexCacheMisses,
+    required this.textureCacheHits,
+    required this.textureCacheMisses,
+    required this.repackCount,
+    required this.repackMicros,
+    required this.repackMaxMicros,
+    required this.repackLayouts,
+    required this.vertexUploadCount,
+    required this.vertexUploadMicros,
+    required this.vertexUploadBytes,
+    required this.vertexUploadMaxMicros,
+    required this.indexUploadCount,
+    required this.indexUploadMicros,
+    required this.indexUploadBytes,
+    required this.indexUploadMaxMicros,
+    required this.textureUploadCount,
+    required this.textureUploadMicros,
+    required this.textureUploadBytes,
+    required this.textureUploadMaxMicros,
+    required this.frameVertexUploadCount,
+    required this.frameVertexUploadBytes,
+    required this.frameIndexUploadCount,
+    required this.frameIndexUploadBytes,
+    required this.expiryEvictionCount,
+    required this.expiryEvictionBytes,
+    required this.budgetEvictionCount,
+    required this.budgetEvictionBytes,
+  });
+
+  final int vertexCacheHits;
+  final int vertexCacheMisses;
+  final int indexCacheHits;
+  final int indexCacheMisses;
+  final int textureCacheHits;
+  final int textureCacheMisses;
+  final int repackCount;
+  final int repackMicros;
+  final int repackMaxMicros;
+
+  /// Cached-buffer repacks, ordered by total repack time descending.
+  final List<GpuRepackLayoutSnapshot> repackLayouts;
+
+  final int vertexUploadCount;
+  final int vertexUploadMicros;
+  final int vertexUploadBytes;
+  final int vertexUploadMaxMicros;
+  final int indexUploadCount;
+  final int indexUploadMicros;
+  final int indexUploadBytes;
+  final int indexUploadMaxMicros;
+  final int textureUploadCount;
+  final int textureUploadMicros;
+  final int textureUploadBytes;
+  final int textureUploadMaxMicros;
+  final int frameVertexUploadCount;
+  final int frameVertexUploadBytes;
+  final int frameIndexUploadCount;
+  final int frameIndexUploadBytes;
+  final int expiryEvictionCount;
+  final int expiryEvictionBytes;
+  final int budgetEvictionCount;
+  final int budgetEvictionBytes;
+
+  int get vertexLookupCount => vertexCacheHits + vertexCacheMisses;
+  int get indexLookupCount => indexCacheHits + indexCacheMisses;
+  int get textureLookupCount => textureCacheHits + textureCacheMisses;
+
+  double? get averageRepackMicros =>
+      repackCount == 0 ? null : repackMicros / repackCount;
+  double? get averageVertexUploadMicros =>
+      vertexUploadCount == 0 ? null : vertexUploadMicros / vertexUploadCount;
+  double? get averageIndexUploadMicros =>
+      indexUploadCount == 0 ? null : indexUploadMicros / indexUploadCount;
+  double? get averageTextureUploadMicros =>
+      textureUploadCount == 0 ? null : textureUploadMicros / textureUploadCount;
+}
+
+/// Mutable interval counters for GPU resource preparation.
+final class GpuResourceTimingMetrics {
+  int _vertexCacheHits = 0;
+  int _vertexCacheMisses = 0;
+  int _indexCacheHits = 0;
+  int _indexCacheMisses = 0;
+  int _textureCacheHits = 0;
+  int _textureCacheMisses = 0;
+  int _repackCount = 0;
+  int _repackMicros = 0;
+  int _repackMaxMicros = 0;
+  int _vertexUploadCount = 0;
+  int _vertexUploadMicros = 0;
+  int _vertexUploadBytes = 0;
+  int _vertexUploadMaxMicros = 0;
+  int _indexUploadCount = 0;
+  int _indexUploadMicros = 0;
+  int _indexUploadBytes = 0;
+  int _indexUploadMaxMicros = 0;
+  int _textureUploadCount = 0;
+  int _textureUploadMicros = 0;
+  int _textureUploadBytes = 0;
+  int _textureUploadMaxMicros = 0;
+  int _frameVertexUploadCount = 0;
+  int _frameVertexUploadBytes = 0;
+  int _frameIndexUploadCount = 0;
+  int _frameIndexUploadBytes = 0;
+  int _expiryEvictionCount = 0;
+  int _expiryEvictionBytes = 0;
+  int _budgetEvictionCount = 0;
+  int _budgetEvictionBytes = 0;
+  final Map<GpuRepackLayoutKey, _GpuRepackLayoutTotals> _repackLayouts = {};
+  final Map<GpuUploadSizeClass, _GpuUploadSizeTotals> _vertexUploadSizes = {};
+  final Map<GpuUploadSizeClass, _GpuUploadSizeTotals> _indexUploadSizes = {};
+  ({int shader, int sourceStride, int gpuStride, int vertexCount})?
+  _pendingCachedRepack;
+
+  void recordVertexLookup({
+    required bool hit,
+    int? shader,
+    int? sourceStride,
+    int? gpuStride,
+    int? vertexCount,
+  }) {
+    _pendingCachedRepack = null;
+    if (hit) {
+      _vertexCacheHits += 1;
+    } else {
+      _vertexCacheMisses += 1;
+      if (shader != null &&
+          sourceStride != null &&
+          gpuStride != null &&
+          vertexCount != null) {
+        _checkNonNegative('sourceStride', sourceStride);
+        _checkNonNegative('gpuStride', gpuStride);
+        _checkNonNegative('vertexCount', vertexCount);
+        _pendingCachedRepack = (
+          shader: shader,
+          sourceStride: sourceStride,
+          gpuStride: gpuStride,
+          vertexCount: vertexCount,
+        );
+      }
+    }
+  }
+
+  void recordIndexLookup({required bool hit}) {
+    if (hit) {
+      _indexCacheHits += 1;
+    } else {
+      _indexCacheMisses += 1;
+    }
+  }
+
+  void recordTextureLookup({required bool hit}) {
+    if (hit) {
+      _textureCacheHits += 1;
+    } else {
+      _textureCacheMisses += 1;
+    }
+  }
+
+  void recordRepack({required int micros}) {
+    _checkNonNegative('micros', micros);
+    _repackCount += 1;
+    _repackMicros += micros;
+    if (micros > _repackMaxMicros) _repackMaxMicros = micros;
+
+    final pending = _pendingCachedRepack;
+    _pendingCachedRepack = null;
+    if (pending == null) return;
+    final key = (
+      shader: pending.shader,
+      sourceStride: pending.sourceStride,
+      gpuStride: pending.gpuStride,
+    );
+    final totals = _repackLayouts.putIfAbsent(key, _GpuRepackLayoutTotals.new);
+    totals
+      ..count += 1
+      ..micros += micros
+      ..inputBytes += pending.vertexCount * pending.sourceStride
+      ..outputBytes += pending.vertexCount * pending.gpuStride;
+    if (micros > totals.maxMicros) totals.maxMicros = micros;
+  }
+
+  void recordVertexUpload({
+    required int micros,
+    required int bytes,
+    bool frameOwned = false,
+  }) {
+    _checkNonNegative('micros', micros);
+    _checkNonNegative('bytes', bytes);
+    _vertexUploadCount += 1;
+    _vertexUploadMicros += micros;
+    _vertexUploadBytes += bytes;
+    if (micros > _vertexUploadMaxMicros) _vertexUploadMaxMicros = micros;
+    _recordUploadSize(_vertexUploadSizes, micros: micros, bytes: bytes);
+    if (frameOwned) {
+      _frameVertexUploadCount += 1;
+      _frameVertexUploadBytes += bytes;
+    }
+  }
+
+  void recordIndexUpload({
+    required int micros,
+    required int bytes,
+    bool frameOwned = false,
+  }) {
+    _checkNonNegative('micros', micros);
+    _checkNonNegative('bytes', bytes);
+    _indexUploadCount += 1;
+    _indexUploadMicros += micros;
+    _indexUploadBytes += bytes;
+    if (micros > _indexUploadMaxMicros) _indexUploadMaxMicros = micros;
+    _recordUploadSize(_indexUploadSizes, micros: micros, bytes: bytes);
+    if (frameOwned) {
+      _frameIndexUploadCount += 1;
+      _frameIndexUploadBytes += bytes;
+    }
+  }
+
+  void recordTextureUpload({required int micros, required int bytes}) {
+    _checkNonNegative('micros', micros);
+    _checkNonNegative('bytes', bytes);
+    _textureUploadCount += 1;
+    _textureUploadMicros += micros;
+    _textureUploadBytes += bytes;
+    if (micros > _textureUploadMaxMicros) _textureUploadMaxMicros = micros;
+  }
+
+  void recordExpiryEvictions({required int count, required int bytes}) {
+    _checkNonNegative('count', count);
+    _checkNonNegative('bytes', bytes);
+    _expiryEvictionCount += count;
+    _expiryEvictionBytes += bytes;
+  }
+
+  void recordBudgetEviction({required int bytes}) {
+    _checkNonNegative('bytes', bytes);
+    _budgetEvictionCount += 1;
+    _budgetEvictionBytes += bytes;
+  }
+
+  GpuResourceTimingSnapshot takeSnapshotAndReset() {
+    final repackLayouts =
+        _repackLayouts.entries
+            .map(
+              (entry) => GpuRepackLayoutSnapshot(
+                shader: entry.key.shader,
+                sourceStride: entry.key.sourceStride,
+                gpuStride: entry.key.gpuStride,
+                count: entry.value.count,
+                micros: entry.value.micros,
+                maxMicros: entry.value.maxMicros,
+                inputBytes: entry.value.inputBytes,
+                outputBytes: entry.value.outputBytes,
+              ),
+            )
+            .toList(growable: false)
+          ..sort((left, right) => right.micros.compareTo(left.micros));
+    final snapshot = GpuResourceTimingSnapshot(
+      vertexCacheHits: _vertexCacheHits,
+      vertexCacheMisses: _vertexCacheMisses,
+      indexCacheHits: _indexCacheHits,
+      indexCacheMisses: _indexCacheMisses,
+      textureCacheHits: _textureCacheHits,
+      textureCacheMisses: _textureCacheMisses,
+      repackCount: _repackCount,
+      repackMicros: _repackMicros,
+      repackMaxMicros: _repackMaxMicros,
+      repackLayouts: List<GpuRepackLayoutSnapshot>.unmodifiable(repackLayouts),
+      vertexUploadCount: _vertexUploadCount,
+      vertexUploadMicros: _vertexUploadMicros,
+      vertexUploadBytes: _vertexUploadBytes,
+      vertexUploadMaxMicros: _vertexUploadMaxMicros,
+      indexUploadCount: _indexUploadCount,
+      indexUploadMicros: _indexUploadMicros,
+      indexUploadBytes: _indexUploadBytes,
+      indexUploadMaxMicros: _indexUploadMaxMicros,
+      textureUploadCount: _textureUploadCount,
+      textureUploadMicros: _textureUploadMicros,
+      textureUploadBytes: _textureUploadBytes,
+      textureUploadMaxMicros: _textureUploadMaxMicros,
+      frameVertexUploadCount: _frameVertexUploadCount,
+      frameVertexUploadBytes: _frameVertexUploadBytes,
+      frameIndexUploadCount: _frameIndexUploadCount,
+      frameIndexUploadBytes: _frameIndexUploadBytes,
+      expiryEvictionCount: _expiryEvictionCount,
+      expiryEvictionBytes: _expiryEvictionBytes,
+      budgetEvictionCount: _budgetEvictionCount,
+      budgetEvictionBytes: _budgetEvictionBytes,
+    );
+    _logRepackLayouts(snapshot.repackLayouts);
+    _logUploadSizes(_vertexUploadSizes, _indexUploadSizes);
+    _vertexCacheHits = 0;
+    _vertexCacheMisses = 0;
+    _indexCacheHits = 0;
+    _indexCacheMisses = 0;
+    _textureCacheHits = 0;
+    _textureCacheMisses = 0;
+    _repackCount = 0;
+    _repackMicros = 0;
+    _repackMaxMicros = 0;
+    _vertexUploadCount = 0;
+    _vertexUploadMicros = 0;
+    _vertexUploadBytes = 0;
+    _vertexUploadMaxMicros = 0;
+    _indexUploadCount = 0;
+    _indexUploadMicros = 0;
+    _indexUploadBytes = 0;
+    _indexUploadMaxMicros = 0;
+    _textureUploadCount = 0;
+    _textureUploadMicros = 0;
+    _textureUploadBytes = 0;
+    _textureUploadMaxMicros = 0;
+    _frameVertexUploadCount = 0;
+    _frameVertexUploadBytes = 0;
+    _frameIndexUploadCount = 0;
+    _frameIndexUploadBytes = 0;
+    _expiryEvictionCount = 0;
+    _expiryEvictionBytes = 0;
+    _budgetEvictionCount = 0;
+    _budgetEvictionBytes = 0;
+    _repackLayouts.clear();
+    _vertexUploadSizes.clear();
+    _indexUploadSizes.clear();
+    _pendingCachedRepack = null;
+
+    return snapshot;
+  }
+
+  static void _recordUploadSize(
+    Map<GpuUploadSizeClass, _GpuUploadSizeTotals> totals, {
+    required int micros,
+    required int bytes,
+  }) {
+    final value = totals.putIfAbsent(
+      gpuUploadSizeClassForBytes(bytes),
+      _GpuUploadSizeTotals.new,
+    );
+    value
+      ..count += 1
+      ..micros += micros
+      ..bytes += bytes;
+    if (micros > value.maxMicros) value.maxMicros = micros;
+  }
+
+  static void _checkNonNegative(String name, int value) {
+    if (value < 0) {
+      throw RangeError.value(value, name, 'must not be negative');
+    }
+  }
+}
+
+void _logRepackLayouts(List<GpuRepackLayoutSnapshot> layouts) {
+  if (layouts.isEmpty) {
+    debugPrint('[GpuRepack] none');
+    return;
+  }
+
+  String megabytes(int bytes) =>
+      '${(bytes / (1024 * 1024)).toStringAsFixed(1)}MB';
+  final values = layouts
+      .take(6)
+      .map((layout) {
+        final name = _shaderName(layout.shader);
+        final average = layout.averageMicros.toStringAsFixed(0);
+        return '$name[${layout.sourceStride}>${layout.gpuStride}]='
+            '${layout.count}/${megabytes(layout.inputBytes)}>'
+            '${megabytes(layout.outputBytes)}/${average}us/${layout.maxMicros}us';
+      })
+      .join(' ');
+  final omitted = layouts.length > 6 ? ' +${layouts.length - 6}more' : '';
+  debugPrint('[GpuRepack] $values$omitted');
+}
+
+void _logUploadSizes(
+  Map<GpuUploadSizeClass, _GpuUploadSizeTotals> vertex,
+  Map<GpuUploadSizeClass, _GpuUploadSizeTotals> index,
+) {
+  if (vertex.isEmpty && index.isEmpty) {
+    debugPrint('[GpuUploadSize] none');
+    return;
+  }
+
+  String megabytes(int bytes) =>
+      '${(bytes / (1024 * 1024)).toStringAsFixed(1)}MB';
+  String className(GpuUploadSizeClass sizeClass) => switch (sizeClass) {
+    GpuUploadSizeClass.small => '<=16K',
+    GpuUploadSizeClass.medium => '<=256K',
+    GpuUploadSizeClass.large => '>256K',
+  };
+  String describe(
+    String prefix,
+    Map<GpuUploadSizeClass, _GpuUploadSizeTotals> totals,
+  ) {
+    final values = <String>[];
+    for (final sizeClass in GpuUploadSizeClass.values) {
+      final value = totals[sizeClass];
+      if (value == null || value.count == 0) continue;
+      final average = (value.micros / value.count).toStringAsFixed(0);
+      values.add(
+        '$prefix${className(sizeClass)}=${value.count}/'
+        '${megabytes(value.bytes)}/${value.micros}us/${average}us/'
+        '${value.maxMicros}us',
+      );
+    }
+    return values.join(' ');
+  }
+
+  final vertexText = describe('v', vertex);
+  final indexText = describe('i', index);
+  final values = [
+    vertexText,
+    indexText,
+  ].where((value) => value.isNotEmpty).join(' ');
+  debugPrint('[GpuUploadSize] $values');
+}
+
+String _shaderName(int shader) => switch (shader) {
+  ShaderType.fill => 'fill',
+  ShaderType.fillOutline => 'fillOutline',
+  ShaderType.line => 'line',
+  ShaderType.background => 'background',
+  ShaderType.fillExtrusion => 'fillExtrusion',
+  ShaderType.lineSDF => 'lineSDF',
+  ShaderType.lineGradient => 'lineGradient',
+  ShaderType.linePattern => 'linePattern',
+  ShaderType.circle => 'circle',
+  ShaderType.raster => 'raster',
+  ShaderType.fillOutlineTriangulated => 'fillOutlineTri',
+  ShaderType.clippingMask => 'clippingMask',
+  ShaderType.backgroundPattern => 'backgroundPattern',
+  _ => 'shader$shader',
+};

--- a/lib/src/gpu/resource_miss_tracker.dart
+++ b/lib/src/gpu/resource_miss_tracker.dart
@@ -1,0 +1,204 @@
+import 'package:flutter/foundation.dart';
+
+/// Why a cache-owned GPU buffer had to be uploaded again.
+enum GpuCacheMissReason {
+  /// This resource ID has never been observed before.
+  newBuffer,
+
+  /// The same resource ID was observed with a different content version.
+  versionChange,
+
+  /// The resource ID/version pair is unchanged, but another key field changed.
+  ///
+  /// For vertices this includes native address, vertex count, or layout fields.
+  /// For indices this normally means the native address changed. Tracking this
+  /// separately exposes geometry-identity churn that a larger cache cannot fix.
+  identityChange,
+
+  /// The exact cache key was evicted by expiry and later requested again.
+  expiryRevisit,
+
+  /// The exact cache key was evicted by the byte budget and later requested again.
+  budgetRevisit,
+}
+
+enum GpuCacheEvictionKind { expiry, budget }
+
+/// One interval total for a cache-miss cause.
+final class GpuCacheMissSnapshot {
+  const GpuCacheMissSnapshot({
+    required this.reason,
+    required this.count,
+    required this.bytes,
+  });
+
+  final GpuCacheMissReason reason;
+  final int count;
+  final int bytes;
+}
+
+final class _GpuCacheMissTotals {
+  int count = 0;
+  int bytes = 0;
+}
+
+const _gpuIdentityChangeSampleLimit = 4;
+
+/// Bounded identity history used to classify cache misses without retaining GPU
+/// resources or native memory.
+final class GpuCacheMissTracker<K> {
+  GpuCacheMissTracker({
+    required this.idOf,
+    required this.versionOf,
+    this.historyLimit = 8192,
+  }) {
+    if (historyLimit <= 0) {
+      throw RangeError.value(historyLimit, 'historyLimit', 'must be positive');
+    }
+  }
+
+  final int Function(K key) idOf;
+  final int Function(K key) versionOf;
+  final int historyLimit;
+
+  final Map<int, K> _lastSeenKeys = <int, K>{};
+  final Map<K, GpuCacheEvictionKind> _evictedKeys = <K, GpuCacheEvictionKind>{};
+  final Set<K> _pendingMisses = <K>{};
+  final Map<GpuCacheMissReason, _GpuCacheMissTotals> _totals =
+      <GpuCacheMissReason, _GpuCacheMissTotals>{};
+  int _identityChangeSamplesLogged = 0;
+
+  /// Records one lookup. A miss is classified later, when its uploaded byte
+  /// size is known at [recordStore].
+  void recordLookup({required K key, required bool hit}) {
+    if (hit) {
+      _rememberKey(idOf(key), key);
+      return;
+    }
+    _pendingMisses.remove(key);
+    _pendingMisses.add(key);
+    while (_pendingMisses.length > historyLimit) {
+      _pendingMisses.remove(_pendingMisses.first);
+    }
+  }
+
+  /// Completes a pending miss after upload/store.
+  ///
+  /// [classify] is false for lookups that share this tracker temporarily but do
+  /// not belong to the resource class being diagnosed.
+  void recordStore({
+    required K key,
+    required int bytes,
+    required bool classify,
+  }) {
+    if (bytes < 0) {
+      throw RangeError.value(bytes, 'bytes', 'must not be negative');
+    }
+    if (!_pendingMisses.remove(key)) return;
+    if (!classify) return;
+
+    final id = idOf(key);
+    final version = versionOf(key);
+    final eviction = _evictedKeys.remove(key);
+    final previousKey = _lastSeenKeys[id];
+    final previousVersion = previousKey == null ? null : versionOf(previousKey);
+    final reason = switch (eviction) {
+      GpuCacheEvictionKind.expiry => GpuCacheMissReason.expiryRevisit,
+      GpuCacheEvictionKind.budget => GpuCacheMissReason.budgetRevisit,
+      null when previousVersion == null => GpuCacheMissReason.newBuffer,
+      null when previousVersion != version => GpuCacheMissReason.versionChange,
+      null => GpuCacheMissReason.identityChange,
+    };
+
+    if (reason == GpuCacheMissReason.identityChange &&
+        previousKey != null &&
+        _identityChangeSamplesLogged < _gpuIdentityChangeSampleLimit) {
+      _identityChangeSamplesLogged += 1;
+      debugPrint(
+        '[GpuIdentityChange] id=$id version=$version '
+        'previous=$previousKey current=$key',
+      );
+    }
+
+    final totals = _totals.putIfAbsent(reason, _GpuCacheMissTotals.new);
+    totals
+      ..count += 1
+      ..bytes += bytes;
+    _rememberKey(id, key);
+  }
+
+  /// Remembers that [key] left the cache so an exact later reappearance can be
+  /// distinguished from native identity/version churn.
+  void recordEviction({required K key, required GpuCacheEvictionKind kind}) {
+    _evictedKeys.remove(key);
+    _evictedKeys[key] = kind;
+    _trimMap(_evictedKeys);
+  }
+
+  /// Returns interval totals while retaining bounded identity history.
+  List<GpuCacheMissSnapshot> takeSnapshotAndReset() {
+    final snapshots = <GpuCacheMissSnapshot>[
+      for (final reason in GpuCacheMissReason.values)
+        if ((_totals[reason]?.count ?? 0) > 0)
+          GpuCacheMissSnapshot(
+            reason: reason,
+            count: _totals[reason]!.count,
+            bytes: _totals[reason]!.bytes,
+          ),
+    ];
+    _totals.clear();
+    _identityChangeSamplesLogged = 0;
+    return List<GpuCacheMissSnapshot>.unmodifiable(snapshots);
+  }
+
+  void clear() {
+    _lastSeenKeys.clear();
+    _evictedKeys.clear();
+    _pendingMisses.clear();
+    _totals.clear();
+    _identityChangeSamplesLogged = 0;
+  }
+
+  void _rememberKey(int id, K key) {
+    _lastSeenKeys.remove(id);
+    _lastSeenKeys[id] = key;
+    _trimMap(_lastSeenKeys);
+  }
+
+  void _trimMap<K2, V2>(Map<K2, V2> values) {
+    while (values.length > historyLimit) {
+      values.remove(values.keys.first);
+    }
+  }
+}
+
+/// Emits one compact breakdown of fill-extrusion cache misses.
+void logGpuFillExtrusionMissClasses({
+  required List<GpuCacheMissSnapshot> vertex,
+  required List<GpuCacheMissSnapshot> index,
+}) {
+  if (vertex.isEmpty && index.isEmpty) {
+    debugPrint('[GpuMissClass] none');
+    return;
+  }
+
+  String megabytes(int bytes) =>
+      '${(bytes / (1024 * 1024)).toStringAsFixed(1)}MB';
+  String name(GpuCacheMissReason reason) => switch (reason) {
+    GpuCacheMissReason.newBuffer => 'new',
+    GpuCacheMissReason.versionChange => 'version',
+    GpuCacheMissReason.identityChange => 'identity',
+    GpuCacheMissReason.expiryRevisit => 'expiry',
+    GpuCacheMissReason.budgetRevisit => 'budget',
+  };
+  String describe(List<GpuCacheMissSnapshot> values) => values.isEmpty
+      ? 'none'
+      : values
+            .map(
+              (value) =>
+                  '${name(value.reason)}:${value.count}/${megabytes(value.bytes)}',
+            )
+            .join(' ');
+
+  debugPrint('[GpuMissClass] feV=${describe(vertex)} feI=${describe(index)}');
+}

--- a/native/scripts/package_darwin.sh
+++ b/native/scripts/package_darwin.sh
@@ -24,6 +24,42 @@ case "${MODE}" in
         ;;
 esac
 
+verify_fill_extrusion_transport() {
+    local bridge_source="${NATIVE_ROOT}/src/bridge_merge.cpp"
+    local draw_flags="${PROJECT_ROOT}/lib/src/frame/draw_flags.dart"
+    local pipeline_key="${PROJECT_ROOT}/lib/src/frame/pipeline_key.dart"
+    local shader_manifest="${PROJECT_ROOT}/shaders/MapShaders.shaderbundle.json"
+    local packed_color_shader="${PROJECT_ROOT}/shaders/fill_extrusion_dd_packed_color.vert"
+
+    local forbidden_markers=(
+        'kFillExtrusionPackedColorGpuStride'
+        'kFillExtrusionPackedColorGpuReadyFlag'
+        '[GpuNativeFE]'
+        'fillExtrusionPackedColorGpuReady'
+        'fillExtrusionPackedColorDataDriven'
+        'FillExtrusionDDPackedColorVertex'
+    )
+    local marker
+    for marker in "${forbidden_markers[@]}"; do
+        if grep -Fq "${marker}" \
+            "${bridge_source}" \
+            "${draw_flags}" \
+            "${pipeline_key}" \
+            "${shader_manifest}"; then
+            echo "error: deprecated 36-byte fill-extrusion transport is still present: ${marker}" >&2
+            echo "Restore the 44-byte packed fill-extrusion transport before packaging." >&2
+            exit 1
+        fi
+    done
+
+    if [[ -e "${packed_color_shader}" ]]; then
+        echo "error: deprecated packed-color fill-extrusion shader is still present: ${packed_color_shader}" >&2
+        exit 1
+    fi
+}
+
+verify_fill_extrusion_transport
+
 IOS_PACKAGE_ROOT="${PROJECT_ROOT}/build-ios-fluttergpu-package"
 MACOS_PACKAGE_ROOT="${PROJECT_ROOT}/build-macos-fluttergpu-package"
 HEADERS="${DARWIN_PACKAGE_ROOT}/Headers"
@@ -96,5 +132,10 @@ if [[ "${slice_count}" != "${expected_slice_count}" ]]; then
     echo "error: XCFramework contains ${slice_count} library slices instead of ${expected_slice_count}" >&2
     exit 1
 fi
+
+# The binary target stays at one local path. Touching the package manifest after
+# replacing the XCFramework forces Xcode/SwiftPM to reevaluate that local package
+# instead of reusing a previously resolved binary artifact.
+touch "${DARWIN_PACKAGE_ROOT}/Package.swift"
 
 echo "Built ${OUTPUT}"

--- a/native/src/bridge_merge.cpp
+++ b/native/src/bridge_merge.cpp
@@ -7,8 +7,12 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
+#include <functional>
+#include <limits>
 #include <map>
+#include <optional>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 static uint64_t fnv(const void* d, size_t n) {
@@ -27,9 +31,111 @@ struct MergedVertex {
         return x == other.x && y == other.y;
     }
 };
+
+// Content-addressed fill-extrusion identities are cached by the native source
+// generation so steady frames never rescan large 44-byte vertex streams. A
+// recreated Drawable/bucket gets a different source key and is hashed once;
+// identical final bytes reproduce the same exported GPU identity.
+struct FillExtrusionContentSourceKey {
+    uint32_t bufferId;
+    uint32_t bufferVersion;
+    const void* vertexData;
+    uint32_t vertexCount;
+    uint32_t vertexStride;
+    const void* indexData;
+    uint32_t indexCount;
+    uint32_t layerIndex;
+
+    bool operator<(const FillExtrusionContentSourceKey& other) const {
+        if (bufferId != other.bufferId) return bufferId < other.bufferId;
+        if (bufferVersion != other.bufferVersion) return bufferVersion < other.bufferVersion;
+        if (vertexData != other.vertexData) {
+            return std::less<const void*>{}(vertexData, other.vertexData);
+        }
+        if (vertexCount != other.vertexCount) return vertexCount < other.vertexCount;
+        if (vertexStride != other.vertexStride) return vertexStride < other.vertexStride;
+        if (indexData != other.indexData) {
+            return std::less<const void*>{}(indexData, other.indexData);
+        }
+        if (indexCount != other.indexCount) return indexCount < other.indexCount;
+        return layerIndex < other.layerIndex;
+    }
+};
+
+struct FillExtrusionHashFingerprint {
+    uint64_t first = 0;
+    uint64_t second = 0;
+
+    bool operator<(const FillExtrusionHashFingerprint& other) const {
+        if (first != other.first) return first < other.first;
+        return second < other.second;
+    }
+};
+
+struct FillExtrusionContentIdentity {
+    uint32_t bufferId = 0;
+    uint32_t bufferVersion = 0;
+    uint64_t lastUsedFrame = 0;
+    FillExtrusionHashFingerprint structuralFingerprint;
+    FillExtrusionHashFingerprint contentFingerprint;
+};
+
+struct FillExtrusionContentVersion {
+    uint32_t version = 0;
+    uint64_t lastUsedFrame = 0;
+};
+
+struct FillExtrusionStructuralIdentity {
+    uint32_t bufferId = 0;
+    uint64_t lastUsedFrame = 0;
+    std::map<FillExtrusionHashFingerprint, FillExtrusionContentVersion> contentVersions;
+    std::map<uint32_t, FillExtrusionHashFingerprint> versionContents;
+};
+
+// Data-driven line vertices keep the bridge-expanded 120-byte layout for now.
+// Constant line-family vertices remain in Command Export's packed 8-byte
+// layout and are decoded directly by the Flutter GPU vertex shaders.
+struct LineGpuKey {
+    uint32_t bufferId;
+    uint32_t bufferVersion;
+    const void* vertexData;
+    uint32_t vertexCount;
+    uint32_t vertexStride;
+
+    bool operator<(const LineGpuKey& other) const {
+        if (bufferId != other.bufferId) return bufferId < other.bufferId;
+        if (bufferVersion != other.bufferVersion) return bufferVersion < other.bufferVersion;
+        if (vertexData != other.vertexData) {
+            return std::less<const void*>{}(vertexData, other.vertexData);
+        }
+        if (vertexCount != other.vertexCount) return vertexCount < other.vertexCount;
+        return vertexStride < other.vertexStride;
+    }
+};
+
+struct PreparedLineVertices {
+    std::vector<uint8_t> bytes;
+    uint64_t lastUsedFrame = 0;
+};
+
+// GPU-ready bridge line segments use stable IDs so Dart can retain device
+// buffers when bridge-expanded native storage moves within the same generation.
+struct PreparedBufferIds {
+    std::vector<uint32_t> segmentIds;
+    uint64_t lastUsedFrame = 0;
+};
+
 struct MergeSessionState {
     std::vector<std::vector<uint16_t>> indices;
     std::vector<std::vector<MergedVertex>> vertices;
+    std::map<FillExtrusionContentSourceKey, FillExtrusionContentIdentity> fillExtrusionContentIdentities;
+    std::map<FillExtrusionHashFingerprint, FillExtrusionStructuralIdentity>
+        fillExtrusionStructuralIdentities;
+    std::map<uint32_t, FillExtrusionHashFingerprint> fillExtrusionStructuralIds;
+    std::map<LineGpuKey, PreparedLineVertices> lineGpuVertices;
+    std::map<uint32_t, PreparedBufferIds> preparedBufferIds;
+    uint32_t nextPreparedBufferId = 1;
+    uint64_t frame = 0;
 };
 
 static std::map<void*, MergeSessionState> g_mergeSessions;
@@ -45,9 +151,432 @@ void bridge_releaseMergeSession(void* session) {
 #define g_mergedVertices mergeSession().vertices
 
 void bridge_resetMergeStorage() {
-    g_mergedIndices.clear();
-    g_mergedVertices.clear();
+    auto& session = mergeSession();
+    session.indices.clear();
+    session.vertices.clear();
+    ++session.frame;
 }
+
+namespace {
+constexpr uint32_t kFillExtrusionConstantStride = 12;
+constexpr uint32_t kFillExtrusionPackedStride = 44;
+constexpr uint32_t kLinePackedStride = 8;
+constexpr uint32_t kLineDataDrivenPackedStride = 88;
+constexpr uint32_t kLineGpuStride = 24;
+constexpr uint32_t kLineDataDrivenGpuStride = 120;
+// Bridge-only transport bits. command_export currently owns bits 0..23. Dart
+// treats these only as vertex-layout markers and never forwards them to a
+// shader-facing data-driven mask.
+constexpr uint32_t kLineGpuReadyFlag = 1u << 25;
+constexpr uint64_t kFillExtrusionContentSourceRetentionFrames = 120;
+constexpr uint64_t kFillExtrusionIdentityRetentionFrames = 1800;
+constexpr uint64_t kLineGpuRetentionFrames = 60;
+constexpr uint64_t kPreparedBufferIdRetentionFrames = 600;
+constexpr size_t kLineGpuCacheBudgetBytes = 64 * 1024 * 1024;
+constexpr uint32_t kPreparedBufferIdNamespace = 0x80000000u;
+constexpr uint32_t kPreparedBufferIdValueMask = 0x7fffffffu;
+constexpr uint32_t kContentAddressedFillExtrusionNamespace = 0xC0000000u;
+constexpr uint32_t kContentAddressedFillExtrusionValueMask = 0x3fffffffu;
+static_assert(sizeof(float) == 4);
+static_assert(sizeof(int16_t) == 2);
+static_assert(sizeof(uint16_t) == 2);
+
+struct ContentHashState {
+    uint64_t first;
+    uint64_t second;
+};
+
+uint64_t rotateLeft64(uint64_t value, unsigned shift) {
+    return (value << shift) | (value >> (64u - shift));
+}
+
+uint64_t avalanche64(uint64_t value) {
+    value ^= value >> 30;
+    value *= 0xbf58476d1ce4e5b9ULL;
+    value ^= value >> 27;
+    value *= 0x94d049bb133111ebULL;
+    value ^= value >> 31;
+    return value;
+}
+
+void hashBytes(ContentHashState& state, const void* data, size_t size) {
+    const auto* bytes = static_cast<const uint8_t*>(data);
+    size_t offset = 0;
+    while (offset + sizeof(uint64_t) <= size) {
+        uint64_t word;
+        std::memcpy(&word, bytes + offset, sizeof(word));
+        state.first ^= avalanche64(word + 0x517cc1b727220a95ULL);
+        state.first = rotateLeft64(state.first, 27) * 0x9e3779b185ebca87ULL;
+        state.second ^= avalanche64(word + 0x94d049bb133111ebULL);
+        state.second = rotateLeft64(state.second, 31) * 0xc2b2ae3d27d4eb4fULL;
+        offset += sizeof(uint64_t);
+    }
+    if (offset < size) {
+        uint64_t tail = 0;
+        std::memcpy(&tail, bytes + offset, size - offset);
+        state.first ^= avalanche64(tail + 0x27d4eb2f165667c5ULL);
+        state.second ^= avalanche64(tail + 0x165667b19e3779f9ULL);
+    }
+    state.first = avalanche64(state.first ^ static_cast<uint64_t>(size));
+    state.second = avalanche64(state.second ^ (static_cast<uint64_t>(size) << 1));
+}
+
+FillExtrusionHashFingerprint fingerprintFor(const ContentHashState& state) {
+    return {
+        avalanche64(state.first ^ rotateLeft64(state.second, 23)),
+        avalanche64(state.second ^ rotateLeft64(state.first, 37)),
+    };
+}
+
+uint32_t fillExtrusionBufferIdFor(
+    MergeSessionState& session,
+    const FillExtrusionHashFingerprint& fingerprint) {
+    const auto found = session.fillExtrusionStructuralIdentities.find(fingerprint);
+    if (found != session.fillExtrusionStructuralIdentities.end()) {
+        found->second.lastUsedFrame = session.frame;
+        return found->second.bufferId;
+    }
+
+    uint64_t candidate = avalanche64(fingerprint.first ^ rotateLeft64(fingerprint.second, 17));
+    while (true) {
+        uint32_t value = static_cast<uint32_t>(candidate) & kContentAddressedFillExtrusionValueMask;
+        if (value == 0) value = 1;
+        const uint32_t bufferId = kContentAddressedFillExtrusionNamespace | value;
+        const auto occupied = session.fillExtrusionStructuralIds.find(bufferId);
+        if (occupied == session.fillExtrusionStructuralIds.end()) {
+            FillExtrusionStructuralIdentity identity;
+            identity.bufferId = bufferId;
+            identity.lastUsedFrame = session.frame;
+            session.fillExtrusionStructuralIdentities.emplace(fingerprint, std::move(identity));
+            session.fillExtrusionStructuralIds.emplace(bufferId, fingerprint);
+            return bufferId;
+        }
+        if (!(fingerprint < occupied->second) && !(occupied->second < fingerprint)) {
+            return bufferId;
+        }
+        candidate = avalanche64(candidate + 0x9e3779b97f4a7c15ULL);
+    }
+}
+
+uint32_t fillExtrusionBufferVersionFor(
+    MergeSessionState& session,
+    const FillExtrusionHashFingerprint& structuralFingerprint,
+    const FillExtrusionHashFingerprint& contentFingerprint) {
+    auto& structural = session.fillExtrusionStructuralIdentities.at(structuralFingerprint);
+    structural.lastUsedFrame = session.frame;
+    const auto found = structural.contentVersions.find(contentFingerprint);
+    if (found != structural.contentVersions.end()) {
+        found->second.lastUsedFrame = session.frame;
+        return found->second.version;
+    }
+
+    uint64_t candidate = avalanche64(contentFingerprint.first ^ rotateLeft64(contentFingerprint.second, 29));
+    while (true) {
+        uint32_t version = static_cast<uint32_t>(candidate ^ (candidate >> 32));
+        if (version == 0) version = 1;
+        const auto occupied = structural.versionContents.find(version);
+        if (occupied == structural.versionContents.end()) {
+            structural.contentVersions.emplace(
+                contentFingerprint,
+                FillExtrusionContentVersion{version, session.frame});
+            structural.versionContents.emplace(version, contentFingerprint);
+            return version;
+        }
+        if (!(contentFingerprint < occupied->second) && !(occupied->second < contentFingerprint)) {
+            return version;
+        }
+        candidate = avalanche64(candidate + 0xc2b2ae3d27d4eb4fULL);
+    }
+}
+
+std::optional<FillExtrusionContentIdentity> fillExtrusionContentIdentityFor(
+    MergeSessionState& session,
+    const mbgl::command_export::DrawCommand& command) {
+    if (!command.vertexData || !command.indexData || command.vertexCount == 0 || command.indexCount == 0 ||
+        command.vertexStride == 0 ||
+        command.vertexCount > std::numeric_limits<size_t>::max() / command.vertexStride ||
+        command.indexCount > std::numeric_limits<size_t>::max() / sizeof(uint16_t)) {
+        return std::nullopt;
+    }
+
+    const FillExtrusionContentSourceKey sourceKey{
+        command.bufferId,
+        command.bufferVersion,
+        command.vertexData,
+        command.vertexCount,
+        command.vertexStride,
+        command.indexData,
+        command.indexCount,
+        command.layerIndex,
+    };
+    const auto found = session.fillExtrusionContentIdentities.find(sourceKey);
+    if (found != session.fillExtrusionContentIdentities.end()) {
+        found->second.lastUsedFrame = session.frame;
+        const auto structural =
+            session.fillExtrusionStructuralIdentities.find(found->second.structuralFingerprint);
+        if (structural != session.fillExtrusionStructuralIdentities.end()) {
+            structural->second.lastUsedFrame = session.frame;
+            const auto content =
+                structural->second.contentVersions.find(found->second.contentFingerprint);
+            if (content != structural->second.contentVersions.end()) {
+                content->second.lastUsedFrame = session.frame;
+            }
+        }
+        return found->second;
+    }
+
+    const size_t vertexBytes = static_cast<size_t>(command.vertexCount) * command.vertexStride;
+    const size_t indexBytes = static_cast<size_t>(command.indexCount) * sizeof(uint16_t);
+
+    // bufferId is structural: it intentionally excludes FE paint ranges so a
+    // feature-state/paint update remains the same resource ID with a new
+    // generation. Index topology plus counts/layer are stable across recreated
+    // buckets for the same geometry.
+    ContentHashState structural{
+        0x243f6a8885a308d3ULL ^ static_cast<uint64_t>(command.vertexCount),
+        0x13198a2e03707344ULL ^ static_cast<uint64_t>(command.indexCount),
+    };
+    hashBytes(structural, command.indexData, indexBytes);
+    structural.first ^= static_cast<uint64_t>(command.vertexStride) << 32;
+    structural.second ^= static_cast<uint64_t>(command.layerIndex) << 24;
+    const auto structuralFingerprint = fingerprintFor(structural);
+
+    // bufferVersion is content-addressed from the exact GPU vertex/index bytes.
+    // Recreated native allocations therefore reproduce the same generation,
+    // while any geometry or data-driven paint mutation changes it.
+    ContentHashState content{
+        0xa4093822299f31d0ULL ^ static_cast<uint64_t>(vertexBytes),
+        0x082efa98ec4e6c89ULL ^ static_cast<uint64_t>(indexBytes),
+    };
+    hashBytes(content, command.vertexData, vertexBytes);
+    hashBytes(content, command.indexData, indexBytes);
+    content.first ^= static_cast<uint64_t>(command.vertexStride) << 40;
+    content.second ^= static_cast<uint64_t>(command.vertexCount) << 16;
+    const auto contentFingerprint = fingerprintFor(content);
+    const uint32_t bufferId = fillExtrusionBufferIdFor(session, structuralFingerprint);
+    const uint32_t version =
+        fillExtrusionBufferVersionFor(session, structuralFingerprint, contentFingerprint);
+
+    FillExtrusionContentIdentity identity{
+        bufferId,
+        version,
+        session.frame,
+        structuralFingerprint,
+        contentFingerprint,
+    };
+    session.fillExtrusionContentIdentities.emplace(sourceKey, identity);
+    return identity;
+}
+
+void trimFillExtrusionContentIdentities(MergeSessionState& session) {
+    for (auto it = session.fillExtrusionContentIdentities.begin();
+         it != session.fillExtrusionContentIdentities.end();) {
+        const auto age = session.frame - it->second.lastUsedFrame;
+        if (it->second.lastUsedFrame != session.frame && age >= kFillExtrusionContentSourceRetentionFrames) {
+            it = session.fillExtrusionContentIdentities.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    for (auto it = session.fillExtrusionStructuralIdentities.begin();
+         it != session.fillExtrusionStructuralIdentities.end();) {
+        const auto age = session.frame - it->second.lastUsedFrame;
+        if (it->second.lastUsedFrame != session.frame &&
+            age >= kFillExtrusionIdentityRetentionFrames) {
+            session.fillExtrusionStructuralIds.erase(it->second.bufferId);
+            it = session.fillExtrusionStructuralIdentities.erase(it);
+        } else {
+            auto& structural = it->second;
+            for (auto content = structural.contentVersions.begin();
+                 content != structural.contentVersions.end();) {
+                const auto contentAge = session.frame - content->second.lastUsedFrame;
+                if (content->second.lastUsedFrame != session.frame &&
+                    contentAge >= kFillExtrusionIdentityRetentionFrames) {
+                    structural.versionContents.erase(content->second.version);
+                    content = structural.contentVersions.erase(content);
+                } else {
+                    ++content;
+                }
+            }
+            ++it;
+        }
+    }
+}
+
+uint32_t preparedBufferIdFor(MergeSessionState& session,
+                             uint32_t sourceBufferId,
+                             uint32_t segmentOrdinal) {
+    auto& prepared = session.preparedBufferIds[sourceBufferId];
+    prepared.lastUsedFrame = session.frame;
+    while (prepared.segmentIds.size() <= segmentOrdinal) {
+        uint32_t value = session.nextPreparedBufferId++ & kPreparedBufferIdValueMask;
+        if (value == 0) {
+            value = session.nextPreparedBufferId++ & kPreparedBufferIdValueMask;
+        }
+        prepared.segmentIds.push_back(kPreparedBufferIdNamespace | value);
+    }
+    return prepared.segmentIds[segmentOrdinal];
+}
+
+void trimPreparedBufferIds(MergeSessionState& session) {
+    for (auto it = session.preparedBufferIds.begin(); it != session.preparedBufferIds.end();) {
+        const auto age = session.frame - it->second.lastUsedFrame;
+        if (it->second.lastUsedFrame != session.frame && age >= kPreparedBufferIdRetentionFrames) {
+            it = session.preparedBufferIds.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+// Fill-extrusion bytes already match Flutter GPU's 12-byte constant or 44-byte
+// data-driven layout. Give them a content-addressed identity instead of a
+// Drawable/allocation identity, without changing the DrawCommand ABI.
+void assignPackedFillExtrusionBufferIds(
+    std::vector<mbgl::command_export::DrawCommand>& commands) {
+    using namespace mbgl::command_export;
+    auto& session = mergeSession();
+    for (auto& command : commands) {
+        if (command.shaderType != ShaderType::FillExtrusion ||
+            (command.vertexStride != kFillExtrusionConstantStride &&
+             command.vertexStride != kFillExtrusionPackedStride)) {
+            continue;
+        }
+        const auto identity = fillExtrusionContentIdentityFor(session, command);
+        if (!identity) continue;
+        command.bufferId = identity->bufferId;
+        command.bufferVersion = identity->bufferVersion;
+    }
+    trimFillExtrusionContentIdentities(session);
+}
+
+bool isLineShader(mbgl::command_export::ShaderType shader) {
+    using mbgl::command_export::ShaderType;
+    return shader == ShaderType::Line || shader == ShaderType::LineSDF ||
+           shader == ShaderType::LineGradient || shader == ShaderType::LinePattern;
+}
+
+bool expandLineVertices(const mbgl::command_export::DrawCommand& command,
+                        std::vector<uint8_t>& output) {
+    using namespace mbgl::command_export;
+    const bool dataDriven = (command.flags & DrawCommandFlags::LineDataDrivenMask) != 0;
+    const uint32_t sourceStride = dataDriven ? kLineDataDrivenPackedStride : kLinePackedStride;
+    const uint32_t targetStride = dataDriven ? kLineDataDrivenGpuStride : kLineGpuStride;
+    if (!command.vertexData || command.vertexCount == 0 || command.vertexStride != sourceStride ||
+        command.vertexCount > std::numeric_limits<size_t>::max() / targetStride) {
+        return false;
+    }
+
+    const auto* source = static_cast<const uint8_t*>(command.vertexData);
+    output.resize(static_cast<size_t>(command.vertexCount) * targetStride);
+    for (uint32_t vertex = 0; vertex < command.vertexCount; ++vertex) {
+        const auto* src = source + static_cast<size_t>(vertex) * sourceStride;
+        auto* dst = output.data() + static_cast<size_t>(vertex) * targetStride;
+
+        int16_t position[2];
+        std::memcpy(position, src, sizeof(position));
+        const float layout[6] = {
+            static_cast<float>(position[0]),
+            static_cast<float>(position[1]),
+            static_cast<float>(src[4]),
+            static_cast<float>(src[5]),
+            static_cast<float>(src[6]),
+            static_cast<float>(src[7]),
+        };
+        std::memcpy(dst, layout, sizeof(layout));
+
+        if (!dataDriven) continue;
+        std::memcpy(dst + 24, src + 8, 64);
+
+        uint16_t patternFrom[4];
+        uint16_t patternTo[4];
+        std::memcpy(patternFrom, src + 72, sizeof(patternFrom));
+        std::memcpy(patternTo, src + 80, sizeof(patternTo));
+        const float pattern[8] = {
+            static_cast<float>(patternFrom[0]),
+            static_cast<float>(patternFrom[1]),
+            static_cast<float>(patternFrom[2]),
+            static_cast<float>(patternFrom[3]),
+            static_cast<float>(patternTo[0]),
+            static_cast<float>(patternTo[1]),
+            static_cast<float>(patternTo[2]),
+            static_cast<float>(patternTo[3]),
+        };
+        std::memcpy(dst + 88, pattern, sizeof(pattern));
+    }
+    return true;
+}
+
+void trimLineGpuCache(MergeSessionState& session) {
+    size_t totalBytes = 0;
+    for (auto it = session.lineGpuVertices.begin(); it != session.lineGpuVertices.end();) {
+        const auto age = session.frame - it->second.lastUsedFrame;
+        if (it->second.lastUsedFrame != session.frame && age >= kLineGpuRetentionFrames) {
+            it = session.lineGpuVertices.erase(it);
+        } else {
+            totalBytes += it->second.bytes.size();
+            ++it;
+        }
+    }
+
+    while (totalBytes > kLineGpuCacheBudgetBytes) {
+        auto victim = session.lineGpuVertices.end();
+        for (auto it = session.lineGpuVertices.begin(); it != session.lineGpuVertices.end(); ++it) {
+            if (it->second.lastUsedFrame == session.frame) continue;
+            if (victim == session.lineGpuVertices.end() ||
+                it->second.lastUsedFrame < victim->second.lastUsedFrame) {
+                victim = it;
+            }
+        }
+        if (victim == session.lineGpuVertices.end()) break;
+        totalBytes -= victim->second.bytes.size();
+        session.lineGpuVertices.erase(victim);
+    }
+}
+
+void prepareLineGpuVertices(std::vector<mbgl::command_export::DrawCommand>& commands) {
+    using namespace mbgl::command_export;
+    auto& session = mergeSession();
+    std::unordered_map<uint32_t, uint32_t> segmentOrdinals;
+    for (auto& command : commands) {
+        if (!isLineShader(command.shaderType) || !command.vertexData || command.vertexCount == 0) {
+            continue;
+        }
+
+        const bool dataDriven = (command.flags & DrawCommandFlags::LineDataDrivenMask) != 0;
+        if (!dataDriven) continue;
+        const uint32_t sourceStride = kLineDataDrivenPackedStride;
+        const uint32_t targetStride = kLineDataDrivenGpuStride;
+        if (command.vertexStride != sourceStride) continue;
+
+        const uint32_t sourceBufferId = command.bufferId;
+        const uint32_t segmentOrdinal = segmentOrdinals[sourceBufferId]++;
+        const LineGpuKey key{
+            sourceBufferId,
+            command.bufferVersion,
+            command.vertexData,
+            command.vertexCount,
+            command.vertexStride,
+        };
+        auto it = session.lineGpuVertices.find(key);
+        if (it == session.lineGpuVertices.end()) {
+            PreparedLineVertices prepared;
+            if (!expandLineVertices(command, prepared.bytes)) continue;
+            prepared.lastUsedFrame = session.frame;
+            it = session.lineGpuVertices.emplace(key, std::move(prepared)).first;
+        } else {
+            it->second.lastUsedFrame = session.frame;
+        }
+
+        command.bufferId = preparedBufferIdFor(session, sourceBufferId, segmentOrdinal);
+        command.vertexData = it->second.bytes.data();
+        command.vertexStride = targetStride;
+        command.flags |= kLineGpuReadyFlag;
+    }
+    trimLineGpuCache(session);
+    trimPreparedBufferIds(session);
+}
+} // namespace
 
 void bridge_mergeCommands(mbgl::command_export::FrameData& fd) {
     using namespace mbgl::command_export;
@@ -77,14 +606,13 @@ void bridge_mergeCommands(mbgl::command_export::FrameData& fd) {
 
     if (commands.empty()) return;
 
+    // Fill-extrusion keeps its native packed bytes but receives a deterministic
+    // content identity. Only DD line vertices still use bridge-side expansion.
+    assignPackedFillExtrusionBufferIds(commands);
+    prepareLineGpuVertices(commands);
+
     if (commands.size() <= 1) return;
 
-    // Stencil clear/mask/test/replace operations form one ordered command
-    // stream. Sorting individual commands can move a consumer away from the
-    // mask setup it depends on (notably across opaque/translucent invocations
-    // of the same style layer). Keep MapLibre's native emission order whenever
-    // that stream is present. Frames without stencil retain the established
-    // layer/sublayer ordering.
     const bool hasOrderedStencil = std::any_of(commands.begin(), commands.end(), [](const DrawCommand& command) {
         return command.stencilMode != StencilModeType::Disabled;
     });
@@ -127,7 +655,6 @@ void bridge_mergeCommands(mbgl::command_export::FrameData& fd) {
     std::vector<DrawCommand> result;
     result.reserve(commands.size());
 
-    // Expand vertices: transform by matrix, quantize NDC, export float2.
     auto expandVertices = [](const DrawCommand& cmd, std::vector<MergedVertex>& verts) {
         const float* mat = reinterpret_cast<const float*>(cmd.drawableUBO);
         const auto* src = static_cast<const uint8_t*>(cmd.vertexData);
@@ -140,10 +667,6 @@ void bridge_mergeCommands(mbgl::command_export::FrameData& fd) {
             float cy = mat[1]*fx + mat[5]*fy + mat[13];
             float cw = mat[3]*fx + mat[7]*fy + mat[15];
             if (cw != 0.0f) { cx /= cw; cy /= cw; }
-            // Signed symmetric quantization: 8192 steps per NDC unit (2x the
-            // precision of the old biased 4096). Store the quantized values
-            // as floats so Dart can upload them without per-frame repacking.
-            // +0.5/-0.5 rounds instead of truncating.
             int16_t ox = static_cast<int16_t>(std::clamp(cx * 8192.0f + (cx >= 0 ? 0.5f : -0.5f), -32767.0f, 32767.0f));
             int16_t oy = static_cast<int16_t>(std::clamp(cy * 8192.0f + (cy >= 0 ? 0.5f : -0.5f), -32767.0f, 32767.0f));
             verts.push_back({
@@ -153,10 +676,6 @@ void bridge_mergeCommands(mbgl::command_export::FrameData& fd) {
         }
     };
 
-    // Pass 1: Build groups by
-    // (layerIndex, subLayerIndex, shaderType, propsUBO hash).
-    // Hash/compare the actual propsUBOSize (clamped to the embedded buffer)
-    // so commands with different UBO sizes never merge.
     std::unordered_map<GK, std::vector<size_t>, GKH> groups;
     for (size_t ci = 0; ci < commands.size(); ci++) {
         auto& cmd = commands[ci];
@@ -165,9 +684,6 @@ void bridge_mergeCommands(mbgl::command_export::FrameData& fd) {
         } else if (cmd.shaderType != ShaderType::Background) {
             continue;
         }
-        // A merged draw has only one stencil reference, while tile-clipped
-        // commands carry one reference per source tile. Mask, test, 3D write,
-        // and clear commands are all ordering barriers and never merge.
         if (cmd.stencilMode != StencilModeType::Disabled) continue;
         if ((cmd.flags & depthFlags) != 0) continue;
         const uint32_t pn = std::min<uint32_t>(cmd.propsUBOSize, sizeof(cmd.propsUBO));
@@ -190,9 +706,7 @@ void bridge_mergeCommands(mbgl::command_export::FrameData& fd) {
         groups[key] = {ci};
     }
 
-    // Pass 2: For multi-command groups, expand vertices and build merged VB+IB
     std::vector<bool> consumed(commands.size(), false);
-    // Map: first cmd index -> list of (vi, ii, vCount) sub-batches
     struct SubBatch { size_t vi, ii; uint32_t vCount; };
     std::unordered_map<size_t, std::vector<SubBatch>> mergedBatches;
 
@@ -205,7 +719,6 @@ void bridge_mergeCommands(mbgl::command_export::FrameData& fd) {
 
     for (auto& [key, idxs] : groups) {
         if (idxs.size() <= 1) continue;
-        // Mark all but first as consumed
         for (size_t i = 1; i < idxs.size(); i++) consumed[idxs[i]] = true;
 
         auto& subs = mergedBatches[idxs[0]];
@@ -226,8 +739,6 @@ void bridge_mergeCommands(mbgl::command_export::FrameData& fd) {
                 bv = 0;
             }
             expandVertices(cmd, g_mergedVertices[vi]);
-            // Append indices, skipping degenerate triangles
-            // (where 2+ vertices collapsed to same int16 position)
             auto& vb = g_mergedVertices[vi];
             auto& ib = g_mergedIndices[ii];
             uint32_t base = bv;
@@ -235,7 +746,6 @@ void bridge_mergeCommands(mbgl::command_export::FrameData& fd) {
                 uint32_t i0 = cmd.indexData[i] + base;
                 uint32_t i1 = cmd.indexData[i+1] + base;
                 uint32_t i2 = cmd.indexData[i+2] + base;
-                // Skip if any two vertices have same packed position
                 if (vb[i0] == vb[i1] || vb[i1] == vb[i2] || vb[i0] == vb[i2])
                     continue;
                 ib.push_back(static_cast<uint16_t>(i0));
@@ -247,7 +757,6 @@ void bridge_mergeCommands(mbgl::command_export::FrameData& fd) {
         if (bv > 0) subs.push_back({vi, ii, bv});
     }
 
-    // Pass 3: Emit commands in order, replacing merged groups
     for (size_t ci = 0; ci < commands.size(); ci++) {
         if (consumed[ci]) continue;
         auto mIt = mergedBatches.find(ci);

--- a/shaders/MapShaders.shaderbundle.json
+++ b/shaders/MapShaders.shaderbundle.json
@@ -43,6 +43,14 @@
     "type": "vertex",
     "file": "fill_extrusion.vert"
   },
+  "FillExtrusionDDVertex": {
+    "type": "vertex",
+    "file": "fill_extrusion_dd.vert"
+  },
+  "FillExtrusionExpandedDDVertex": {
+    "type": "vertex",
+    "file": "fill_extrusion_dd_expanded.vert"
+  },
   "FillExtrusionFragment": {
     "type": "fragment",
     "file": "fill_extrusion.frag"
@@ -162,9 +170,5 @@
   "RasterFragment": {
     "type": "fragment",
     "file": "raster.frag"
-  },
-  "FillExtrusionDDVertex": {
-    "type": "vertex",
-    "file": "fill_extrusion_dd.vert"
   }
 }

--- a/shaders/fill.vert
+++ b/shaders/fill.vert
@@ -1,4 +1,5 @@
-// MapLibre Fill vertex shader - packed short2 as single uint
+// MapLibre Fill vertex shader. Dart expands the packed short2 position to
+// numeric floats so every Impeller backend can bind it.
 #version 460 core
 
 layout(location = 0) in vec2 a_pos;

--- a/shaders/fill_dd.vert
+++ b/shaders/fill_dd.vert
@@ -1,7 +1,5 @@
 // MapLibre Fill vertex shader - independently data-driven color/opacity.
-// Vertex: short2(pos) + float4(packed color range) + float2(opacity range)
-// = 28 bytes, normalized by the C++ exporter. Source-function values are
-// duplicated into both stops; composite-function values retain both stops.
+// Dart expands the packed short2 position before the paint ranges.
 #version 460 core
 
 layout(location = 0) in vec2 a_pos;

--- a/shaders/fill_extrusion.vert
+++ b/shaders/fill_extrusion.vert
@@ -1,10 +1,8 @@
 // Fill extrusion vertex shader - 3D buildings (layer-constant base/height).
-// Vertex: short2(pos) + ushort2(decimals_ed) + short2(normal2d) = 12 bytes.
-// Dart expands these to six floats while preserving signedness.
+// Dart expands short2(pos), ushort2(decimals_ed), and short2(normal2d) to
+// numeric floats so every Impeller backend can bind them.
 #version 460 core
 
-// Expanded attributes: [pos_x, pos_y] and
-// [packed_decimals, edge_distance, normal_x, normal_y].
 layout(location = 0) in vec2 a_pos;
 layout(location = 1) in vec4 a_decimals_ed_normal;
 
@@ -43,6 +41,7 @@ vec2 unpack_float(const float packed_value) {
 }
 
 void main() {
+    vec2 a_decimals_ed = a_decimals_ed_normal.xy;
     vec2 normal2d = a_decimals_ed_normal.zw / 16384.0;
     vec3 normal = vec3(
         normal2d,
@@ -53,9 +52,8 @@ void main() {
     float height = max(0.0, props.height);
     vec4 color = props.color;
 
-    float t = mod(a_decimals_ed_normal.x, 2.0);
-    vec2 decimals =
-        unpack_float(floor(a_decimals_ed_normal.x / 2.0)) / 128.0;
+    float t = mod(a_decimals_ed.x, 2.0);
+    vec2 decimals = unpack_float(floor(a_decimals_ed.x / 2.0)) / 128.0;
 
     gl_Position =
         drawable.matrix * vec4(a_pos + decimals, t > 0.0 ? height : base, 1.0);

--- a/shaders/fill_extrusion_dd_expanded.vert
+++ b/shaders/fill_extrusion_dd_expanded.vert
@@ -1,5 +1,7 @@
-// Fill extrusion vertex shader - data-driven base/height/color variant.
-// Dart expands the compact layout prefix while retaining the paint ranges.
+// Legacy bridge-expanded fill-extrusion DD vertex shader.
+// Older packaged native artifacts may still mark bit24 and export the 56-byte
+// float layout. Keep this shader only for that compatibility path; new native
+// builds leave the original 44-byte Command Export layout packed.
 #version 460 core
 
 layout(location = 0) in vec2 a_pos;
@@ -37,8 +39,6 @@ layout(binding = 1) uniform FillExtrusionPropsUBO {
 
 out vec4 v_color;
 
-// Exact port of MapLibre's unpack_float/decode_color helpers. Paint binders
-// encode premultiplied RG and BA byte pairs as exactly representable floats.
 vec2 unpack_float(const float packed_value) {
     int packed_int_value = int(packed_value);
     int v0 = packed_int_value / 256;
@@ -53,7 +53,6 @@ vec4 decode_color(const vec2 encoded_color) {
 }
 
 void main() {
-    vec2 a_decimals_ed = a_decimals_ed_normal.xy;
     vec2 normal2d = a_decimals_ed_normal.zw / 16384.0;
     vec3 normal = vec3(
         normal2d,
@@ -71,28 +70,23 @@ void main() {
         color = props.color;
     }
 
-    float t = mod(a_decimals_ed.x, 2.0);
-    vec2 decimals = unpack_float(floor(a_decimals_ed.x / 2.0)) / 128.0;
+    float t = mod(a_decimals_ed_normal.x, 2.0);
+    vec2 decimals =
+        unpack_float(floor(a_decimals_ed_normal.x / 2.0)) / 128.0;
 
     gl_Position =
         drawable.matrix * vec4(a_pos + decimals, t > 0.0 ? height : base, 1.0);
 
-    // Relative luminance of the surface color
     float colorvalue = color.r * 0.2126 + color.g * 0.7152 + color.b * 0.0722;
-
     v_color = vec4(0.0, 0.0, 0.0, 1.0);
-
-    // Slight ambient so no extrusion is totally black
     vec4 ambientlight = vec4(0.03, 0.03, 0.03, 1.0);
     color += ambientlight;
 
-    // cos(theta) between surface normal and light ray
     float directional = clamp(dot(normal, props.light_pos_base.xyz), 0.0, 1.0);
     directional = mix((1.0 - props.light_intensity),
                       max((1.0 - colorvalue + props.light_intensity), 1.0),
                       directional);
 
-    // Vertical gradient along side surfaces
     if (normal.z == 0.0) {
         directional *= (
             (1.0 - props.vertical_gradient) +

--- a/shaders/fill_outline_triangulated.vert
+++ b/shaders/fill_outline_triangulated.vert
@@ -1,6 +1,6 @@
 // MapLibre triangulated fill outline. Flutter GPU has no configurable native
-// line width, so the outline is expanded into triangles. The fragment shader
-// applies the OpenGL fill-outline coverage curve in physical-pixel space.
+// line width, so the outline is expanded into triangles. Dart expands the
+// packed position, normal, and extrusion data to numeric floats.
 #version 460 core
 
 #define scale 0.015873016
@@ -26,6 +26,7 @@ out vec2 v_normal;
 out float v_width;
 out float v_gamma_scale;
 out float v_dpr;
+
 void main() {
     float dpr = max(u_device_pixel_ratio, 0.000001);
     float antialiasing = 0.5 / dpr;

--- a/shaders/fill_outline_triangulated_dd.vert
+++ b/shaders/fill_outline_triangulated_dd.vert
@@ -1,6 +1,6 @@
 // MapLibre triangulated fill outline with independently data-driven
-// outline-color and opacity. The first 8 bytes retain LineLayoutVertex;
-// normalized source/composite paint ranges follow at offsets 8 and 24.
+// outline-color and opacity. Dart expands the packed layout prefix before the
+// normalized source and composite paint ranges.
 #version 460 core
 
 #define scale 0.015873016

--- a/shaders/line.vert
+++ b/shaders/line.vert
@@ -1,7 +1,6 @@
 // MapLibre Line vertex shader — full port of the upstream line shader:
 // honors line-width, line-gap-width and line-offset from the evaluated
-// props UBO (the old version only supported a constant width override).
-// Packed vertex data as uvec2: short2 pos_normal + uchar4 data (zero-copy).
+// props UBO. Dart expands packed LineLayoutVertex fields to numeric floats.
 #version 460 core
 
 #define scale 0.015873016
@@ -12,16 +11,12 @@ layout(location = 1) in vec4 a_data;
 layout(binding = 0) uniform LineDrawableUBO {
     mat4 u_matrix;
     float u_ratio;
-    // Interpolation factors (unused: per-feature paint attributes are not
-    // exported by the Command Export backend)
     float u_color_t;
     float u_blur_t;
     float u_opacity_t;
     float u_gapwidth_t;
     float u_offset_t;
     float u_width_t;
-    // pad1 in LineDrawableUBO — patched by the Dart renderer with the
-    // actual device pixel ratio (antialiasing width depends on it)
     float u_device_pixel_ratio;
 };
 
@@ -36,8 +31,6 @@ layout(binding = 1) uniform LineEvaluatedPropsUBO {
     float props_pad1, props_pad2;
 };
 
-// MapLibre's GlobalPaintParamsUBO values needed for perspective-correct
-// antialiasing. Dart derives these from the physical target size and DPR.
 layout(binding = 3) uniform MapGlobalUBO {
     vec2 u_units_to_pixels;
     vec2 u_world_size;
@@ -47,6 +40,7 @@ out vec2 v_normal;
 out vec2 v_width2;
 out float v_gamma_scale;
 out float v_dpr;
+
 void main() {
     float dpr = max(u_device_pixel_ratio, 0.000001);
     float ANTIALIASING = 1.0 / dpr / 2.0;
@@ -55,8 +49,6 @@ void main() {
     float a_direction = mod(a_data.z, 4.0) - 1.0;
 
     vec2 pos = floor(a_pos_normal * 0.5);
-
-    // x is 1 for round caps, y is 1 if the normal points up (LSB-encoded)
     vec2 normal = a_pos_normal - 2.0 * pos;
     normal.y = normal.y * 2.0 - 1.0;
     v_normal = normal;
@@ -68,11 +60,8 @@ void main() {
     float inset = gapwidth + (gapwidth > 0.0 ? ANTIALIASING : 0.0);
     float outset = gapwidth + halfwidth * (gapwidth > 0.0 ? 2.0 : 1.0) +
                    (halfwidth == 0.0 ? 0.0 : ANTIALIASING);
-
-    // Scale the extrusion vector to the line width of this vertex
     vec2 dist = outset * a_extrude * scale;
 
-    // Sideways offset (line-offset); rotate for round end caps
     float u = 0.5 * a_direction;
     float t = 1.0 - abs(u);
     vec2 offset2 = offset * a_extrude * scale * normal.y * mat2(t, -u, u, t);
@@ -80,14 +69,11 @@ void main() {
     vec4 projected_extrude = u_matrix * vec4(dist / u_ratio, 0.0, 0.0);
     gl_Position = u_matrix * vec4(pos + offset2 / u_ratio, 0.0, 1.0) + projected_extrude;
 
-    // Match MapLibre's perspective correction: pitched lines need a wider or
-    // narrower antialiasing ramp when projection squashes their extrusion.
     float extrude_length_without_perspective = length(dist);
     float extrude_length_with_perspective =
         length(projected_extrude.xy / gl_Position.w * u_units_to_pixels);
     v_gamma_scale = extrude_length_without_perspective /
                     extrude_length_with_perspective;
     v_dpr = dpr;
-
     v_width2 = vec2(outset, inset);
 }

--- a/shaders/line_gradient.vert
+++ b/shaders/line_gradient.vert
@@ -1,5 +1,4 @@
-// MapLibre LineGradient vertex shader (line-gradient) — port of the
-// upstream line_gradient shader. Samples a 256x1 color ramp texture.
+// MapLibre LineGradient vertex shader. Dart expands packed vertex fields.
 #version 460 core
 
 #define scale 0.015873016
@@ -11,14 +10,12 @@ layout(location = 1) in vec4 a_data;
 layout(binding = 0) uniform LineGradientDrawableUBO {
     mat4 u_matrix;
     float u_ratio;
-    // Interpolation factors (unused)
     float u_blur_t;
     float u_opacity_t;
     float u_gapwidth_t;
     float u_offset_t;
     float u_width_t;
     float drawable_pad1;
-    // pad2 — patched by the Dart renderer with the device pixel ratio
     float u_device_pixel_ratio;
 };
 
@@ -43,14 +40,13 @@ out vec2 v_width2;
 out float v_lineprogress;
 out float v_gamma_scale;
 out float v_dpr;
+
 void main() {
     float dpr = max(u_device_pixel_ratio, 0.000001);
     float ANTIALIASING = 1.0 / dpr / 2.0;
 
     vec2 a_extrude = a_data.xy - 128.0;
     float a_direction = mod(a_data.z, 4.0) - 1.0;
-    // Line progress normalized to [0, 1] (upstream uses *2.0/MAX_LINE_DISTANCE
-    // with LINE_DISTANCE_SCALE folded in)
     v_lineprogress = (floor(a_data.z / 4.0) + a_data.w * 64.0) * 2.0 / MAX_LINE_DISTANCE;
 
     vec2 pos = floor(a_pos_normal * 0.5);
@@ -65,7 +61,6 @@ void main() {
     float inset = gapwidth + (gapwidth > 0.0 ? ANTIALIASING : 0.0);
     float outset = gapwidth + halfwidth * (gapwidth > 0.0 ? 2.0 : 1.0) +
                    (halfwidth == 0.0 ? 0.0 : ANTIALIASING);
-
     vec2 dist = outset * a_extrude * scale;
 
     float u = 0.5 * a_direction;
@@ -81,6 +76,5 @@ void main() {
     v_gamma_scale = extrude_length_without_perspective /
                     extrude_length_with_perspective;
     v_dpr = dpr;
-
     v_width2 = vec2(outset, inset);
 }

--- a/shaders/line_pattern.vert
+++ b/shaders/line_pattern.vert
@@ -1,5 +1,4 @@
-// MapLibre LinePattern vertex shader (line-pattern) — port of the upstream
-// line_pattern shader. Samples the tile icon atlas exported from C++.
+// MapLibre LinePattern vertex shader. Dart expands packed vertex fields.
 #version 460 core
 
 #define scale 0.015873016
@@ -11,7 +10,6 @@ layout(location = 1) in vec4 a_data;
 layout(binding = 0) uniform LinePatternDrawableUBO {
     mat4 u_matrix;
     float u_ratio;
-    // Interpolation factors (unused)
     float u_blur_t;
     float u_opacity_t;
     float u_gapwidth_t;
@@ -32,8 +30,6 @@ layout(binding = 1) uniform LineEvaluatedPropsUBO {
     float props_pad1, props_pad2;
 };
 
-// scale.x = pixelRatio — used for ANTIALIASING (the drawable UBO has no
-// spare pad for the DPR in the pattern variant)
 layout(binding = 2) uniform LinePatternTilePropsUBO {
     vec4 u_pattern_from;
     vec4 u_pattern_to;
@@ -53,6 +49,7 @@ out vec2 v_width2;
 out float v_linesofar;
 out float v_gamma_scale;
 out float v_dpr;
+
 void main() {
     float dpr = max(u_scale.x, 0.000001);
     float ANTIALIASING = 1.0 / dpr / 2.0;
@@ -73,7 +70,6 @@ void main() {
     float inset = gapwidth + (gapwidth > 0.0 ? ANTIALIASING : 0.0);
     float outset = gapwidth + halfwidth * (gapwidth > 0.0 ? 2.0 : 1.0) +
                    (halfwidth == 0.0 ? 0.0 : ANTIALIASING);
-
     vec2 dist = outset * a_extrude * scale;
 
     float u = 0.5 * a_direction;
@@ -89,6 +85,5 @@ void main() {
     v_gamma_scale = extrude_length_without_perspective /
                     extrude_length_with_perspective;
     v_dpr = dpr;
-
     v_width2 = vec2(outset, inset);
 }

--- a/shaders/line_sdf.vert
+++ b/shaders/line_sdf.vert
@@ -1,6 +1,4 @@
-// MapLibre LineSDF vertex shader (line-dasharray) — port of the upstream
-// line_sdf shader. Samples the dash SDF atlas exported from C++.
-// Vertex layout identical to line.vert (short2 pos_normal + uchar4 data).
+// MapLibre LineSDF vertex shader. Dart expands packed LineLayoutVertex fields.
 #version 460 core
 
 #define scale 0.015873016
@@ -16,7 +14,6 @@ layout(binding = 0) uniform LineSDFDrawableUBO {
     float u_tex_y_a;
     float u_tex_y_b;
     float u_ratio;
-    // Interpolation factors (unused)
     float u_color_t;
     float u_blur_t;
     float u_opacity_t;
@@ -24,7 +21,6 @@ layout(binding = 0) uniform LineSDFDrawableUBO {
     float u_offset_t;
     float u_width_t;
     float u_floorwidth_t;
-    // pad1 — patched by the Dart renderer with the device pixel ratio
     float u_device_pixel_ratio;
     float drawable_pad2;
 };
@@ -51,13 +47,13 @@ out vec2 v_tex_a;
 out vec2 v_tex_b;
 out float v_gamma_scale;
 out float v_dpr;
+
 void main() {
     float dpr = max(u_device_pixel_ratio, 0.000001);
     float ANTIALIASING = 1.0 / dpr / 2.0;
 
     vec2 a_extrude = a_data.xy - 128.0;
     float a_direction = mod(a_data.z, 4.0) - 1.0;
-    // Distance along the line, packed into the upper bits of data.zw
     float a_linesofar = (floor(a_data.z / 4.0) + a_data.w * 64.0) * LINE_DISTANCE_SCALE;
 
     vec2 pos = floor(a_pos_normal * 0.5);
@@ -73,7 +69,6 @@ void main() {
     float inset = gapwidth + (gapwidth > 0.0 ? ANTIALIASING : 0.0);
     float outset = gapwidth + halfwidth * (gapwidth > 0.0 ? 2.0 : 1.0) +
                    (halfwidth == 0.0 ? 0.0 : ANTIALIASING);
-
     vec2 dist = outset * a_extrude * scale;
 
     float u = 0.5 * a_direction;
@@ -94,6 +89,5 @@ void main() {
                    normal.y * u_patternscale_a.y + u_tex_y_a);
     v_tex_b = vec2(a_linesofar * u_patternscale_b.x / floorwidth,
                    normal.y * u_patternscale_b.y + u_tex_y_b);
-
     v_width2 = vec2(outset, inset);
 }

--- a/test/command_layout_test.dart
+++ b/test/command_layout_test.dart
@@ -36,6 +36,7 @@ void main() {
       expect(stride(ShaderType.raster), 8);
       expect(stride(ShaderType.background), 4);
       expect(stride(ShaderType.backgroundPattern), 4);
+      expect(gpuVertexStride(ShaderType.background, 0), 8);
       expect(stride(ShaderType.fillOutline), 4);
       expect(stride(ShaderType.clippingMask), 4);
     });
@@ -53,6 +54,14 @@ void main() {
         44,
       );
       expect(
+        stride(
+          ShaderType.fillExtrusion,
+          DrawCommandFlags.fillExtrusionDataDriven |
+              DrawCommandFlags.fillExtrusionGpuReady,
+        ),
+        56,
+      );
+      expect(
         stride(ShaderType.circle, DrawCommandFlags.circleColorDataDriven),
         76,
       );
@@ -67,9 +76,6 @@ void main() {
     });
 
     test('merged geometry overrides every shader layout', () {
-      // Native rewrites merged batches into a bare float2 regardless of what
-      // the shader's own vertices look like, so the merged flag must win even
-      // against a data-driven layout.
       for (final shader in _allShaders) {
         expect(
           nativeVertexStride(
@@ -85,9 +91,7 @@ void main() {
       }
     });
 
-    test('is the stride the renderer validates the export against', () {
-      // Both sides of the comparison must agree for an untouched command:
-      // repacking is skipped exactly when they are already equal.
+    test('only GPU-ready native layouts match GPU strides', () {
       expect(
         nativeVertexStride(
           shader: ShaderType.fill,
@@ -95,6 +99,34 @@ void main() {
           merged: true,
         ),
         gpuVertexStride(ShaderType.fill, DrawCommandFlags.crossTileMerged),
+      );
+      expect(
+        nativeVertexStride(
+          shader: ShaderType.fillExtrusion,
+          flags: 0,
+          merged: false,
+        ),
+        lessThan(gpuVertexStride(ShaderType.fillExtrusion, 0)),
+      );
+      const packedExtrusion = DrawCommandFlags.fillExtrusionDataDriven;
+      expect(
+        nativeVertexStride(
+          shader: ShaderType.fillExtrusion,
+          flags: packedExtrusion,
+          merged: false,
+        ),
+        lessThan(gpuVertexStride(ShaderType.fillExtrusion, packedExtrusion)),
+      );
+      const expandedExtrusion =
+          DrawCommandFlags.fillExtrusionDataDriven |
+          DrawCommandFlags.fillExtrusionGpuReady;
+      expect(
+        nativeVertexStride(
+          shader: ShaderType.fillExtrusion,
+          flags: expandedExtrusion,
+          merged: false,
+        ),
+        gpuVertexStride(ShaderType.fillExtrusion, expandedExtrusion),
       );
     });
   });
@@ -122,9 +154,6 @@ void main() {
     });
 
     test('only raster and pattern quads need texture bytes to exist', () {
-      // The asymmetry is deliberate: a line variant that exports no texture is
-      // simply an untextured line, while a raster quad without an image is a
-      // hole. Pin it so the two rules are not accidentally merged.
       expect(shaderRequiresTextureData(ShaderType.raster), isTrue);
       expect(shaderRequiresTextureData(ShaderType.backgroundPattern), isTrue);
       expect(shaderRequiresTextureData(ShaderType.lineSDF), isFalse);

--- a/test/draw_flags_test.dart
+++ b/test/draw_flags_test.dart
@@ -3,10 +3,9 @@ import 'package:maplibre_flutter_gpu/src/native/draw_command.dart';
 import 'package:maplibre_flutter_gpu/src/frame/draw_flags.dart';
 
 void main() {
-  // Each bit is a contract with command_export::DrawCommand::Flags. A wrong
-  // value here does not fail to compile and does not throw — it silently
-  // selects the wrong pipeline or vertex stride. Pin every one.
-  test('flag bits match the native DrawCommand ABI', () {
+  // Bits 0..23 are a contract with command_export::DrawCommand::Flags. Bits
+  // 24..25 are owned by the parent bridge as transport-only GPU-ready markers.
+  test('flag bits match the native and bridge contracts', () {
     expect(DrawCommandFlags.crossTileMerged, 1 << 0);
     expect(DrawCommandFlags.fillExtrusionDataDriven, 1 << 1);
     expect(DrawCommandFlags.fillColorDataDriven, 1 << 2);
@@ -31,6 +30,8 @@ void main() {
     expect(DrawCommandFlags.fillOutlineOpacityDataDriven, 1 << 21);
     expect(DrawCommandFlags.depthTest, 1 << 22);
     expect(DrawCommandFlags.depthWrite, 1 << 23);
+    expect(DrawCommandFlags.fillExtrusionGpuReady, 1 << 24);
+    expect(DrawCommandFlags.lineGpuReady, 1 << 25);
   });
 
   test('group masks cover exactly their group members', () {
@@ -106,7 +107,9 @@ void main() {
     const everythingElse =
         DrawCommandFlags.crossTileMerged |
         DrawCommandFlags.depthTest |
-        DrawCommandFlags.depthWrite;
+        DrawCommandFlags.depthWrite |
+        DrawCommandFlags.fillExtrusionGpuReady |
+        DrawCommandFlags.lineGpuReady;
     expect(fillUsesDataDrivenPipeline(everythingElse), isFalse);
     expect(fillOutlineUsesDataDrivenPipeline(everythingElse), isFalse);
     expect(circleUsesDataDrivenPipeline(everythingElse), isFalse);
@@ -130,10 +133,24 @@ void main() {
       fillExtrusionVertexStride(DrawCommandFlags.fillExtrusionDataDriven),
       44,
     );
+    expect(
+      fillExtrusionVertexStride(
+        DrawCommandFlags.fillExtrusionDataDriven |
+            DrawCommandFlags.fillExtrusionGpuReady,
+      ),
+      56,
+    );
     expect(circleVertexStride(0), 4);
     expect(circleVertexStride(DrawCommandFlags.circleColorDataDriven), 76);
     expect(lineVertexStride(0), 8);
+    expect(lineVertexStride(DrawCommandFlags.lineGpuReady), 24);
     expect(lineVertexStride(DrawCommandFlags.lineColorDataDriven), 88);
+    expect(
+      lineVertexStride(
+        DrawCommandFlags.lineColorDataDriven | DrawCommandFlags.lineGpuReady,
+      ),
+      120,
+    );
   });
 
   test('line family membership matches the four line shaders', () {

--- a/test/fill_data_driven_shader_test.dart
+++ b/test/fill_data_driven_shader_test.dart
@@ -3,15 +3,18 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:maplibre_flutter_gpu/src/frame/draw_flags.dart';
+import 'package:maplibre_flutter_gpu/src/native/draw_command.dart';
 
 void main() {
   test('fill data-driven flags select the fixed 28-byte vertex format', () {
     expect(fillUsesDataDrivenPipeline(0), isFalse);
     expect(fillVertexStride(0), 4);
+    expect(gpuVertexStride(ShaderType.fill, 0), 8);
 
     expect(fillUsesDataDrivenPipeline(1 << 2), isTrue);
     expect(fillDataDrivenMask(1 << 2), 1);
     expect(fillVertexStride(1 << 2), 28);
+    expect(gpuVertexStride(ShaderType.fill, 1 << 2), 32);
 
     expect(fillUsesDataDrivenPipeline(1 << 3), isTrue);
     expect(fillDataDrivenMask(1 << 3), 2);
@@ -19,6 +22,16 @@ void main() {
 
     expect(fillDataDrivenMask((1 << 2) | (1 << 3)), 3);
     expect(fillUsesDataDrivenPipeline(1 << 1), isFalse);
+  });
+
+  test('fill shaders consume numerically expanded positions', () {
+    final fixed = File('shaders/fill.vert').readAsStringSync();
+    final dataDriven = File('shaders/fill_dd.vert').readAsStringSync();
+
+    for (final vertex in [fixed, dataDriven]) {
+      expect(vertex, contains('layout(location = 0) in vec2 a_pos;'));
+      expect(vertex, isNot(contains('floatBitsToUint')));
+    }
   });
 
   test('fill data-driven shader preserves MapLibre paint evaluation', () {

--- a/test/fill_extrusion_data_driven_shader_test.dart
+++ b/test/fill_extrusion_data_driven_shader_test.dart
@@ -9,17 +9,28 @@ import 'package:maplibre_flutter_gpu/src/frame/draw_flags.dart';
 import 'package:maplibre_flutter_gpu/src/frame/ubo_abi.dart';
 
 void main() {
-  test('fill extrusion DD flags select the fixed 44-byte layout', () {
-    expect(fillExtrusionVertexStride(0), 12);
+  test(
+    'fill extrusion DD accepts packed and legacy expanded transport layouts',
+    () {
+      expect(fillExtrusionVertexStride(0), 12);
 
-    const baseOrHeight = 1 << 1;
-    expect(fillExtrusionVertexStride(baseOrHeight), 44);
-    expect(fillExtrusionDataDrivenMask(baseOrHeight), 0);
+      const baseOrHeight = DrawCommandFlags.fillExtrusionDataDriven;
+      expect(fillExtrusionVertexStride(baseOrHeight), 44);
+      expect(fillExtrusionDataDrivenMask(baseOrHeight), 0);
 
-    const color = 1 << 4;
-    expect(fillExtrusionVertexStride(baseOrHeight | color), 44);
-    expect(fillExtrusionDataDrivenMask(baseOrHeight | color), 1);
-  });
+      const color = DrawCommandFlags.fillExtrusionColorDataDriven;
+      expect(fillExtrusionVertexStride(baseOrHeight | color), 44);
+      expect(fillExtrusionDataDrivenMask(baseOrHeight | color), 1);
+
+      const expanded = DrawCommandFlags.fillExtrusionGpuReady;
+      expect(fillExtrusionVertexStride(baseOrHeight | expanded), 56);
+      expect(fillExtrusionVertexStride(baseOrHeight | color | expanded), 56);
+      expect(
+        fillExtrusionUsesExpandedGpuLayout(baseOrHeight | expanded),
+        isTrue,
+      );
+    },
+  );
 
   test('fill extrusion depth prepass follows MapLibre opacity contract', () {
     expect(fillExtrusionNeedsDepthPrepass(0), isTrue);
@@ -34,30 +45,48 @@ void main() {
     ) as Map<String, dynamic>;
     expect(manifest['FillExtrusionDDVertex']['file'], 'fill_extrusion_dd.vert');
     expect(
+      manifest['FillExtrusionExpandedDDVertex']['file'],
+      'fill_extrusion_dd_expanded.vert',
+    );
+    expect(
       manifest['FillExtrusionDepthFragment']['file'],
       'fill_extrusion_depth.frag',
     );
 
     final vertex = File('shaders/fill_extrusion_dd.vert').readAsStringSync();
+    final expanded = File('shaders/fill_extrusion_dd_expanded.vert')
+        .readAsStringSync();
     expect(vertex, contains('layout(location = 0) in vec2 a_pos;'));
     expect(
       vertex,
       contains('layout(location = 1) in vec4 a_decimals_ed_normal;'),
     );
+    expect(vertex, contains('layout(location = 2) in vec2 a_base_range;'));
+    expect(vertex, contains('layout(location = 3) in vec2 a_height_range;'));
     expect(vertex, contains('layout(location = 4) in vec4 a_color_range;'));
     expect(vertex, contains('uint data_driven_mask;'));
+    expect(vertex, contains('vec2 a_decimals_ed = a_decimals_ed_normal.xy;'));
+    expect(vertex, contains('a_decimals_ed_normal.zw / 16384.0'));
     expect(vertex, contains('unpack_float(encoded_color.x) / 255.0'));
     expect(
       vertex,
       contains('color = mix(min_color, max_color, drawable.color_t);'),
     );
     expect(vertex, contains('color = props.color;'));
-    expect(vertex, contains('normal2d = a_decimals_ed_normal.zw / 16384.0'));
     expect(
       vertex,
-      contains('unpack_float(floor(a_decimals_ed_normal.x / 2.0)) / 128.0'),
+      contains('unpack_float(floor(a_decimals_ed.x / 2.0)) / 128.0'),
     );
     expect(vertex, contains('if (normal.z == 0.0)'));
+    expect(expanded, contains('layout(location = 0) in vec2 a_pos;'));
+  });
+
+  test('fill extrusion pipelines use reflected float layouts', () {
+    final registry = File('lib/src/gpu/pipeline_registry.dart')
+        .readAsStringSync();
+
+    expect(registry, isNot(contains('gpu.VertexFormat.uint32')));
+    expect(registry, contains("vertex: 'FillExtrusionExpandedDDVertex'"));
   });
 
   test('renderer restores shared depth prepass and read-only color pass', () {
@@ -68,17 +97,6 @@ void main() {
     expect(renderer, contains('gpu.StorageMode.devicePrivate'));
     expect(renderer, contains('depthStoreAction: gpu.StoreAction.store'));
     expect(renderer, contains('binder.depthPipelineFor(first)'));
-    // The prepass reuses the color pipeline's vertex shader with a transparent
-    // fragment, so the two keys must stay paired.
-    expect(
-      renderer,
-      contains(
-        RegExp(
-          r'\? RenderPipelineKey\.fillExtrusionDataDrivenDepth'
-          r'\s*: RenderPipelineKey\.fillExtrusionDepth',
-        ),
-      ),
-    );
     expect(renderer, contains('es[layerEnd].layer == first.layer'));
     expect(renderer, contains('depthWrite: true'));
     expect(
@@ -99,7 +117,6 @@ void main() {
     final renderer = SourceFiles.renderer;
 
     expect(renderer, contains('_pipelines.prewarmFillExtrusionPipelines();'));
-    expect(registry, contains('void prewarmFillExtrusionPipelines()'));
     final prewarmStart = registry.indexOf('void prewarmFillExtrusionPipelines');
     final prewarm = registry.substring(
       prewarmStart,
@@ -110,6 +127,8 @@ void main() {
       'RenderPipelineKey.fillExtrusionDepth',
       'RenderPipelineKey.fillExtrusionDataDriven',
       'RenderPipelineKey.fillExtrusionDataDrivenDepth',
+      'RenderPipelineKey.fillExtrusionExpandedDataDriven',
+      'RenderPipelineKey.fillExtrusionExpandedDataDrivenDepth',
     ]) {
       expect(prewarm, contains('this[$key];'), reason: key);
     }
@@ -129,6 +148,5 @@ void main() {
       contains('offsetof(shaders::FillExtrusionDrawableUBO, pad1) == 108'),
     );
     expect(RendererUboAbi.fillExtrusionDataDrivenMaskOffset, 108);
-    // Byte-level coverage lives in uniform_packer_test.dart.
   });
 }

--- a/test/fill_outline_data_driven_shader_test.dart
+++ b/test/fill_outline_data_driven_shader_test.dart
@@ -2,20 +2,22 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
-
-import 'support/source_files.dart';
-
 import 'package:maplibre_flutter_gpu/src/frame/draw_flags.dart';
 import 'package:maplibre_flutter_gpu/src/frame/ubo_abi.dart';
+import 'package:maplibre_flutter_gpu/src/native/draw_command.dart';
+
+import 'support/source_files.dart';
 
 void main() {
   test('fill-outline flags select the 32-byte triangulated DD layout', () {
     expect(fillOutlineUsesDataDrivenPipeline(0), isFalse);
     expect(fillOutlineVertexStride(0), 8);
+    expect(gpuVertexStride(ShaderType.fillOutlineTriangulated, 0), 24);
 
     expect(fillOutlineUsesDataDrivenPipeline(1 << 20), isTrue);
     expect(fillOutlineDataDrivenMask(1 << 20), 1);
     expect(fillOutlineVertexStride(1 << 20), 32);
+    expect(gpuVertexStride(ShaderType.fillOutlineTriangulated, 1 << 20), 48);
 
     expect(fillOutlineUsesDataDrivenPipeline(1 << 21), isTrue);
     expect(fillOutlineDataDrivenMask(1 << 21), 2);
@@ -92,6 +94,10 @@ void main() {
     final ddFragment = File('shaders/fill_outline_triangulated_dd.frag')
         .readAsStringSync();
 
+    for (final vertex in [fixedVertex, ddVertex]) {
+      expect(vertex, contains('layout(location = 0) in vec2 a_pos_normal;'));
+      expect(vertex, contains('layout(location = 1) in vec4 a_data;'));
+    }
     for (final equation in const [
       'float antialiasing = 0.5 / dpr;',
       'float halfwidth = 0.5;',

--- a/test/gpu_ready_fill_extrusion_test.dart
+++ b/test/gpu_ready_fill_extrusion_test.dart
@@ -1,0 +1,81 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_flutter_gpu/src/frame/draw_flags.dart';
+import 'package:maplibre_flutter_gpu/src/frame/vertex_repack.dart';
+import 'package:maplibre_flutter_gpu/src/native/draw_command.dart';
+
+import 'support/source_files.dart';
+
+void main() {
+  test('packed fill extrusion expands for GPU upload', () {
+    final constant = Uint8List(12);
+    final packedDd = Uint8List(44);
+
+    final constantResult = repackVertexDataForGpu(
+      constant,
+      vertexCount: 1,
+      sourceStride: 12,
+      shader: ShaderType.fillExtrusion,
+      flags: 0,
+    );
+    final ddResult = repackVertexDataForGpu(
+      packedDd,
+      vertexCount: 1,
+      sourceStride: 44,
+      shader: ShaderType.fillExtrusion,
+      flags: DrawCommandFlags.fillExtrusionDataDriven,
+    );
+
+    expect(identical(constantResult, constant), isFalse);
+    expect(identical(ddResult, packedDd), isFalse);
+    expect(constantResult.lengthInBytes, 24);
+    expect(ddResult.lengthInBytes, 56);
+    expect(gpuVertexStride(ShaderType.fillExtrusion, 0), 24);
+    expect(
+      gpuVertexStride(
+        ShaderType.fillExtrusion,
+        DrawCommandFlags.fillExtrusionDataDriven,
+      ),
+      56,
+    );
+  });
+
+  test('legacy GPU-ready data-driven extrusion remains compatible', () {
+    final source = Uint8List(56);
+    final data = ByteData.sublistView(source);
+    for (var index = 0; index < 14; index += 1) {
+      data.setFloat32(index * 4, index + 0.5, Endian.little);
+    }
+
+    const flags =
+        DrawCommandFlags.fillExtrusionDataDriven |
+        DrawCommandFlags.fillExtrusionGpuReady;
+    final result = repackVertexDataForGpu(
+      source,
+      vertexCount: 1,
+      sourceStride: 56,
+      shader: ShaderType.fillExtrusion,
+      flags: flags,
+    );
+
+    expect(identical(result, source), isTrue);
+    expect(gpuVertexStride(ShaderType.fillExtrusion, flags), 56);
+  });
+
+  test('native bridge leaves fill extrusion packed', () {
+    final source = SourceFiles.bridgeMergeOnly;
+
+    expect(
+      source,
+      isNot(contains('\n    prepareFillExtrusionGpuVertices(commands);')),
+    );
+    expect(source, contains('prepareLineGpuVertices(commands);'));
+    expect(
+      source,
+      contains(
+        'Fill-extrusion bytes already match Flutter GPU\'s 12-byte constant or 44-byte',
+      ),
+    );
+  });
+}

--- a/test/gpu_ready_line_test.dart
+++ b/test/gpu_ready_line_test.dart
@@ -1,0 +1,134 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_flutter_gpu/src/frame/command_layout.dart';
+import 'package:maplibre_flutter_gpu/src/frame/draw_flags.dart';
+import 'package:maplibre_flutter_gpu/src/frame/vertex_repack.dart';
+import 'package:maplibre_flutter_gpu/src/native/draw_command.dart';
+
+import 'support/source_files.dart';
+
+void main() {
+  test('packed constant line expands for GPU upload', () {
+    final source = Uint8List(8);
+    final result = repackVertexDataForGpu(
+      source,
+      vertexCount: 1,
+      sourceStride: 8,
+      shader: ShaderType.line,
+      flags: 0,
+    );
+
+    expect(identical(result, source), isFalse);
+    expect(result.lengthInBytes, 24);
+    expect(gpuVertexStride(ShaderType.line, 0), 24);
+  });
+
+  test('legacy GPU-ready constant line stays expanded', () {
+    final source = Uint8List(24);
+    final data = ByteData.sublistView(source);
+    data
+      ..setFloat32(0, -17, Endian.little)
+      ..setFloat32(4, 42, Endian.little)
+      ..setFloat32(8, 1, Endian.little)
+      ..setFloat32(12, 127, Endian.little)
+      ..setFloat32(16, 200, Endian.little)
+      ..setFloat32(20, 255, Endian.little);
+
+    final result = repackVertexDataForGpu(
+      source,
+      vertexCount: 1,
+      sourceStride: 24,
+      shader: ShaderType.line,
+      flags: DrawCommandFlags.lineGpuReady,
+    );
+    expect(identical(result, source), isTrue);
+    expect(result.lengthInBytes, 24);
+  });
+
+  test('GPU-ready data-driven line keeps the 120-byte path', () {
+    final source = Uint8List(120);
+    final result = repackVertexDataForGpu(
+      source,
+      vertexCount: 1,
+      sourceStride: 120,
+      shader: ShaderType.lineSDF,
+      flags:
+          DrawCommandFlags.lineColorDataDriven | DrawCommandFlags.lineGpuReady,
+    );
+
+    expect(identical(result, source), isTrue);
+    expect(
+      gpuVertexStride(
+        ShaderType.lineSDF,
+        DrawCommandFlags.lineColorDataDriven | DrawCommandFlags.lineGpuReady,
+      ),
+      120,
+    );
+  });
+
+  test('packed DD line remains a valid 88-to-120 repack source', () {
+    expect(lineVertexStride(DrawCommandFlags.lineColorDataDriven), 88);
+    expect(
+      gpuVertexStride(ShaderType.line, DrawCommandFlags.lineColorDataDriven),
+      120,
+    );
+  });
+
+  test('GPU-ready line strides remain accepted as native command layouts', () {
+    expect(
+      nativeVertexStride(
+        shader: ShaderType.line,
+        flags: DrawCommandFlags.lineGpuReady,
+        merged: false,
+      ),
+      24,
+    );
+    const ddFlags =
+        DrawCommandFlags.lineColorDataDriven | DrawCommandFlags.lineGpuReady;
+    expect(
+      nativeVertexStride(
+        shader: ShaderType.linePattern,
+        flags: ddFlags,
+        merged: false,
+      ),
+      120,
+    );
+  });
+
+  test('native bridge keeps constant line packed and expands DD only', () {
+    final source = SourceFiles.bridgeMergeOnly;
+    final prepare = source.indexOf('prepareLineGpuVertices(commands);');
+    final earlyReturn = source.indexOf('if (commands.size() <= 1) return;');
+
+    expect(source, contains('kLinePackedStride = 8'));
+    expect(source, contains('kLineDataDrivenPackedStride = 88'));
+    expect(source, contains('kLineGpuStride = 24'));
+    expect(source, contains('kLineDataDrivenGpuStride = 120'));
+    expect(source, contains('kLineGpuReadyFlag = 1u << 25'));
+    expect(source, contains('if (!dataDriven) continue;'));
+    expect(
+      source,
+      contains('const uint32_t sourceStride = kLineDataDrivenPackedStride;'),
+    );
+    expect(
+      source,
+      contains('const uint32_t targetStride = kLineDataDrivenGpuStride;'),
+    );
+    expect(source, contains('command.flags |= kLineGpuReadyFlag;'));
+    expect(
+      source,
+      contains(
+        'Data-driven line vertices keep the bridge-expanded 120-byte layout',
+      ),
+    );
+    expect(
+      source,
+      contains(
+        'Constant line-family vertices remain in Command Export\'s packed 8-byte',
+      ),
+    );
+    expect(prepare, greaterThanOrEqualTo(0));
+    expect(earlyReturn, greaterThan(prepare));
+  });
+}

--- a/test/gpu_renderer_test.dart
+++ b/test/gpu_renderer_test.dart
@@ -516,21 +516,39 @@ void main() {
     expect(alignUniformOffset(17, 24), 24);
   });
 
-  test('GPU vertex strides account for float-expanded attributes', () {
+  test('GPU vertex strides expand integer attributes to numeric floats', () {
     expect(gpuVertexStride(ShaderType.fill, 0), 8);
     expect(gpuVertexStride(ShaderType.fill, 1 << 2), 32);
+    expect(
+      gpuVertexStride(ShaderType.fill, DrawCommandFlags.crossTileMerged),
+      8,
+    );
+    expect(gpuVertexStride(ShaderType.background, 0), 8);
+    expect(
+      gpuVertexStride(ShaderType.background, DrawCommandFlags.crossTileMerged),
+      8,
+    );
     expect(gpuVertexStride(ShaderType.circle, 0), 8);
     expect(gpuVertexStride(ShaderType.circle, 1 << 5), 80);
     expect(gpuVertexStride(ShaderType.fillExtrusion, 0), 24);
     expect(gpuVertexStride(ShaderType.fillExtrusion, 1 << 1), 56);
+    expect(
+      gpuVertexStride(
+        ShaderType.fillExtrusion,
+        DrawCommandFlags.fillExtrusionDataDriven |
+            DrawCommandFlags.fillExtrusionGpuReady,
+      ),
+      56,
+    );
     expect(gpuVertexStride(ShaderType.line, 0), 24);
+    expect(gpuVertexStride(ShaderType.line, DrawCommandFlags.lineGpuReady), 24);
     expect(gpuVertexStride(ShaderType.linePattern, 1 << 19), 120);
     expect(gpuVertexStride(ShaderType.fillOutlineTriangulated, 0), 24);
     expect(gpuVertexStride(ShaderType.fillOutlineTriangulated, 1 << 20), 48);
     expect(gpuVertexStride(ShaderType.raster, 0), 16);
   });
 
-  test('packed signed-short positions become numeric float attributes', () {
+  test('packed fill positions expand to numeric floats', () {
     final source = Uint8List(8);
     final input = ByteData.sublistView(source);
     input
@@ -546,9 +564,9 @@ void main() {
       shader: ShaderType.fill,
       flags: 0,
     );
-    final output = ByteData.sublistView(result);
 
-    expect(result.lengthInBytes, 16);
+    expect(identical(result, source), isFalse);
+    final output = ByteData.sublistView(result);
     expect(
       [
         for (var offset = 0; offset < 16; offset += 4)
@@ -558,7 +576,7 @@ void main() {
     );
   });
 
-  test('line layout expands short2 and uchar4 to six floats', () {
+  test('packed constant line expands to numeric floats', () {
     final source = Uint8List(8);
     final input = ByteData.sublistView(source);
     input
@@ -576,9 +594,9 @@ void main() {
       shader: ShaderType.line,
       flags: 0,
     );
-    final output = ByteData.sublistView(result);
 
-    expect(result.lengthInBytes, 24);
+    expect(identical(result, source), isFalse);
+    final output = ByteData.sublistView(result);
     expect(
       [
         for (var offset = 0; offset < 24; offset += 4)
@@ -616,42 +634,22 @@ void main() {
     },
   );
 
-  test(
-    'extrusion layout preserves signed positions/normals and ushort data',
-    () {
-      final extrusionSource = Uint8List(12);
-      final extrusionInput = ByteData.sublistView(extrusionSource);
-      extrusionInput
-        ..setInt16(0, -3, Endian.little)
-        ..setInt16(2, -2, Endian.little)
-        ..setUint16(4, 65535, Endian.little)
-        ..setUint16(6, 32768, Endian.little)
-        ..setInt16(8, -1, Endian.little)
-        ..setInt16(10, 2, Endian.little);
-      final extrusion = repackVertexDataForGpu(
-        extrusionSource,
-        vertexCount: 1,
-        sourceStride: 12,
-        shader: ShaderType.fillExtrusion,
-        flags: 0,
-      );
-      final extrusionOutput = ByteData.sublistView(extrusion);
-      expect(
-        [
-          for (var offset = 0; offset < 24; offset += 4)
-            extrusionOutput.getFloat32(offset, Endian.little),
-        ],
-        [-3.0, -2.0, 65535.0, 32768.0, -1.0, 2.0],
-      );
-    },
-  );
+  test('packed extrusion layouts expand compact fields', () {
+    final constant = Uint8List(12);
+    final constantData = ByteData.sublistView(constant);
+    constantData
+      ..setInt16(0, -3, Endian.little)
+      ..setInt16(2, -2, Endian.little)
+      ..setUint16(4, 65535, Endian.little)
+      ..setUint16(6, 32768, Endian.little)
+      ..setInt16(8, -1, Endian.little)
+      ..setInt16(10, 2, Endian.little);
 
-  test('data-driven extrusion keeps float ranges while repacking vertices', () {
-    final source = Uint8List(88);
-    final input = ByteData.sublistView(source);
+    final dd = Uint8List(88);
+    final ddData = ByteData.sublistView(dd);
     for (var vertex = 0; vertex < 2; vertex++) {
       final offset = vertex * 44;
-      input
+      ddData
         ..setInt16(offset, -3 - vertex, Endian.little)
         ..setInt16(offset + 2, 4 + vertex, Endian.little)
         ..setUint16(offset + 4, 32768 + vertex, Endian.little)
@@ -659,7 +657,7 @@ void main() {
         ..setInt16(offset + 8, -1 - vertex, Endian.little)
         ..setInt16(offset + 10, 2 + vertex, Endian.little);
       for (var payload = 12; payload < 44; payload += 4) {
-        input.setFloat32(
+        ddData.setFloat32(
           offset + payload,
           vertex * 10 + payload / 4,
           Endian.little,
@@ -667,32 +665,41 @@ void main() {
       }
     }
 
-    final result = repackVertexDataForGpu(
-      source,
+    final constantResult = repackVertexDataForGpu(
+      constant,
+      vertexCount: 1,
+      sourceStride: 12,
+      shader: ShaderType.fillExtrusion,
+      flags: 0,
+    );
+    final ddResult = repackVertexDataForGpu(
+      dd,
       vertexCount: 2,
       sourceStride: 44,
       shader: ShaderType.fillExtrusion,
       flags: DrawCommandFlags.fillExtrusionDataDriven,
     );
-    final output = ByteData.sublistView(result);
 
-    expect(result.lengthInBytes, 112);
+    expect(identical(constantResult, constant), isFalse);
+    expect(identical(ddResult, dd), isFalse);
+    final constantOutput = ByteData.sublistView(constantResult);
     expect(
       [
         for (var offset = 0; offset < 24; offset += 4)
-          output.getFloat32(offset, Endian.little),
+          constantOutput.getFloat32(offset, Endian.little),
+      ],
+      [-3.0, -2.0, 65535.0, 32768.0, -1.0, 2.0],
+    );
+    expect(ddResult.lengthInBytes, 112);
+    final ddOutput = ByteData.sublistView(ddResult);
+    expect(
+      [
+        for (var offset = 0; offset < 24; offset += 4)
+          ddOutput.getFloat32(offset, Endian.little),
       ],
       [-3.0, 4.0, 32768.0, 65535.0, -1.0, 2.0],
     );
-    expect(result.sublist(24, 56), orderedEquals(source.sublist(12, 44)));
-    expect(
-      [
-        for (var offset = 56; offset < 80; offset += 4)
-          output.getFloat32(offset, Endian.little),
-      ],
-      [-4.0, 5.0, 32769.0, 65534.0, -2.0, 3.0],
-    );
-    expect(result.sublist(80, 112), orderedEquals(source.sublist(56, 88)));
+    expect(ddResult.sublist(24, 56), orderedEquals(dd.sublist(12, 44)));
   });
 
   test('DD line preserves float ranges and expands ushort4 patterns', () {
@@ -743,9 +750,6 @@ void main() {
         output.getFloat32(offset, Endian.little),
     ], patternTo.map((value) => value.toDouble()));
   });
-
-  // Adjacent-run grouping and draw-order preservation are asserted against the
-  // real planner in test/render_pass_planning_test.dart.
 
   test('render target uses MapLibre premultiplied clear color', () {
     final clear = frameClearValue((
@@ -821,6 +825,19 @@ void main() {
 
     expect(victims, ['old-large', 'old-small']);
     expect(victims, isNot(contains('current')));
+  });
+
+  test('GPU cache retries a budget blocked by current-frame entries', () {
+    final entries = {'current': (lastUsed: 3, bytes: 200)};
+
+    expect(
+      gpuCacheBudgetVictims(entries, currentFrame: 3, maxBytes: 96),
+      isEmpty,
+    );
+    expect(gpuCacheBudgetNeedsRetry(residentBytes: 200, maxBytes: 96), isTrue);
+    expect(gpuCacheBudgetVictims(entries, currentFrame: 4, maxBytes: 96), [
+      'current',
+    ]);
   });
 
   test('GPU cache expiry maintenance follows frames-in-flight cadence', () {

--- a/test/packed_fill_extrusion_identity_test.dart
+++ b/test/packed_fill_extrusion_identity_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_flutter_gpu/src/gpu/resource_cache.dart';
+import 'package:maplibre_flutter_gpu/src/native/draw_command.dart';
+
+void main() {
+  test('prepared packed fill extrusion ignores native pointer changes', () {
+    const first = (
+      bufferId: 0x80000007,
+      bufferVersion: 3,
+      dataAddress: 100,
+      vertexCount: 128,
+      sourceStride: 44,
+      shader: ShaderType.fillExtrusion,
+      gpuStride: 44,
+    );
+    const second = (
+      bufferId: 0x80000007,
+      bufferVersion: 3,
+      dataAddress: 200,
+      vertexCount: 128,
+      sourceStride: 44,
+      shader: ShaderType.fillExtrusion,
+      gpuStride: 44,
+    );
+
+    final canonicalFirst = gpuCanonicalVertexBufferCacheKey(first);
+    final canonicalSecond = gpuCanonicalVertexBufferCacheKey(second);
+
+    expect(canonicalFirst, canonicalSecond);
+    expect(canonicalFirst.dataAddress, 0);
+  });
+
+  test('prepared packed fill extrusion still respects content version', () {
+    const first = (
+      bufferId: 0x80000007,
+      bufferVersion: 3,
+      dataAddress: 100,
+      vertexCount: 128,
+      sourceStride: 44,
+      shader: ShaderType.fillExtrusion,
+      gpuStride: 44,
+    );
+    const nextVersion = (
+      bufferId: 0x80000007,
+      bufferVersion: 4,
+      dataAddress: 200,
+      vertexCount: 128,
+      sourceStride: 44,
+      shader: ShaderType.fillExtrusion,
+      gpuStride: 44,
+    );
+
+    expect(
+      gpuCanonicalVertexBufferCacheKey(first),
+      isNot(gpuCanonicalVertexBufferCacheKey(nextVersion)),
+    );
+  });
+}

--- a/test/packed_line_shader_test.dart
+++ b/test/packed_line_shader_test.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_flutter_gpu/src/frame/draw_flags.dart';
+import 'package:maplibre_flutter_gpu/src/native/draw_command.dart';
+
+void main() {
+  test('constant line shaders consume expanded LineLayoutVertex', () {
+    for (final path in <String>[
+      'shaders/line.vert',
+      'shaders/line_sdf.vert',
+      'shaders/line_gradient.vert',
+      'shaders/line_pattern.vert',
+    ]) {
+      final source = File(path).readAsStringSync();
+      expect(source, contains('layout(location = 0) in vec2 a_pos_normal;'));
+      expect(source, contains('layout(location = 1) in vec4 a_data;'));
+      expect(source, isNot(contains('floatBitsToUint')));
+    }
+  });
+
+  test('constant and DD line GPU strides use numeric floats', () {
+    for (final shader in <int>[
+      ShaderType.line,
+      ShaderType.lineSDF,
+      ShaderType.lineGradient,
+      ShaderType.linePattern,
+    ]) {
+      expect(gpuVertexStride(shader, 0), 24);
+      expect(gpuVertexStride(shader, DrawCommandFlags.lineGpuReady), 24);
+      expect(
+        gpuVertexStride(shader, DrawCommandFlags.lineColorDataDriven),
+        120,
+      );
+    }
+  });
+}

--- a/test/persistent_buffer_pool_test.dart
+++ b/test/persistent_buffer_pool_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_flutter_gpu/src/gpu/persistent_buffer_pool.dart';
+
+void main() {
+  test('persistent buffer pool eligibility is capped at 256 KiB', () {
+    expect(gpuPersistentBufferPoolEligible(0), isFalse);
+    expect(gpuPersistentBufferPoolEligible(1), isTrue);
+    expect(gpuPersistentBufferPoolEligible(256 * 1024), isTrue);
+    expect(gpuPersistentBufferPoolEligible(256 * 1024 + 1), isFalse);
+  });
+
+  test('persistent buffer pool reserves 16-byte aligned ranges', () {
+    expect(gpuPersistentBufferPoolReservedBytes(0), 0);
+    expect(gpuPersistentBufferPoolReservedBytes(1), 16);
+    expect(gpuPersistentBufferPoolReservedBytes(16), 16);
+    expect(gpuPersistentBufferPoolReservedBytes(17), 32);
+    expect(gpuPersistentBufferPoolReservedBytes(256 * 1024), 256 * 1024);
+  });
+
+  test('persistent buffer pool helpers reject invalid inputs', () {
+    expect(() => gpuPersistentBufferPoolEligible(-1), throwsRangeError);
+    expect(
+      () => gpuPersistentBufferPoolEligible(1, maxAllocationBytes: 0),
+      throwsArgumentError,
+    );
+    expect(() => gpuPersistentBufferPoolReservedBytes(-1), throwsRangeError);
+    expect(
+      () => gpuPersistentBufferPoolReservedBytes(1, alignmentBytes: 0),
+      throwsArgumentError,
+    );
+  });
+
+  test('persistent buffer pool caps physical page bytes', () {
+    expect(
+      gpuPersistentBufferPoolCanAddPage(
+        currentPageBytes: 0,
+        pageBytes: 1024,
+        maxPageBytes: 2048,
+      ),
+      isTrue,
+    );
+    expect(
+      gpuPersistentBufferPoolCanAddPage(
+        currentPageBytes: 1024,
+        pageBytes: 1024,
+        maxPageBytes: 2048,
+      ),
+      isTrue,
+    );
+    expect(
+      gpuPersistentBufferPoolCanAddPage(
+        currentPageBytes: 2048,
+        pageBytes: 1024,
+        maxPageBytes: 2048,
+      ),
+      isFalse,
+    );
+  });
+
+  test('persistent buffer pool validates aligned allocation capacity', () {
+    expect(
+      gpuPersistentBufferPoolMaxAllocationFitsPage(
+        pageBytes: 16,
+        maxAllocationBytes: 10,
+        alignmentBytes: 16,
+      ),
+      isTrue,
+    );
+    expect(
+      gpuPersistentBufferPoolMaxAllocationFitsPage(
+        pageBytes: 10,
+        maxAllocationBytes: 10,
+        alignmentBytes: 16,
+      ),
+      isFalse,
+    );
+  });
+}

--- a/test/pipeline_registry_test.dart
+++ b/test/pipeline_registry_test.dart
@@ -9,9 +9,6 @@ RenderPipelineKey _key(int shader, [int flags = 0]) =>
 
 void main() {
   test('every pipeline key has a spec', () {
-    // Creating a pipeline needs a GPU context, so this is the only place the
-    // "new variant, no shaders declared" mistake can be caught before a frame
-    // tries to draw with it.
     expect(
       MapPipelineRegistry.specifiedKeys.toSet(),
       RenderPipelineKey.values.toSet(),
@@ -58,6 +55,14 @@ void main() {
         ),
         RenderPipelineKey.fillExtrusionDataDriven,
       );
+      expect(
+        _key(
+          ShaderType.fillExtrusion,
+          DrawCommandFlags.fillExtrusionDataDriven |
+              DrawCommandFlags.fillExtrusionGpuReady,
+        ),
+        RenderPipelineKey.fillExtrusionExpandedDataDriven,
+      );
     });
 
     test('keeps each line variant on its own pipeline', () {
@@ -79,8 +84,6 @@ void main() {
     });
 
     test('merged geometry outranks the shader it came from', () {
-      // bridge_merge.cpp rewrites merged buffers into screen-space float2 and
-      // resets the flags, so only fill and background arrive here.
       expect(
         _key(ShaderType.fill, DrawCommandFlags.crossTileMerged),
         RenderPipelineKey.fillMerged,
@@ -125,7 +128,7 @@ void main() {
       }
     });
 
-    test('matches the color pipeline it precedes', () {
+    test('matches packed and expanded color pipelines', () {
       expect(
         depthPipelineKeyFor(shader: ShaderType.fillExtrusion, flags: 0),
         RenderPipelineKey.fillExtrusionDepth,
@@ -136,6 +139,15 @@ void main() {
           flags: DrawCommandFlags.fillExtrusionDataDriven,
         ),
         RenderPipelineKey.fillExtrusionDataDrivenDepth,
+      );
+      expect(
+        depthPipelineKeyFor(
+          shader: ShaderType.fillExtrusion,
+          flags:
+              DrawCommandFlags.fillExtrusionDataDriven |
+              DrawCommandFlags.fillExtrusionGpuReady,
+        ),
+        RenderPipelineKey.fillExtrusionExpandedDataDrivenDepth,
       );
     });
   });

--- a/test/prepared_graph_metrics_test.dart
+++ b/test/prepared_graph_metrics_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_flutter_gpu/src/gpu/prepared_graph_metrics.dart';
+
+void main() {
+  test('detailed timing metrics aggregate phases, maxima, and reasons', () {
+    final metrics = PreparedGraphDetailedTimingMetrics()
+      ..recordHit(totalMicros: 80, validationMicros: 20, refreshMicros: 60)
+      ..recordHit(totalMicros: 120, validationMicros: 30, refreshMicros: 90)
+      ..recordRebuild(
+        totalMicros: 5000,
+        reason: PreparedGraphRebuildReason.topologyMismatch,
+        validationMicros: 40,
+        decodeMicros: 4800,
+        captureMicros: 160,
+      )
+      ..recordRebuild(
+        totalMicros: 6200,
+        reason: PreparedGraphRebuildReason.refreshFailed,
+        validationMicros: 50,
+        refreshMicros: 400,
+        decodeMicros: 5500,
+        captureMicros: 250,
+      )
+      ..recordRebuild(
+        totalMicros: 1000,
+        reason: PreparedGraphRebuildReason.noGraph,
+        decodeMicros: 900,
+        captureMicros: 100,
+      );
+
+    final snapshot = metrics.takeSnapshotAndReset();
+
+    expect(snapshot.totals.hitCount, 2);
+    expect(snapshot.totals.rebuildCount, 3);
+    expect(snapshot.totals.hitRate, closeTo(0.4, 0.000001));
+    expect(snapshot.hitMaxMicros, 120);
+    expect(snapshot.rebuildMaxMicros, 6200);
+    expect(snapshot.validationCount, 4);
+    expect(snapshot.averageValidationMicros, 35);
+    expect(snapshot.refreshCount, 3);
+    expect(snapshot.averageRefreshMicros, closeTo(550 / 3, 0.000001));
+    expect(snapshot.decodeCount, 3);
+    expect(snapshot.averageDecodeMicros, closeTo(11200 / 3, 0.000001));
+    expect(snapshot.captureCount, 3);
+    expect(snapshot.averageCaptureMicros, 170);
+    expect(snapshot.noGraphRebuildCount, 1);
+    expect(snapshot.topologyMismatchRebuildCount, 1);
+    expect(snapshot.refreshFailedRebuildCount, 1);
+  });
+
+  test('detailed timing snapshots reset every interval', () {
+    final metrics = PreparedGraphDetailedTimingMetrics()
+      ..recordHit(totalMicros: 75, validationMicros: 25, refreshMicros: 50);
+
+    metrics.takeSnapshotAndReset();
+    final empty = metrics.takeSnapshotAndReset();
+
+    expect(empty.totals.sampleCount, 0);
+    expect(empty.hitMaxMicros, 0);
+    expect(empty.rebuildMaxMicros, 0);
+    expect(empty.averageValidationMicros, isNull);
+    expect(empty.averageRefreshMicros, isNull);
+    expect(empty.averageDecodeMicros, isNull);
+    expect(empty.averageCaptureMicros, isNull);
+    expect(empty.noGraphRebuildCount, 0);
+    expect(empty.topologyMismatchRebuildCount, 0);
+    expect(empty.refreshFailedRebuildCount, 0);
+  });
+}

--- a/test/prepared_graph_mismatch_test.dart
+++ b/test/prepared_graph_mismatch_test.dart
@@ -1,0 +1,231 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_flutter_gpu/src/gpu/prepared_graph.dart';
+import 'package:maplibre_flutter_gpu/src/gpu/prepared_graph_metrics.dart';
+import 'package:maplibre_flutter_gpu/src/native/abi_generated.dart';
+import 'package:maplibre_flutter_gpu/src/native/draw_command.dart';
+
+void main() {
+  ByteData command() {
+    final data = ByteData(DrawCommandAbi.size);
+    data
+      ..setUint32(DrawCommandAbi.shaderType, ShaderType.fill, Endian.little)
+      ..setUint32(
+        DrawCommandAbi.drawMode,
+        DrawModeType.triangles,
+        Endian.little,
+      )
+      ..setUint64(DrawCommandAbi.vertexData, 1, Endian.little)
+      ..setUint32(DrawCommandAbi.vertexCount, 4, Endian.little)
+      ..setUint32(DrawCommandAbi.vertexStride, 4, Endian.little)
+      ..setUint64(DrawCommandAbi.indexData, 2, Endian.little)
+      ..setUint32(DrawCommandAbi.indexCount, 6, Endian.little)
+      ..setUint32(DrawCommandAbi.layerIndex, 7, Endian.little)
+      ..setInt32(DrawCommandAbi.subLayerIndex, 2, Endian.little)
+      ..setUint32(
+        DrawCommandAbi.stencilMode,
+        StencilModeType.disabled,
+        Endian.little,
+      )
+      ..setFloat32(DrawCommandAbi.drawableUBO, 1, Endian.little)
+      ..setFloat32(DrawCommandAbi.drawableUBO + 20, 1, Endian.little);
+    return data;
+  }
+
+  PreparedGraphKey capture(ByteData data, {bool active = true}) =>
+      PreparedGraphKey.capture(
+        commandBytes: data.buffer.asUint8List(),
+        commandCount: 1,
+        commandStride: DrawCommandAbi.size,
+        activeCommandOffsets: active ? const <int>[0] : const <int>[],
+      );
+
+  PreparedGraphTopologyMismatchReason? changed(
+    void Function(ByteData data) mutate,
+  ) {
+    final data = command();
+    final key = capture(data);
+    mutate(data);
+    return key.firstMismatch(
+      commandBytes: data.buffer.asUint8List(),
+      commandCount: 1,
+      commandStride: DrawCommandAbi.size,
+    );
+  }
+
+  test('prepared graph classifies every stable command-field mismatch', () {
+    expect(
+      changed(
+        (data) => data.setUint32(
+          DrawCommandAbi.shaderType,
+          ShaderType.line,
+          Endian.little,
+        ),
+      ),
+      PreparedGraphTopologyMismatchReason.shader,
+    );
+    expect(
+      changed(
+        (data) => data.setUint32(
+          DrawCommandAbi.drawMode,
+          DrawModeType.triangles + 1,
+          Endian.little,
+        ),
+      ),
+      PreparedGraphTopologyMismatchReason.drawMode,
+    );
+    expect(
+      changed(
+        (data) => data.setUint32(DrawCommandAbi.flags, 1 << 2, Endian.little),
+      ),
+      PreparedGraphTopologyMismatchReason.flags,
+    );
+    expect(
+      changed(
+        (data) => data.setUint32(DrawCommandAbi.layerIndex, 8, Endian.little),
+      ),
+      PreparedGraphTopologyMismatchReason.layer,
+    );
+    expect(
+      changed(
+        (data) => data.setInt32(DrawCommandAbi.subLayerIndex, 3, Endian.little),
+      ),
+      PreparedGraphTopologyMismatchReason.subLayer,
+    );
+    expect(
+      changed(
+        (data) => data.setUint32(
+          DrawCommandAbi.stencilMode,
+          StencilModeType.clippingTest,
+          Endian.little,
+        ),
+      ),
+      PreparedGraphTopologyMismatchReason.stencil,
+    );
+    expect(
+      changed(
+        (data) => data
+          ..setFloat32(DrawCommandAbi.drawableUBO, 0, Endian.little)
+          ..setFloat32(DrawCommandAbi.drawableUBO + 20, 0, Endian.little),
+      ),
+      PreparedGraphTopologyMismatchReason.admission,
+    );
+  });
+
+  test('prepared graph classifies command-block mismatches', () {
+    final data = command();
+    final key = capture(data);
+
+    expect(
+      key.firstMismatch(
+        commandBytes: data.buffer.asUint8List(),
+        commandCount: 2,
+        commandStride: DrawCommandAbi.size,
+      ),
+      PreparedGraphTopologyMismatchReason.commandCount,
+    );
+    expect(
+      key.firstMismatch(
+        commandBytes: data.buffer.asUint8List(),
+        commandCount: 1,
+        commandStride: DrawCommandAbi.size + 4,
+      ),
+      PreparedGraphTopologyMismatchReason.commandStride,
+    );
+    expect(
+      key.firstMismatch(
+        commandBytes: Uint8List(DrawCommandAbi.size - 1),
+        commandCount: 1,
+        commandStride: DrawCommandAbi.size,
+      ),
+      PreparedGraphTopologyMismatchReason.commandBytes,
+    );
+    expect(
+      capture(command(), active: false).firstMismatch(
+        commandBytes: command().buffer.asUint8List(),
+        commandCount: 1,
+        commandStride: DrawCommandAbi.size,
+      ),
+      PreparedGraphTopologyMismatchReason.nonReusable,
+    );
+  });
+
+  test('template probing preserves the active graph mismatch reason', () {
+    final original = command();
+    final activeKey = capture(original);
+    final current = command()
+      ..setUint32(DrawCommandAbi.layerIndex, 8, Endian.little);
+
+    final droppedTemplate = command()
+      ..setUint32(DrawCommandAbi.layerIndex, 8, Endian.little)
+      ..setFloat32(DrawCommandAbi.drawableUBO, 0, Endian.little)
+      ..setFloat32(DrawCommandAbi.drawableUBO + 20, 0, Endian.little);
+    final cache = PreparedGraphTemplateCache<String>()
+      ..remember(
+        key: capture(droppedTemplate, active: false),
+        value: 'dropped',
+      );
+
+    expect(
+      activeKey.matches(
+        commandBytes: current.buffer.asUint8List(),
+        commandCount: 1,
+        commandStride: DrawCommandAbi.size,
+      ),
+      isFalse,
+    );
+    expect(
+      cache.takeMatching(
+        commandBytes: current.buffer.asUint8List(),
+        commandCount: 1,
+        commandStride: DrawCommandAbi.size,
+      ),
+      isNull,
+    );
+
+    final metrics = PreparedGraphDetailedTimingMetrics()
+      ..recordRebuild(
+        totalMicros: 1000,
+        reason: PreparedGraphRebuildReason.topologyMismatch,
+        validationMicros: 50,
+        decodeMicros: 900,
+        captureMicros: 50,
+      );
+    final snapshot = metrics.takeSnapshotAndReset();
+
+    expect(snapshot.topologyMismatchRebuildCount, 1);
+    expect(
+      snapshot.topologyMismatchCount(PreparedGraphTopologyMismatchReason.layer),
+      1,
+    );
+    expect(
+      snapshot.topologyMismatchCount(
+        PreparedGraphTopologyMismatchReason.admission,
+      ),
+      0,
+    );
+  });
+
+  test(
+    'topology mismatch without a pending diagnosis is counted as unknown',
+    () {
+      PreparedGraphTopologyDiagnostics.clearPendingMismatch();
+      final metrics = PreparedGraphDetailedTimingMetrics()
+        ..recordRebuild(
+          totalMicros: 100,
+          reason: PreparedGraphRebuildReason.topologyMismatch,
+          decodeMicros: 90,
+          captureMicros: 10,
+        );
+      final snapshot = metrics.takeSnapshotAndReset();
+
+      expect(
+        snapshot.topologyMismatchCount(
+          PreparedGraphTopologyMismatchReason.unknown,
+        ),
+        1,
+      );
+    },
+  );
+}

--- a/test/prepared_graph_template_renderer_test.dart
+++ b/test/prepared_graph_template_renderer_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'support/source_files.dart';
+
+void main() {
+  test('renderer restores recurring topology from resource-free templates', () {
+    final source = SourceFiles.renderer;
+
+    expect(source, contains('PreparedGraphTemplateCache<Object?>'));
+    expect(source, contains('capacity: 4'));
+    expect(source, contains('_preparedGraphTemplates.remember('));
+    expect(source, contains('.takeMatching('));
+    expect(source, contains('_restorePreparedGraphTemplate('));
+    expect(source, contains('_preparedGraphTemplates.clear();'));
+
+    final restore = source.indexOf(
+      '_PreparedGraphState? _restorePreparedGraphTemplate(',
+    );
+    expect(restore, greaterThanOrEqualTo(0));
+    final restoreBody = source.substring(restore);
+    expect(restoreBody, contains('_acquireDrawEntry('));
+    expect(restoreBody, contains('_refreshPreparedEntries('));
+    expect(restoreBody, contains('pipelineKeyFor('));
+    expect(restoreBody, contains('depthPipelineKeyFor('));
+    expect(
+      restoreBody,
+      isNot(contains('PreparedGraphTemplateCache<GpuBufferEntry')),
+    );
+  });
+}

--- a/test/prepared_graph_test.dart
+++ b/test/prepared_graph_test.dart
@@ -1,0 +1,337 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_flutter_gpu/src/gpu/prepared_graph.dart';
+import 'package:maplibre_flutter_gpu/src/native/abi_generated.dart';
+import 'package:maplibre_flutter_gpu/src/native/draw_command.dart';
+
+void main() {
+  ByteData command() {
+    final data = ByteData(DrawCommandAbi.size);
+    data
+      ..setUint32(DrawCommandAbi.shaderType, ShaderType.fill, Endian.little)
+      ..setUint32(
+        DrawCommandAbi.drawMode,
+        DrawModeType.triangles,
+        Endian.little,
+      )
+      ..setUint64(DrawCommandAbi.vertexData, 1, Endian.little)
+      ..setUint32(DrawCommandAbi.vertexCount, 4, Endian.little)
+      ..setUint32(DrawCommandAbi.vertexStride, 4, Endian.little)
+      ..setUint64(DrawCommandAbi.indexData, 2, Endian.little)
+      ..setUint32(DrawCommandAbi.indexCount, 6, Endian.little)
+      ..setUint32(DrawCommandAbi.layerIndex, 7, Endian.little)
+      ..setUint32(DrawCommandAbi.bufferId, 11, Endian.little)
+      ..setUint32(DrawCommandAbi.bufferVersion, 3, Endian.little)
+      ..setUint32(
+        DrawCommandAbi.texFilter,
+        TextureFilterType.linear,
+        Endian.little,
+      )
+      ..setInt32(DrawCommandAbi.subLayerIndex, 2, Endian.little)
+      ..setUint32(
+        DrawCommandAbi.stencilMode,
+        StencilModeType.disabled,
+        Endian.little,
+      )
+      ..setFloat32(DrawCommandAbi.drawableUBO, 1, Endian.little)
+      ..setFloat32(DrawCommandAbi.drawableUBO + 20, 1, Endian.little);
+
+    return data;
+  }
+
+  PreparedGraphKey capture(ByteData data, {bool active = true}) =>
+      PreparedGraphKey.capture(
+        commandBytes: data.buffer.asUint8List(),
+        commandCount: 1,
+        commandStride: DrawCommandAbi.size,
+        activeCommandOffsets: active ? const <int>[0] : const <int>[],
+      );
+
+  bool matches(PreparedGraphKey key, ByteData data) => key.matches(
+    commandBytes: data.buffer.asUint8List(),
+    commandCount: 1,
+    commandStride: DrawCommandAbi.size,
+  );
+
+  test('dynamic uniforms and stencil references preserve graph identity', () {
+    final data = command();
+    final key = capture(data);
+
+    data
+      ..setFloat32(DrawCommandAbi.drawableUBO, 4, Endian.little)
+      ..setFloat32(DrawCommandAbi.propsUBO, 0.5, Endian.little)
+      ..setUint32(DrawCommandAbi.stencilReference, 19, Endian.little);
+
+    expect(matches(key, data), isTrue);
+  });
+
+  test('geometry and resource changes preserve graph identity', () {
+    final data = command();
+    final key = capture(data);
+
+    data
+      ..setUint64(DrawCommandAbi.vertexData, 101, Endian.little)
+      ..setUint32(DrawCommandAbi.vertexCount, 8, Endian.little)
+      ..setUint64(DrawCommandAbi.indexData, 202, Endian.little)
+      ..setUint32(DrawCommandAbi.indexCount, 12, Endian.little)
+      ..setUint32(DrawCommandAbi.bufferId, 33, Endian.little)
+      ..setUint32(DrawCommandAbi.bufferVersion, 9, Endian.little)
+      ..setUint32(DrawCommandAbi.texChannels, 4, Endian.little)
+      ..setUint64(DrawCommandAbi.texData, 303, Endian.little)
+      ..setUint32(DrawCommandAbi.texWidth, 64, Endian.little)
+      ..setUint32(DrawCommandAbi.texHeight, 32, Endian.little)
+      ..setUint32(DrawCommandAbi.texId, 44, Endian.little)
+      ..setUint32(DrawCommandAbi.texVersion, 5, Endian.little)
+      ..setUint32(
+        DrawCommandAbi.texFilter,
+        TextureFilterType.nearest,
+        Endian.little,
+      );
+
+    expect(matches(key, data), isTrue);
+  });
+
+  test('pipeline and ordering changes invalidate the graph', () {
+    final data = command();
+    final key = capture(data);
+
+    data.setUint32(DrawCommandAbi.flags, 1 << 2, Endian.little);
+    expect(matches(key, data), isFalse);
+
+    data
+      ..setUint32(DrawCommandAbi.flags, 0, Endian.little)
+      ..setUint32(DrawCommandAbi.layerIndex, 8, Endian.little);
+    expect(matches(key, data), isFalse);
+
+    data
+      ..setUint32(DrawCommandAbi.layerIndex, 7, Endian.little)
+      ..setInt32(DrawCommandAbi.subLayerIndex, 3, Endian.little);
+    expect(matches(key, data), isFalse);
+  });
+
+  test('placement admission changes invalidate the graph', () {
+    final data = command();
+    final key = capture(data);
+
+    data
+      ..setFloat32(DrawCommandAbi.drawableUBO, 0, Endian.little)
+      ..setFloat32(DrawCommandAbi.drawableUBO + 20, 0, Endian.little);
+
+    expect(matches(key, data), isFalse);
+  });
+
+  test('post-admission drops prevent unsafe graph reuse', () {
+    final data = command();
+    final key = capture(data, active: false);
+
+    expect(key.reusable, isFalse);
+    expect(matches(key, data), isFalse);
+  });
+
+  test('prepared graph retains stable entries and partitions', () {
+    final data = command();
+    final entries = <int>[1, 2];
+    final partitions = <List<int>>[
+      <int>[1],
+      <int>[2],
+    ];
+    final graph = PreparedGraph<int, List<int>>(
+      key: capture(data),
+      entries: entries,
+      partitions: partitions,
+      uniformAlignment: 256,
+      uniformCursor: 512,
+      hasMapGlobalUniform: true,
+      commandCount: 1,
+      lastFillExtrusionLayerIndex: null,
+    );
+
+    expect(identical(graph.entries, entries), isTrue);
+    expect(identical(graph.partitions, partitions), isTrue);
+    expect(graph.uniformCursor, 512);
+  });
+
+  test('prepared graph template cache promotes an exact topology match', () {
+    final data = command();
+    final key = capture(data);
+    final cache = PreparedGraphTemplateCache<String>(capacity: 2)
+      ..remember(key: key, value: 'fill');
+
+    data
+      ..setUint64(DrawCommandAbi.vertexData, 100, Endian.little)
+      ..setUint32(DrawCommandAbi.bufferVersion, 9, Endian.little);
+
+    final match = cache.takeMatching(
+      commandBytes: data.buffer.asUint8List(),
+      commandCount: 1,
+      commandStride: DrawCommandAbi.size,
+    );
+
+    expect(match?.value, 'fill');
+    expect(identical(match?.key, key), isTrue);
+    expect(cache.length, 0);
+  });
+
+  test('template cache deduplicates the same exact topology', () {
+    final first = capture(command());
+    final second = capture(command());
+    final cache = PreparedGraphTemplateCache<String>(capacity: 2)
+      ..remember(key: first, value: 'first')
+      ..remember(key: second, value: 'second');
+
+    expect(cache.length, 1);
+    expect(
+      cache
+          .takeMatching(
+            commandBytes: command().buffer.asUint8List(),
+            commandCount: 1,
+            commandStride: DrawCommandAbi.size,
+          )
+          ?.value,
+      'second',
+    );
+  });
+
+  test('prepared graph template cache is bounded and ignores unsafe keys', () {
+    final drawable = command();
+    final dropped = command()
+      ..setFloat32(DrawCommandAbi.drawableUBO, 0, Endian.little)
+      ..setFloat32(DrawCommandAbi.drawableUBO + 20, 0, Endian.little);
+    final cache = PreparedGraphTemplateCache<String>(capacity: 1)
+      ..remember(key: capture(drawable), value: 'draw')
+      ..remember(key: capture(dropped, active: false), value: 'drop')
+      ..remember(key: capture(command(), active: false), value: 'unsafe');
+
+    expect(cache.length, 1);
+    expect(
+      cache.takeMatching(
+        commandBytes: drawable.buffer.asUint8List(),
+        commandCount: 1,
+        commandStride: DrawCommandAbi.size,
+      ),
+      isNull,
+    );
+    expect(
+      cache
+          .takeMatching(
+            commandBytes: dropped.buffer.asUint8List(),
+            commandCount: 1,
+            commandStride: DrawCommandAbi.size,
+          )
+          ?.value,
+      'drop',
+    );
+  });
+
+  test('template cache applies capacity across structural families', () {
+    final first = command();
+    final second = command()
+      ..setUint32(DrawCommandAbi.layerIndex, 8, Endian.little);
+    final cache = PreparedGraphTemplateCache<String>(capacity: 1)
+      ..remember(key: capture(first), value: 'first')
+      ..remember(key: capture(second), value: 'second');
+
+    expect(cache.length, 1);
+    expect(
+      cache.takeMatching(
+        commandBytes: first.buffer.asUint8List(),
+        commandCount: 1,
+        commandStride: DrawCommandAbi.size,
+      ),
+      isNull,
+    );
+    expect(
+      cache
+          .takeMatching(
+            commandBytes: second.buffer.asUint8List(),
+            commandCount: 1,
+            commandStride: DrawCommandAbi.size,
+          )
+          ?.value,
+      'second',
+    );
+  });
+
+  test(
+    'prepared graph template cache applies capacity across command counts',
+    () {
+      final one = command();
+      final second = command()
+        ..setUint32(DrawCommandAbi.layerIndex, 8, Endian.little);
+      final twoBytes = Uint8List(DrawCommandAbi.size * 2)
+        ..setRange(0, DrawCommandAbi.size, one.buffer.asUint8List())
+        ..setRange(
+          DrawCommandAbi.size,
+          DrawCommandAbi.size * 2,
+          second.buffer.asUint8List(),
+        );
+      final twoKey = PreparedGraphKey.capture(
+        commandBytes: twoBytes,
+        commandCount: 2,
+        commandStride: DrawCommandAbi.size,
+        activeCommandOffsets: <int>[0, DrawCommandAbi.size],
+      );
+      final cache = PreparedGraphTemplateCache<String>(capacity: 1)
+        ..remember(key: capture(one), value: 'one')
+        ..remember(key: twoKey, value: 'two');
+
+      expect(cache.length, 1);
+      expect(
+        cache.takeMatching(
+          commandBytes: one.buffer.asUint8List(),
+          commandCount: 1,
+          commandStride: DrawCommandAbi.size,
+        ),
+        isNull,
+      );
+      expect(
+        cache
+            .takeMatching(
+              commandBytes: twoBytes,
+              commandCount: 2,
+              commandStride: DrawCommandAbi.size,
+            )
+            ?.value,
+        'two',
+      );
+      expect(cache.length, 0);
+    },
+  );
+
+  test('prepared graph template cache rejects a non-positive capacity', () {
+    expect(
+      () => PreparedGraphTemplateCache<void>(capacity: 0),
+      throwsRangeError,
+    );
+  });
+
+  test('prepared graph timing metrics aggregate hits and rebuilds', () {
+    final metrics = PreparedGraphTimingMetrics()
+      ..record(reused: true, micros: 100)
+      ..record(reused: true, micros: 300)
+      ..record(reused: false, micros: 1200);
+
+    final snapshot = metrics.takeSnapshotAndReset();
+
+    expect(snapshot.hitCount, 2);
+    expect(snapshot.rebuildCount, 1);
+    expect(snapshot.sampleCount, 3);
+    expect(snapshot.hitRate, closeTo(2 / 3, 0.000001));
+    expect(snapshot.averageHitMicros, 200);
+    expect(snapshot.averageRebuildMicros, 1200);
+  });
+
+  test('prepared graph timing snapshots reset the logging interval', () {
+    final metrics = PreparedGraphTimingMetrics()
+      ..record(reused: true, micros: 75);
+
+    metrics.takeSnapshotAndReset();
+    final empty = metrics.takeSnapshotAndReset();
+
+    expect(empty.sampleCount, 0);
+    expect(empty.hitRate, 0);
+    expect(empty.averageHitMicros, isNull);
+    expect(empty.averageRebuildMicros, isNull);
+  });
+}

--- a/test/prepared_segment_buffer_id_test.dart
+++ b/test/prepared_segment_buffer_id_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'support/source_files.dart';
+
+void main() {
+  test(
+    'bridge content-addresses fill extrusion geometry without ABI changes',
+    () {
+      final source = SourceFiles.bridgeMergeOnly;
+
+      expect(
+        source,
+        contains('kContentAddressedFillExtrusionNamespace = 0xC0000000u'),
+      );
+      expect(source, contains('struct FillExtrusionContentSourceKey'));
+      expect(source, contains('struct FillExtrusionHashFingerprint'));
+      expect(source, contains('fillExtrusionStructuralIds'));
+      expect(source, contains('fillExtrusionBufferIdFor('));
+      expect(source, contains('fillExtrusionBufferVersionFor('));
+      expect(source, contains('structural.versionContents.find(version)'));
+      expect(
+        source,
+        contains('candidate = avalanche64(candidate + 0xc2b2ae3d27d4eb4fULL);'),
+      );
+      expect(source, contains('fillExtrusionContentIdentityFor('));
+      expect(
+        source,
+        contains('hashBytes(content, command.vertexData, vertexBytes);'),
+      );
+      expect(
+        source,
+        contains('hashBytes(content, command.indexData, indexBytes);'),
+      );
+      expect(source, contains('command.bufferId = identity->bufferId;'));
+      expect(
+        source,
+        contains('command.bufferVersion = identity->bufferVersion;'),
+      );
+      expect(
+        source,
+        contains('kFillExtrusionContentSourceRetentionFrames = 120'),
+      );
+      expect(source, contains('assignPackedFillExtrusionBufferIds(commands);'));
+      expect(
+        source,
+        isNot(contains('\n    prepareFillExtrusionGpuVertices(commands);')),
+        reason: 'packed fill-extrusion vertices must not be expanded again',
+      );
+
+      // Line expansion keeps the legacy prepared-ID namespace independently.
+      expect(source, contains('struct PreparedBufferIds'));
+      expect(source, contains('kPreparedBufferIdNamespace = 0x80000000u'));
+      expect(
+        source,
+        contains('preparedBufferIdFor(MergeSessionState& session'),
+      );
+    },
+  );
+}

--- a/test/resource_cache_expiry_reason_test.dart
+++ b/test/resource_cache_expiry_reason_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_flutter_gpu/src/gpu/resource_cache.dart';
+
+void main() {
+  test(
+    'expiry reason distinguishes superseded generations from unused age',
+    () {
+      expect(
+        gpuCacheEntryExpiryReason(
+          frame: 13,
+          lastUsed: 10,
+          superseded: true,
+          unusedRetentionFrames: 600,
+        ),
+        isNull,
+      );
+      expect(
+        gpuCacheEntryExpiryReason(
+          frame: 14,
+          lastUsed: 10,
+          superseded: true,
+          unusedRetentionFrames: 600,
+        ),
+        GpuCacheExpiryReason.superseded,
+      );
+      expect(
+        gpuCacheEntryExpiryReason(
+          frame: 610,
+          lastUsed: 10,
+          superseded: false,
+          unusedRetentionFrames: 600,
+        ),
+        GpuCacheExpiryReason.unused,
+      );
+    },
+  );
+
+  test('superseded reason wins when both expiry rules match', () {
+    expect(
+      gpuCacheEntryExpiryReason(
+        frame: 700,
+        lastUsed: 10,
+        superseded: true,
+        unusedRetentionFrames: 600,
+      ),
+      GpuCacheExpiryReason.superseded,
+    );
+  });
+}

--- a/test/resource_cache_metrics_test.dart
+++ b/test/resource_cache_metrics_test.dart
@@ -1,0 +1,295 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_flutter_gpu/src/gpu/resource_cache.dart';
+import 'package:maplibre_flutter_gpu/src/native/draw_command.dart';
+
+void main() {
+  test('expiry eviction callback reports removed keys and values', () {
+    final cache = <({int id, int version}), ({int lastUsed, int bytes})>{
+      (id: 1, version: 1): (lastUsed: 1, bytes: 100),
+      (id: 1, version: 2): (lastUsed: 10, bytes: 200),
+    };
+    var evictedBytes = 0;
+    ({int id, int version})? evictedKey;
+
+    evictExpiredCacheVersions(
+      cache,
+      frame: 10,
+      idOf: (key) => key.id,
+      versionOf: (key) => key.version,
+      lastUsedOf: (value) => value.lastUsed,
+      unusedRetentionFramesOf: (_) => 100,
+      onEvict: (key, value) {
+        evictedKey = key;
+        evictedBytes += value.bytes;
+      },
+    );
+
+    expect(cache.keys, contains((id: 1, version: 2)));
+    expect(cache.keys, isNot(contains((id: 1, version: 1))));
+    expect(evictedKey, (id: 1, version: 1));
+    expect(evictedBytes, 100);
+  });
+
+  test('entry-specific retention can use cache key metadata', () {
+    final cache = <({int id, int version, bool longLived}), ({int lastUsed})>{
+      (id: 1, version: 1, longLived: true): (lastUsed: 0),
+      (id: 2, version: 1, longLived: false): (lastUsed: 0),
+    };
+
+    evictExpiredCacheVersions(
+      cache,
+      frame: 70,
+      idOf: (key) => key.id,
+      versionOf: (key) => key.version,
+      lastUsedOf: (value) => value.lastUsed,
+      unusedRetentionFramesForEntry: (key, _) => key.longLived ? 120 : 60,
+    );
+
+    expect(cache.keys, contains((id: 1, version: 1, longLived: true)));
+    expect(cache.keys, isNot(contains((id: 2, version: 1, longLived: false))));
+  });
+
+  GpuVertexBufferCacheKey vertexKey({
+    required int shader,
+    required int dataAddress,
+    required int sourceStride,
+    required int gpuStride,
+    int bufferId = 0x80000007,
+    int bufferVersion = 3,
+    int vertexCount = 128,
+  }) => (
+    bufferId: bufferId,
+    bufferVersion: bufferVersion,
+    dataAddress: dataAddress,
+    vertexCount: vertexCount,
+    sourceStride: sourceStride,
+    shader: shader,
+    gpuStride: gpuStride,
+  );
+
+  test('prepared bridge vertices canonicalize away native pointer changes', () {
+    final lineA = gpuCanonicalVertexBufferCacheKey(
+      vertexKey(
+        shader: ShaderType.line,
+        dataAddress: 100,
+        sourceStride: 24,
+        gpuStride: 24,
+      ),
+    );
+    final lineB = gpuCanonicalVertexBufferCacheKey(
+      vertexKey(
+        shader: ShaderType.line,
+        dataAddress: 200,
+        sourceStride: 24,
+        gpuStride: 24,
+      ),
+    );
+    final extrusionA = gpuCanonicalVertexBufferCacheKey(
+      vertexKey(
+        shader: ShaderType.fillExtrusion,
+        dataAddress: 300,
+        sourceStride: 56,
+        gpuStride: 56,
+      ),
+    );
+    final extrusionB = gpuCanonicalVertexBufferCacheKey(
+      vertexKey(
+        shader: ShaderType.fillExtrusion,
+        dataAddress: 400,
+        sourceStride: 56,
+        gpuStride: 56,
+      ),
+    );
+
+    expect(lineA, lineB);
+    expect(lineA.dataAddress, 0);
+    expect(extrusionA, extrusionB);
+    expect(extrusionA.dataAddress, 0);
+  });
+
+  test('canonical prepared keys still distinguish content generations', () {
+    final base = gpuCanonicalVertexBufferCacheKey(
+      vertexKey(
+        shader: ShaderType.lineSDF,
+        dataAddress: 100,
+        sourceStride: 120,
+        gpuStride: 120,
+      ),
+    );
+    final nextVersion = gpuCanonicalVertexBufferCacheKey(
+      vertexKey(
+        shader: ShaderType.lineSDF,
+        dataAddress: 200,
+        sourceStride: 120,
+        gpuStride: 120,
+        bufferVersion: 4,
+      ),
+    );
+    final differentCount = gpuCanonicalVertexBufferCacheKey(
+      vertexKey(
+        shader: ShaderType.lineSDF,
+        dataAddress: 200,
+        sourceStride: 120,
+        gpuStride: 120,
+        vertexCount: 64,
+      ),
+    );
+
+    expect(base, isNot(nextVersion));
+    expect(base, isNot(differentCount));
+  });
+
+  test('legacy or packed vertices keep strict native pointer identity', () {
+    final oldNativeA = gpuCanonicalVertexBufferCacheKey(
+      vertexKey(
+        shader: ShaderType.line,
+        dataAddress: 100,
+        sourceStride: 24,
+        gpuStride: 24,
+        bufferId: 7,
+      ),
+    );
+    final oldNativeB = gpuCanonicalVertexBufferCacheKey(
+      vertexKey(
+        shader: ShaderType.line,
+        dataAddress: 200,
+        sourceStride: 24,
+        gpuStride: 24,
+        bufferId: 7,
+      ),
+    );
+    final packedA = gpuCanonicalVertexBufferCacheKey(
+      vertexKey(
+        shader: ShaderType.line,
+        dataAddress: 100,
+        sourceStride: 8,
+        gpuStride: 24,
+      ),
+    );
+    final packedB = gpuCanonicalVertexBufferCacheKey(
+      vertexKey(
+        shader: ShaderType.line,
+        dataAddress: 200,
+        sourceStride: 8,
+        gpuStride: 24,
+      ),
+    );
+
+    expect(oldNativeA, isNot(oldNativeB));
+    expect(oldNativeA.dataAddress, 100);
+    expect(packedA, isNot(packedB));
+    expect(packedA.dataAddress, 100);
+  });
+
+  test('regular buffer budget grows in bounded pressure steps', () {
+    const mib = 1024 * 1024;
+
+    expect(gpuRegularBufferBudgetForResidentBytes(0), 64 * mib);
+    expect(gpuRegularBufferBudgetForResidentBytes(64 * mib), 64 * mib);
+    expect(gpuRegularBufferBudgetForResidentBytes(65 * mib), 72 * mib);
+    expect(gpuRegularBufferBudgetForResidentBytes(72 * mib), 72 * mib);
+    expect(gpuRegularBufferBudgetForResidentBytes(73 * mib), 80 * mib);
+    expect(gpuRegularBufferBudgetForResidentBytes(100 * mib), 96 * mib);
+    expect(gpuRegularBufferBudgetForResidentBytes(128 * mib), 96 * mib);
+    expect(gpuRegularBufferBudgetForResidentBytes(160 * mib), 96 * mib);
+  });
+
+  test('regular buffer budget rejects invalid inputs and bounds', () {
+    expect(() => gpuRegularBufferBudgetForResidentBytes(-1), throwsRangeError);
+    expect(
+      () => gpuRegularBufferBudgetForResidentBytes(
+        1,
+        minBytes: 100,
+        maxBytes: 99,
+      ),
+      throwsArgumentError,
+    );
+    expect(
+      () => gpuRegularBufferBudgetForResidentBytes(1, growthStepBytes: 0),
+      throwsArgumentError,
+    );
+  });
+
+  test('fill extrusion cache budget follows two recent working sets', () {
+    const mib = 1024 * 1024;
+
+    expect(gpuFillExtrusionBudgetForWorkingSetBytes(0), 64 * mib);
+    expect(gpuFillExtrusionBudgetForWorkingSetBytes(16 * mib), 64 * mib);
+    expect(gpuFillExtrusionBudgetForWorkingSetBytes(32 * mib), 64 * mib);
+    expect(gpuFillExtrusionBudgetForWorkingSetBytes(40 * mib), 80 * mib);
+    expect(gpuFillExtrusionBudgetForWorkingSetBytes(64 * mib), 96 * mib);
+    expect(gpuFillExtrusionBudgetForWorkingSetBytes(80 * mib), 96 * mib);
+    expect(gpuFillExtrusionBudgetForWorkingSetBytes(96 * mib), 96 * mib);
+    expect(gpuFillExtrusionBudgetForWorkingSetBytes(128 * mib), 96 * mib);
+  });
+
+  test(
+    'fill extrusion budget grows immediately but shrinks only after idle',
+    () {
+      const mib = 1024 * 1024;
+
+      expect(
+        gpuFillExtrusionBudgetWithHysteresis(
+          currentBudgetBytes: 64 * mib,
+          targetBudgetBytes: 112 * mib,
+          hasRecentWorkingSet: true,
+          framesSinceRecentUse: 0,
+        ),
+        112 * mib,
+      );
+      expect(
+        gpuFillExtrusionBudgetWithHysteresis(
+          currentBudgetBytes: 112 * mib,
+          targetBudgetBytes: 64 * mib,
+          hasRecentWorkingSet: true,
+          framesSinceRecentUse: 0,
+        ),
+        112 * mib,
+      );
+      expect(
+        gpuFillExtrusionBudgetWithHysteresis(
+          currentBudgetBytes: 112 * mib,
+          targetBudgetBytes: 64 * mib,
+          hasRecentWorkingSet: false,
+          framesSinceRecentUse: 119,
+          idleShrinkFrames: 120,
+        ),
+        112 * mib,
+      );
+      expect(
+        gpuFillExtrusionBudgetWithHysteresis(
+          currentBudgetBytes: 112 * mib,
+          targetBudgetBytes: 64 * mib,
+          hasRecentWorkingSet: false,
+          framesSinceRecentUse: 120,
+          idleShrinkFrames: 120,
+        ),
+        64 * mib,
+      );
+    },
+  );
+
+  test('fill extrusion cache budget rejects invalid inputs and bounds', () {
+    expect(
+      () => gpuFillExtrusionBudgetForWorkingSetBytes(-1),
+      throwsRangeError,
+    );
+    expect(
+      () => gpuFillExtrusionBudgetForWorkingSetBytes(
+        1,
+        minBytes: 100,
+        maxBytes: 99,
+      ),
+      throwsArgumentError,
+    );
+    expect(
+      () => gpuFillExtrusionBudgetWithHysteresis(
+        currentBudgetBytes: -1,
+        targetBudgetBytes: 0,
+        hasRecentWorkingSet: false,
+        framesSinceRecentUse: 0,
+      ),
+      throwsArgumentError,
+    );
+  });
+}

--- a/test/resource_cache_retention_test.dart
+++ b/test/resource_cache_retention_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_flutter_gpu/src/gpu/resource_cache.dart';
+import 'package:maplibre_flutter_gpu/src/native/draw_command.dart';
+
+void main() {
+  test('cached buffers keep a thirty-second reuse window', () {
+    expect(gpuVertexUnusedRetentionFrames(ShaderType.fill), 1800);
+    expect(gpuVertexUnusedRetentionFrames(ShaderType.fillOutline), 1800);
+    expect(gpuVertexUnusedRetentionFrames(ShaderType.line), 1800);
+    expect(gpuVertexUnusedRetentionFrames(ShaderType.lineSDF), 1800);
+    expect(gpuVertexUnusedRetentionFrames(ShaderType.fillExtrusion), 1800);
+    expect(gpuIndexUnusedRetentionFrames(), 1800);
+    expect(gpuIndexUnusedRetentionFrames(isFillExtrusion: true), 1800);
+  });
+
+  test('generic expiry helper keeps its 60-frame default', () {
+    expect(
+      gpuCacheEntryExpired(frame: 69, lastUsed: 10, superseded: false),
+      isFalse,
+    );
+    expect(
+      gpuCacheEntryExpired(frame: 70, lastUsed: 10, superseded: false),
+      isTrue,
+    );
+  });
+
+  test('superseded generations still retire after frames in flight', () {
+    expect(
+      gpuCacheEntryExpired(
+        frame: 13,
+        lastUsed: 10,
+        superseded: true,
+        unusedRetentionFrames: 1800,
+      ),
+      isFalse,
+    );
+    expect(
+      gpuCacheEntryExpired(
+        frame: 14,
+        lastUsed: 10,
+        superseded: true,
+        unusedRetentionFrames: 1800,
+      ),
+      isTrue,
+    );
+  });
+}

--- a/test/resource_metrics_test.dart
+++ b/test/resource_metrics_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_flutter_gpu/src/gpu/resource_metrics.dart';
+import 'package:maplibre_flutter_gpu/src/native/draw_command.dart';
+
+void main() {
+  test('resource timing metrics aggregate lookups, uploads, and evictions', () {
+    final metrics = GpuResourceTimingMetrics()
+      ..recordVertexLookup(hit: true)
+      ..recordVertexLookup(hit: false)
+      ..recordIndexLookup(hit: true)
+      ..recordTextureLookup(hit: false)
+      ..recordRepack(micros: 40)
+      ..recordRepack(micros: 80)
+      ..recordVertexUpload(micros: 120, bytes: 1024)
+      ..recordVertexUpload(micros: 300, bytes: 2048, frameOwned: true)
+      ..recordIndexUpload(micros: 90, bytes: 512, frameOwned: true)
+      ..recordTextureUpload(micros: 500, bytes: 4096)
+      ..recordExpiryEvictions(count: 3, bytes: 8192)
+      ..recordBudgetEviction(bytes: 16384);
+
+    final snapshot = metrics.takeSnapshotAndReset();
+
+    expect(snapshot.vertexCacheHits, 1);
+    expect(snapshot.vertexCacheMisses, 1);
+    expect(snapshot.indexCacheHits, 1);
+    expect(snapshot.indexCacheMisses, 0);
+    expect(snapshot.textureCacheHits, 0);
+    expect(snapshot.textureCacheMisses, 1);
+    expect(snapshot.averageRepackMicros, 60);
+    expect(snapshot.repackMaxMicros, 80);
+    expect(snapshot.repackLayouts, isEmpty);
+    expect(snapshot.vertexUploadCount, 2);
+    expect(snapshot.averageVertexUploadMicros, 210);
+    expect(snapshot.vertexUploadBytes, 3072);
+    expect(snapshot.vertexUploadMaxMicros, 300);
+    expect(snapshot.indexUploadCount, 1);
+    expect(snapshot.indexUploadBytes, 512);
+    expect(snapshot.textureUploadCount, 1);
+    expect(snapshot.textureUploadBytes, 4096);
+    expect(snapshot.frameVertexUploadCount, 1);
+    expect(snapshot.frameVertexUploadBytes, 2048);
+    expect(snapshot.frameIndexUploadCount, 1);
+    expect(snapshot.frameIndexUploadBytes, 512);
+    expect(snapshot.expiryEvictionCount, 3);
+    expect(snapshot.expiryEvictionBytes, 8192);
+    expect(snapshot.budgetEvictionCount, 1);
+    expect(snapshot.budgetEvictionBytes, 16384);
+  });
+
+  test('cached repacks are grouped by shader and vertex layout', () {
+    final metrics = GpuResourceTimingMetrics()
+      ..recordVertexLookup(
+        hit: false,
+        shader: ShaderType.line,
+        sourceStride: 8,
+        gpuStride: 16,
+        vertexCount: 100,
+      )
+      ..recordRepack(micros: 100)
+      ..recordVertexLookup(
+        hit: false,
+        shader: ShaderType.line,
+        sourceStride: 8,
+        gpuStride: 16,
+        vertexCount: 200,
+      )
+      ..recordRepack(micros: 300)
+      ..recordVertexLookup(
+        hit: false,
+        shader: ShaderType.lineSDF,
+        sourceStride: 12,
+        gpuStride: 20,
+        vertexCount: 50,
+      )
+      ..recordRepack(micros: 500);
+
+    final snapshot = metrics.takeSnapshotAndReset();
+
+    expect(snapshot.repackLayouts, hasLength(2));
+    final sdf = snapshot.repackLayouts[0];
+    expect(sdf.shader, ShaderType.lineSDF);
+    expect(sdf.sourceStride, 12);
+    expect(sdf.gpuStride, 20);
+    expect(sdf.count, 1);
+    expect(sdf.micros, 500);
+    expect(sdf.inputBytes, 600);
+    expect(sdf.outputBytes, 1000);
+
+    final line = snapshot.repackLayouts[1];
+    expect(line.shader, ShaderType.line);
+    expect(line.sourceStride, 8);
+    expect(line.gpuStride, 16);
+    expect(line.count, 2);
+    expect(line.averageMicros, 200);
+    expect(line.maxMicros, 300);
+    expect(line.inputBytes, 2400);
+    expect(line.outputBytes, 4800);
+  });
+
+  test('resource timing snapshots reset the interval', () {
+    final metrics = GpuResourceTimingMetrics()
+      ..recordVertexLookup(
+        hit: false,
+        shader: ShaderType.fill,
+        sourceStride: 4,
+        gpuStride: 8,
+        vertexCount: 10,
+      )
+      ..recordRepack(micros: 20)
+      ..recordVertexUpload(micros: 10, bytes: 32);
+
+    metrics.takeSnapshotAndReset();
+    final empty = metrics.takeSnapshotAndReset();
+
+    expect(empty.vertexLookupCount, 0);
+    expect(empty.indexLookupCount, 0);
+    expect(empty.textureLookupCount, 0);
+    expect(empty.repackCount, 0);
+    expect(empty.repackLayouts, isEmpty);
+    expect(empty.vertexUploadCount, 0);
+    expect(empty.indexUploadCount, 0);
+    expect(empty.textureUploadCount, 0);
+    expect(empty.expiryEvictionCount, 0);
+    expect(empty.budgetEvictionCount, 0);
+  });
+}

--- a/test/resource_miss_tracker_test.dart
+++ b/test/resource_miss_tracker_test.dart
@@ -1,0 +1,204 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_flutter_gpu/src/gpu/resource_miss_tracker.dart';
+
+typedef _TestKey = ({int id, int version, int identity});
+
+void main() {
+  GpuCacheMissTracker<_TestKey> tracker({int historyLimit = 8}) =>
+      GpuCacheMissTracker<_TestKey>(
+        idOf: (key) => key.id,
+        versionOf: (key) => key.version,
+        historyLimit: historyLimit,
+      );
+
+  GpuCacheMissSnapshot only(GpuCacheMissTracker<_TestKey> value) {
+    final snapshot = value.takeSnapshotAndReset();
+    expect(snapshot, hasLength(1));
+    return snapshot.single;
+  }
+
+  void missAndStore(
+    GpuCacheMissTracker<_TestKey> value,
+    _TestKey key, {
+    int bytes = 1024,
+    bool classify = true,
+  }) {
+    value.recordLookup(key: key, hit: false);
+    value.recordStore(key: key, bytes: bytes, classify: classify);
+  }
+
+  test('first observed resource is classified as new', () {
+    final value = tracker();
+    const key = (id: 7, version: 1, identity: 100);
+
+    missAndStore(value, key, bytes: 4096);
+    final snapshot = only(value);
+
+    expect(snapshot.reason, GpuCacheMissReason.newBuffer);
+    expect(snapshot.count, 1);
+    expect(snapshot.bytes, 4096);
+  });
+
+  test('same id with a new version is classified as version churn', () {
+    final value = tracker();
+
+    missAndStore(value, (id: 7, version: 1, identity: 100));
+    value.takeSnapshotAndReset();
+    missAndStore(value, (id: 7, version: 2, identity: 200), bytes: 2048);
+
+    final snapshot = only(value);
+    expect(snapshot.reason, GpuCacheMissReason.versionChange);
+    expect(snapshot.bytes, 2048);
+  });
+
+  test('same id/version with another exact key is identity churn', () {
+    final value = tracker();
+
+    missAndStore(value, (id: 7, version: 1, identity: 100));
+    value.takeSnapshotAndReset();
+    missAndStore(value, (id: 7, version: 1, identity: 200));
+
+    expect(only(value).reason, GpuCacheMissReason.identityChange);
+  });
+
+  test('identity churn logs bounded previous and current key samples', () {
+    final value = tracker();
+    final messages = <String>[];
+    final originalDebugPrint = debugPrint;
+    debugPrint = (String? message, {int? wrapWidth}) {
+      if (message != null) messages.add(message);
+    };
+    try {
+      missAndStore(value, (id: 7, version: 1, identity: 100));
+      value.takeSnapshotAndReset();
+      for (var identity = 200; identity < 205; identity += 1) {
+        missAndStore(value, (id: 7, version: 1, identity: identity));
+      }
+
+      expect(messages, hasLength(4));
+      expect(messages.first, contains('[GpuIdentityChange] id=7 version=1'));
+      expect(messages.first, contains('identity: 100'));
+      expect(messages.first, contains('identity: 200'));
+    } finally {
+      debugPrint = originalDebugPrint;
+    }
+  });
+
+  test('identity sample limit resets with interval metrics', () {
+    final value = tracker();
+    final messages = <String>[];
+    final originalDebugPrint = debugPrint;
+    debugPrint = (String? message, {int? wrapWidth}) {
+      if (message != null) messages.add(message);
+    };
+    try {
+      missAndStore(value, (id: 7, version: 1, identity: 100));
+      value.takeSnapshotAndReset();
+      for (var identity = 200; identity < 205; identity += 1) {
+        missAndStore(value, (id: 7, version: 1, identity: identity));
+      }
+      expect(messages, hasLength(4));
+
+      value.takeSnapshotAndReset();
+      missAndStore(value, (id: 7, version: 1, identity: 300));
+      expect(messages, hasLength(5));
+    } finally {
+      debugPrint = originalDebugPrint;
+    }
+  });
+
+  test('exact expiry revisit outranks version and identity history', () {
+    final value = tracker();
+    const key = (id: 7, version: 1, identity: 100);
+
+    missAndStore(value, key);
+    value.takeSnapshotAndReset();
+    value.recordEviction(key: key, kind: GpuCacheEvictionKind.expiry);
+    missAndStore(value, key, bytes: 8192);
+
+    final snapshot = only(value);
+    expect(snapshot.reason, GpuCacheMissReason.expiryRevisit);
+    expect(snapshot.bytes, 8192);
+  });
+
+  test('exact budget revisit is classified separately', () {
+    final value = tracker();
+    const key = (id: 7, version: 1, identity: 100);
+
+    missAndStore(value, key);
+    value.takeSnapshotAndReset();
+    value.recordEviction(key: key, kind: GpuCacheEvictionKind.budget);
+    missAndStore(value, key);
+
+    expect(only(value).reason, GpuCacheMissReason.budgetRevisit);
+  });
+
+  test('non-target stores clear pending misses without affecting history', () {
+    final value = tracker();
+    const ignored = (id: 7, version: 1, identity: 100);
+
+    missAndStore(value, ignored, classify: false);
+    expect(value.takeSnapshotAndReset(), isEmpty);
+
+    missAndStore(value, (id: 7, version: 2, identity: 200));
+    expect(only(value).reason, GpuCacheMissReason.newBuffer);
+  });
+
+  test('interval reset preserves history for later classification', () {
+    final value = tracker();
+
+    missAndStore(value, (id: 7, version: 1, identity: 100));
+    value.takeSnapshotAndReset();
+    expect(value.takeSnapshotAndReset(), isEmpty);
+
+    missAndStore(value, (id: 7, version: 2, identity: 200));
+    expect(only(value).reason, GpuCacheMissReason.versionChange);
+  });
+
+  test('hits establish identity history without creating miss totals', () {
+    final value = tracker();
+    const key = (id: 7, version: 3, identity: 100);
+
+    value.recordLookup(key: key, hit: true);
+    expect(value.takeSnapshotAndReset(), isEmpty);
+
+    missAndStore(value, (id: 7, version: 3, identity: 200));
+    expect(only(value).reason, GpuCacheMissReason.identityChange);
+  });
+
+  test('history is bounded and constructor rejects invalid limit', () {
+    expect(() => tracker(historyLimit: 0), throwsRangeError);
+
+    final value = tracker(historyLimit: 2);
+    missAndStore(value, (id: 1, version: 1, identity: 1));
+    missAndStore(value, (id: 2, version: 1, identity: 2));
+    missAndStore(value, (id: 3, version: 1, identity: 3));
+    value.takeSnapshotAndReset();
+
+    // ID 1 fell out of the bounded history, so seeing it again is intentionally
+    // treated as new rather than keeping unbounded diagnostic state.
+    missAndStore(value, (id: 1, version: 2, identity: 4));
+    expect(only(value).reason, GpuCacheMissReason.newBuffer);
+  });
+
+  test('pending upload failures retain only bounded recent misses', () {
+    final value = tracker(historyLimit: 2);
+    const first = (id: 1, version: 1, identity: 1);
+    const second = (id: 2, version: 1, identity: 2);
+    const third = (id: 3, version: 1, identity: 3);
+
+    value
+      ..recordLookup(key: first, hit: false)
+      ..recordLookup(key: second, hit: false)
+      ..recordLookup(key: third, hit: false)
+      ..recordStore(key: first, bytes: 1, classify: true)
+      ..recordStore(key: second, bytes: 2, classify: true)
+      ..recordStore(key: third, bytes: 3, classify: true);
+
+    final snapshot = only(value);
+    expect(snapshot.reason, GpuCacheMissReason.newBuffer);
+    expect(snapshot.count, 2);
+    expect(snapshot.bytes, 5);
+  });
+}

--- a/test/resource_upload_size_metrics_test.dart
+++ b/test/resource_upload_size_metrics_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_flutter_gpu/src/gpu/resource_metrics.dart';
+
+void main() {
+  test('upload size attribution uses slab-oriented boundaries', () {
+    expect(gpuUploadSizeClassForBytes(0), GpuUploadSizeClass.small);
+    expect(gpuUploadSizeClassForBytes(16 * 1024), GpuUploadSizeClass.small);
+    expect(
+      gpuUploadSizeClassForBytes(16 * 1024 + 1),
+      GpuUploadSizeClass.medium,
+    );
+    expect(gpuUploadSizeClassForBytes(256 * 1024), GpuUploadSizeClass.medium);
+    expect(
+      gpuUploadSizeClassForBytes(256 * 1024 + 1),
+      GpuUploadSizeClass.large,
+    );
+  });
+
+  test('upload size attribution rejects negative byte counts', () {
+    expect(() => gpuUploadSizeClassForBytes(-1), throwsRangeError);
+  });
+}

--- a/test/stable_fill_extrusion_cache_key_test.dart
+++ b/test/stable_fill_extrusion_cache_key_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_flutter_gpu/src/gpu/resource_cache.dart';
+import 'package:maplibre_flutter_gpu/src/native/draw_command.dart';
+
+void main() {
+  test('native stable fill extrusion id ignores recreated vertex pointer', () {
+    const first = (
+      bufferId: 0xC0000007,
+      bufferVersion: 4,
+      dataAddress: 100,
+      vertexCount: 128,
+      sourceStride: 44,
+      shader: ShaderType.fillExtrusion,
+      gpuStride: 44,
+    );
+    const recreated = (
+      bufferId: 0xC0000007,
+      bufferVersion: 4,
+      dataAddress: 200,
+      vertexCount: 128,
+      sourceStride: 44,
+      shader: ShaderType.fillExtrusion,
+      gpuStride: 44,
+    );
+
+    expect(
+      gpuCanonicalVertexBufferCacheKey(first),
+      gpuCanonicalVertexBufferCacheKey(recreated),
+    );
+  });
+
+  test('native stable fill extrusion id still invalidates by version', () {
+    const first = (
+      bufferId: 0xC0000007,
+      bufferVersion: 4,
+      dataAddress: 100,
+      vertexCount: 128,
+      sourceStride: 44,
+      shader: ShaderType.fillExtrusion,
+      gpuStride: 44,
+    );
+    const changed = (
+      bufferId: 0xC0000007,
+      bufferVersion: 5,
+      dataAddress: 200,
+      vertexCount: 128,
+      sourceStride: 44,
+      shader: ShaderType.fillExtrusion,
+      gpuStride: 44,
+    );
+
+    expect(
+      gpuCanonicalVertexBufferCacheKey(first),
+      isNot(gpuCanonicalVertexBufferCacheKey(changed)),
+    );
+  });
+}

--- a/test/stable_fill_extrusion_geometry_identity_test.dart
+++ b/test/stable_fill_extrusion_geometry_identity_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'support/source_files.dart';
+
+void main() {
+  test('native fill extrusion identity survives drawable recreation', () {
+    final source = SourceFiles.commandExportDrawableOnly;
+
+    expect(
+      source,
+      contains('kStableFillExtrusionBufferIdNamespace = 0xC0000000u'),
+    );
+    expect(source, contains('bucket->getID().id()'));
+    expect(source, contains('const auto& canonical = tileID.canonical;'));
+    expect(
+      source,
+      contains(
+        'std::tie(bucketId, tileZ, tileX, tileY, layerIndex, segmentOrdinal)',
+      ),
+    );
+    expect(
+      source,
+      contains(
+        'state.drawableId == drawableId && state.localBufferVersion != localBufferVersion',
+      ),
+    );
+    expect(
+      source,
+      contains(
+        'state.vertexRevision != vertexRevision || state.indexRevision != indexRevision',
+      ),
+    );
+    expect(source, contains('cmd.bufferId = exportedBufferId;'));
+    expect(source, contains('cmd.bufferVersion = exportedBufferVersion;'));
+  });
+}

--- a/test/support/source_files.dart
+++ b/test/support/source_files.dart
@@ -73,6 +73,13 @@ abstract final class SourceFiles {
   static String get gpuPainterOnly =>
       _read('lib/src/widgets/map_gpu_painter.dart');
 
+  /// Native command post-processing immediately before frame publication.
+  static String get bridgeMergeOnly => _read('native/src/bridge_merge.cpp');
+
+  /// Native Command Export drawable implementation used by GPU contract tests.
+  static String get commandExportDrawableOnly =>
+      _read('vendor/maplibre-native/src/mbgl/command_export/drawable.cpp');
+
   /// The Dart FFI bindings to the native bridge.
   static String get ffi => _join(ffiPaths);
 

--- a/test/vertex_repack_fast_path_test.dart
+++ b/test/vertex_repack_fast_path_test.dart
@@ -1,0 +1,60 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maplibre_flutter_gpu/src/frame/draw_flags.dart';
+import 'package:maplibre_flutter_gpu/src/frame/vertex_repack.dart';
+import 'package:maplibre_flutter_gpu/src/native/draw_command.dart';
+
+void main() {
+  test('packed fill layouts expand for GPU upload', () {
+    for (final spec in <({int stride, int flags})>[
+      (stride: 4, flags: 0),
+      (stride: 28, flags: DrawCommandFlags.fillColorDataDriven),
+    ]) {
+      final source = Uint8List(spec.stride * 2);
+      for (var index = 0; index < source.length; index += 1) {
+        source[index] = (index * 37) & 0xff;
+      }
+
+      final result = repackVertexDataForGpu(
+        source,
+        vertexCount: 2,
+        sourceStride: spec.stride,
+        shader: ShaderType.fill,
+        flags: spec.flags,
+      );
+
+      expect(identical(result, source), isFalse);
+      expect(
+        result.lengthInBytes,
+        gpuVertexStride(ShaderType.fill, spec.flags) * 2,
+      );
+    }
+  });
+
+  test('packed triangulated outline layouts expand for GPU upload', () {
+    for (final spec in <({int stride, int flags})>[
+      (stride: 8, flags: 0),
+      (stride: 32, flags: DrawCommandFlags.fillOutlineColorDataDriven),
+    ]) {
+      final source = Uint8List(spec.stride * 2);
+      for (var index = 0; index < source.length; index += 1) {
+        source[index] = (index * 53) & 0xff;
+      }
+
+      final result = repackVertexDataForGpu(
+        source,
+        vertexCount: 2,
+        sourceStride: spec.stride,
+        shader: ShaderType.fillOutlineTriangulated,
+        flags: spec.flags,
+      );
+
+      expect(identical(result, source), isFalse);
+      expect(
+        result.lengthInBytes,
+        gpuVertexStride(ShaderType.fillOutlineTriangulated, spec.flags) * 2,
+      );
+    }
+  });
+}


### PR DESCRIPTION
## Summary

- reuse prepared render graphs when native command topology remains stable
- retain and bound GPU buffers, textures, graph templates, and diagnostic history
- consume packed geometry layouts to reduce CPU repacking and upload volume
- preserve stable native geometry identities across drawable recreation
- add metrics for graph reuse, uploads, cache misses, and evictions

## Testing

- `flutter test` (633 tests passed)
- `flutter analyze` (no errors or warnings, 2 pre-existing `avoid_relative_lib_imports` info findings)

## Validation still needed

- measure frame time, upload volume, and peak memory on macOS, iOS, and Android devices
- exercise long-running pan, zoom, style, and feature-state updates