### PR TITLE
fix: preserve widget world copies

### DIFF
--- a/darwin/maplibre_flutter_gpu/Packaging/maplibre_bridge_anchor.cpp
+++ b/darwin/maplibre_flutter_gpu/Packaging/maplibre_bridge_anchor.cpp
@@ -81,6 +81,7 @@
     X(maplibre_get_label_blob) \
     X(maplibre_get_label_blob_size) \
     X(maplibre_reproject_labels) \
+    X(maplibre_project_wrapped_coordinates) \
     X(maplibre_get_labels_version) \
     X(maplibre_style_last_error) \
     X(maplibre_style_set) \

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,6 +5,12 @@ import 'package:maplibre_flutter_gpu/maplibre_flutter_gpu.dart';
 
 import 'landmarks.dart';
 
+const double _landmarkMarkerSize = 46;
+const double _selectedLandmarkMarkerSize = 54;
+const double _landmarkMarkerFontSize = 23;
+const double _selectedLandmarkMarkerFontSize = 27;
+const EdgeInsets _landmarkViewportPadding = EdgeInsets.fromLTRB(60, 70, 60, 60);
+
 void main() => runApp(const WorldLandmarksApp());
 
 class WorldLandmarksApp extends StatelessWidget {
@@ -54,10 +60,11 @@ class _WorldLandmarksPageState extends State<WorldLandmarksPage> {
       _zoom = controller.cameraPosition?.zoom ?? _zoom;
       _positions = [
         for (final landmark in worldLandmarks)
-          _LandmarkPosition(
-            landmark: landmark,
-            offset: controller.toScreenOffset(landmark.location),
-          ),
+          for (final offset in controller.toScreenOffsets(
+            landmark.location,
+            padding: _landmarkViewportPadding,
+          ))
+            _LandmarkPosition(landmark: landmark, offset: offset),
       ];
     });
   }
@@ -191,10 +198,10 @@ class _WorldLandmarksPageState extends State<WorldLandmarksPage> {
   );
 
   bool _isOnScreen(Offset offset, Size size) =>
-      offset.dx >= -60 &&
-      offset.dx <= size.width + 60 &&
-      offset.dy >= -70 &&
-      offset.dy <= size.height + 60;
+      offset.dx >= -_landmarkViewportPadding.left &&
+      offset.dx <= size.width + _landmarkViewportPadding.right &&
+      offset.dy >= -_landmarkViewportPadding.top &&
+      offset.dy <= size.height + _landmarkViewportPadding.bottom;
 }
 
 class _LandmarkMarker extends StatelessWidget {
@@ -214,8 +221,11 @@ class _LandmarkMarker extends StatelessWidget {
   Widget build(context) {
     final landmark = position.landmark;
     final scale = landmarkMarkerScale(zoom);
-    final size = (selected ? 54.0 : 46.0) * scale;
-    final fontSize = (selected ? 27.0 : 23.0) * scale;
+    final size =
+        (selected ? _selectedLandmarkMarkerSize : _landmarkMarkerSize) * scale;
+    final fontSize =
+        (selected ? _selectedLandmarkMarkerFontSize : _landmarkMarkerFontSize) *
+        scale;
 
     return Positioned(
       left: position.offset.dx - size / 2,

--- a/lib/src/controller/maplibre_map_controller.dart
+++ b/lib/src/controller/maplibre_map_controller.dart
@@ -552,6 +552,56 @@ class MapLibreMapController extends ChangeNotifier {
     return _bridge.latLonToScreen(latLng.latitude, latLng.longitude);
   }
 
+  /// Projects every visible horizontal world copy of `latLng`.
+  ///
+  /// Multiple offsets can be returned when a low zoom shows the same wrapped
+  /// world more than once. [padding] expands the viewport used to retain
+  /// copies, which lets an overlay remain mounted while its anchor is just
+  /// outside an edge.
+  List<Offset> toScreenOffsets(
+    LatLng latLng, {
+    EdgeInsets padding = EdgeInsets.zero,
+  }) {
+    _ensureNotDisposed();
+    final width = _bridge.logicalWidth;
+    final height = _bridge.logicalHeight;
+    final camera = _cameraPosition;
+    if (width <= 0 || height <= 0 || camera == null) {
+      return <Offset>[toScreenOffset(latLng)];
+    }
+    final worldSize = 512 * math.pow(2, camera.zoom);
+    final paddedSpan = math.max(
+      width + padding.horizontal,
+      height + padding.vertical,
+    );
+    final radius = (paddedSpan / worldSize).ceil() + 2;
+    final centerWrap = ((camera.target.longitude - latLng.longitude) / 360)
+        .round();
+    final wraps = <int>[
+      for (var wrap = centerWrap - radius; wrap <= centerWrap + radius; wrap++)
+        wrap,
+    ];
+    final projected = _bridge.wrappedLatLonsToScreen([
+      for (final wrap in wraps)
+        (
+          latitude: latLng.latitude,
+          longitude: latLng.longitude,
+          tileWrap: wrap,
+        ),
+    ]);
+    final result = <Offset>[];
+    for (final offset in projected) {
+      final visible =
+          offset.dx >= -padding.left &&
+          offset.dx <= width + padding.right &&
+          offset.dy >= -padding.top &&
+          offset.dy <= height + padding.bottom;
+      if (visible && !result.contains(offset)) result.add(offset);
+    }
+
+    return result;
+  }
+
   /// Converts a logical viewport position to a geographic coordinate.
   ///
   /// `screenLocation` is relative to the top-left corner of the [MapLibreMap].

--- a/lib/src/labels/label_data.dart
+++ b/lib/src/labels/label_data.dart
@@ -53,6 +53,9 @@ class LabelData {
   /// Zero and `0xffffffff` mean that the symbol has no stable identity.
   final int crossTileId;
 
+  /// Horizontal world copy containing this placement.
+  final int tileWrap;
+
   /// Latitude of the text anchor in degrees.
   final double lat;
 
@@ -266,6 +269,7 @@ class LabelData {
   /// Creates data for a symbol placed by MapLibre.
   const LabelData({
     this.crossTileId = 0,
+    this.tileWrap = 0,
     required this.lat,
     required this.lon,
     this.iconLat = 0,

--- a/lib/src/labels/label_reconciler.dart
+++ b/lib/src/labels/label_reconciler.dart
@@ -51,7 +51,7 @@ void reconcileLabelEntries(
     final hasStableId = id != 0 && id != _invalidCrossTileId;
     final String key;
     if (hasStableId) {
-      key = '${label.layer}:$id';
+      key = '${label.layer}:$id:${label.tileWrap}';
     } else {
       // Valid identities never use a negative suffix. This keeps fallback keys
       // distinct even when a layer ID contains colons.

--- a/lib/src/labels/label_source.dart
+++ b/lib/src/labels/label_source.dart
@@ -17,7 +17,8 @@ class MapLabelSource {
   final _orderedEntries = <_OrderedLabelEntry>[];
   final _orderedEntriesByKey = <String, _OrderedLabelEntry>{};
   final _layerBuckets = <_LabelLayerBucket>[];
-  final _projectionCoordinates = <({double latitude, double longitude})>[];
+  final _projectionCoordinates =
+      <({double latitude, double longitude, int tileWrap})>[];
   var _activeLayerBucketCount = 0;
   var _nextStableOrdinal = 0;
   var _orderingDirty = true;
@@ -88,7 +89,7 @@ class MapLabelSource {
   void cacheScreenPositions(MaplibreBridge bridge, SpriteAtlas? spriteAtlas) {
     _refreshOrdering();
     _refreshProjectionCoordinates();
-    final projected = bridge.latLonsToScreen(_projectionCoordinates);
+    final projected = bridge.wrappedLatLonsToScreen(_projectionCoordinates);
     final orderedSymbols = <MapSymbol>[];
     for (var index = 0; index < _activeLayerBucketCount; index++) {
       final bucket = _layerBuckets[index];
@@ -275,7 +276,12 @@ class MapLabelSource {
       if (data.textPlaced) {
         entry.textProjectionIndex = projectionIndex;
         matches =
-            _projectionCoordinateMatches(projectionIndex, data.lat, data.lon) &&
+            _projectionCoordinateMatches(
+              projectionIndex,
+              data.lat,
+              data.lon,
+              data.tileWrap,
+            ) &&
             matches;
         projectionIndex++;
       }
@@ -291,6 +297,7 @@ class MapLabelSource {
               projectionIndex,
               data.iconLat,
               data.iconLon,
+              data.tileWrap,
             ) &&
             matches;
         projectionIndex++;
@@ -303,7 +310,11 @@ class MapLabelSource {
     for (final entry in _orderedEntries) {
       final data = entry.state.data;
       if (data.textPlaced) {
-        _projectionCoordinates.add((latitude: data.lat, longitude: data.lon));
+        _projectionCoordinates.add((
+          latitude: data.lat,
+          longitude: data.lon,
+          tileWrap: data.tileWrap,
+        ));
       }
       if (data.iconPlaced &&
           (!data.textPlaced ||
@@ -312,6 +323,7 @@ class MapLabelSource {
         _projectionCoordinates.add((
           latitude: data.iconLat,
           longitude: data.iconLon,
+          tileWrap: data.tileWrap,
         ));
       }
     }
@@ -321,11 +333,14 @@ class MapLabelSource {
     int index,
     double latitude,
     double longitude,
+    int tileWrap,
   ) {
     if (index >= _projectionCoordinates.length) return false;
     final coordinate = _projectionCoordinates[index];
 
-    return coordinate.latitude == latitude && coordinate.longitude == longitude;
+    return coordinate.latitude == latitude &&
+        coordinate.longitude == longitude &&
+        coordinate.tileWrap == tileWrap;
   }
 }
 

--- a/lib/src/native/abi_generated.dart
+++ b/lib/src/native/abi_generated.dart
@@ -46,10 +46,10 @@ abstract final class DrawCommandAbi {
   static const int stencilMode = 396;
 }
 
-/// Byte offsets of C++ `LabelExport` (size 344).
+/// Byte offsets of C++ `LabelExport` (size 352).
 abstract final class LabelExportAbi {
   LabelExportAbi._();
-  static const int size = 344;
+  static const int size = 352;
   static const int lat = 0;
   static const int lon = 8;
   static const int iconLat = 16;
@@ -132,6 +132,7 @@ abstract final class LabelExportAbi {
   static const int logicalTextLength = 332;
   static const int visualTextSectionsOffset = 336;
   static const int visualTextSectionCount = 340;
+  static const int tileWrap = 344;
 }
 
 /// Byte offsets of C++ `LabelStaticExport` (size 200).
@@ -227,7 +228,7 @@ abstract final class LabelDynamicExportAbi {
   static const int iconTransformYY = 136;
   static const int renderOrder = 140;
   static const int staticIndex = 144;
-  static const int reserved = 148;
+  static const int tileWrap = 148;
 }
 
 /// Byte offsets of C++ `LabelStringRefExport` (size 8).

--- a/lib/src/native/label_export_decoder.dart
+++ b/lib/src/native/label_export_decoder.dart
@@ -333,6 +333,10 @@ List<LabelData> decodeLabelExports({
             offset + LabelExportAbi.crossTileID,
             Endian.little,
           ),
+          tileWrap: data.getInt32(
+            offset + LabelExportAbi.tileWrap,
+            Endian.little,
+          ),
           text: logicalText,
           visualText: visualText,
           layer: _string(
@@ -1067,6 +1071,10 @@ List<LabelData> decodeLabelDynamicExports({
           textKeepUpright: cached.textKeepUpright,
           iconKeepUpright: cached.iconKeepUpright,
           crossTileId: cached.crossTileId,
+          tileWrap: data.getInt32(
+            offset + LabelDynamicExportAbi.tileWrap,
+            Endian.little,
+          ),
           text: cached.text,
           visualText: cached.visualText,
           textDirection: cached.textDirection,

--- a/lib/src/native/maplibre_ffi.dart
+++ b/lib/src/native/maplibre_ffi.dart
@@ -109,9 +109,12 @@ class MaplibreBridge
   late final InitD _init;
   late final LatLonToScreenD _latLonToScreen;
   ProjectCoordinatesD? _projectCoordinates;
+  ProjectWrappedCoordinatesD? _projectWrappedCoordinates;
   LatLonToScreenD? _screenToLatLon;
   late final SetSizeD _setSize;
   late final VoidVoidD _destroy;
+  var _logicalWidth = 0;
+  var _logicalHeight = 0;
   NativeCallable<RenderRequestN>? _renderRequestCallable;
   Int32VoidD? _asyncRenderSupported;
   Int32VoidD? _renderFrameAsync;
@@ -127,6 +130,7 @@ class MaplibreBridge
   final _outY = calloc<Double>();
   Pointer<Double> _projectionLatitudes = nullptr;
   Pointer<Double> _projectionLongitudes = nullptr;
+  Pointer<Int32> _projectionTileWraps = nullptr;
   Pointer<Float> _projectionX = nullptr;
   Pointer<Float> _projectionY = nullptr;
   var _projectionCapacity = 0;
@@ -388,6 +392,13 @@ class MaplibreBridge
             'maplibre_project_coordinates',
           );
     });
+    _symbols.lookUpGroup('wrapped batch coordinate projection', () {
+      _projectWrappedCoordinates = _lib
+          .lookupFunction<
+            ProjectWrappedCoordinatesN,
+            ProjectWrappedCoordinatesD
+          >('maplibre_project_wrapped_coordinates');
+    });
     _setSize = _lib.lookupFunction<SetSizeN, SetSizeD>('maplibre_set_size');
     _destroy = _lib.lookupFunction<VoidVoidN, VoidVoidD>('maplibre_destroy');
     // Missing event callbacks use the polling scheduler.
@@ -431,16 +442,29 @@ class MaplibreBridge
   /// Initializes the native map with a logical size, pixel ratio, and style URL.
   ///
   /// Returns one of [initSuccess], [initFailure], or [initBusy].
-  int init(int width, int height, double pixelRatio, String styleUrl) =>
-      _lifecycle.initialize(() {
-        _activateNativeSession();
-        final urlPtr = styleUrl.toNativeUtf8();
-        try {
-          return _init(width, height, pixelRatio, urlPtr.cast());
-        } finally {
-          calloc.free(urlPtr);
-        }
-      });
+  int init(int width, int height, double pixelRatio, String styleUrl) {
+    final result = _lifecycle.initialize(() {
+      _activateNativeSession();
+      final urlPtr = styleUrl.toNativeUtf8();
+      try {
+        return _init(width, height, pixelRatio, urlPtr.cast());
+      } finally {
+        calloc.free(urlPtr);
+      }
+    });
+    if (result == initSuccess) {
+      _logicalWidth = width;
+      _logicalHeight = height;
+    }
+
+    return result;
+  }
+
+  /// Current logical viewport width.
+  int get logicalWidth => _logicalWidth;
+
+  /// Current logical viewport height.
+  int get logicalHeight => _logicalHeight;
 
   /// Synchronously renders one native command frame.
   int renderFrame() {
@@ -566,6 +590,42 @@ class MaplibreBridge
     ];
   }
 
+  /// Projects coordinates at explicit horizontal world copies.
+  List<Offset> wrappedLatLonsToScreen(
+    List<({double latitude, double longitude, int tileWrap})> coordinates,
+  ) {
+    _lifecycle.ensureActive();
+    final count = coordinates.length;
+    if (count == 0) return const <Offset>[];
+    final project = _projectWrappedCoordinates;
+    if (project == null) {
+      return latLonsToScreen([
+        for (final coordinate in coordinates)
+          (latitude: coordinate.latitude, longitude: coordinate.longitude),
+      ]);
+    }
+    _ensureProjectionCapacity(count);
+    for (var index = 0; index < count; index++) {
+      final coordinate = coordinates[index];
+      _projectionLatitudes[index] = coordinate.latitude;
+      _projectionLongitudes[index] = coordinate.longitude;
+      _projectionTileWraps[index] = coordinate.tileWrap;
+    }
+    project(
+      _projectionLatitudes,
+      _projectionLongitudes,
+      _projectionTileWraps,
+      _projectionX,
+      _projectionY,
+      count,
+    );
+
+    return [
+      for (var index = 0; index < count; index++)
+        Offset(_projectionX[index], _projectionY[index]),
+    ];
+  }
+
   /// Ensures the reusable native projection buffers can hold [count] points.
   void _ensureProjectionCapacity(int count) {
     if (_projectionCapacity >= count) return;
@@ -577,11 +637,13 @@ class MaplibreBridge
       calloc
         ..free(_projectionLatitudes)
         ..free(_projectionLongitudes)
+        ..free(_projectionTileWraps)
         ..free(_projectionX)
         ..free(_projectionY);
     }
     _projectionLatitudes = calloc<Double>(capacity);
     _projectionLongitudes = calloc<Double>(capacity);
+    _projectionTileWraps = calloc<Int32>(capacity);
     _projectionX = calloc<Float>(capacity);
     _projectionY = calloc<Float>(capacity);
     _projectionCapacity = capacity;
@@ -608,6 +670,8 @@ class MaplibreBridge
   void setSize(int width, int height) {
     _lifecycle.ensureActive();
     _setSize(width, height);
+    _logicalWidth = width;
+    _logicalHeight = height;
   }
 
   // Native DrawCommand entry points.
@@ -874,6 +938,7 @@ class MaplibreBridge
             calloc
               ..free(_projectionLatitudes)
               ..free(_projectionLongitudes)
+              ..free(_projectionTileWraps)
               ..free(_projectionX)
               ..free(_projectionY);
           }

--- a/lib/src/native/signatures.dart
+++ b/lib/src/native/signatures.dart
@@ -167,6 +167,23 @@ typedef ProjectCoordinatesD = void Function(
   int count,
 );
 
+typedef ProjectWrappedCoordinatesN = Void Function(
+  Pointer<Double> latitudes,
+  Pointer<Double> longitudes,
+  Pointer<Int32> tileWraps,
+  Pointer<Float> outputX,
+  Pointer<Float> outputY,
+  Int32 count,
+);
+typedef ProjectWrappedCoordinatesD = void Function(
+  Pointer<Double> latitudes,
+  Pointer<Double> longitudes,
+  Pointer<Int32> tileWraps,
+  Pointer<Float> outputX,
+  Pointer<Float> outputY,
+  int count,
+);
+
 typedef MoveByN = Void Function(Double dx, Double dy);
 typedef MoveByD = void Function(double dx, double dy);
 

--- a/native/src/bridge_labels.cpp
+++ b/native/src/bridge_labels.cpp
@@ -176,8 +176,9 @@ struct LabelExport {
     uint32_t logicalTextLength;
     uint32_t visualTextSectionsOffset;
     uint32_t visualTextSectionCount;
+    int32_t tileWrap;
 };
-static_assert(sizeof(LabelExport) == 344, "LabelExport size must be stable for FFI");
+static_assert(sizeof(LabelExport) == 352, "LabelExport size must be stable for FFI");
 
 COMMAND_EXPORT_ABI_OFFSET(LabelExport, lat, 0);
 COMMAND_EXPORT_ABI_OFFSET(LabelExport, lon, 8);
@@ -261,6 +262,7 @@ COMMAND_EXPORT_ABI_OFFSET(LabelExport, logicalTextOffset, 328);
 COMMAND_EXPORT_ABI_OFFSET(LabelExport, logicalTextLength, 332);
 COMMAND_EXPORT_ABI_OFFSET(LabelExport, visualTextSectionsOffset, 336);
 COMMAND_EXPORT_ABI_OFFSET(LabelExport, visualTextSectionCount, 340);
+COMMAND_EXPORT_ABI_OFFSET(LabelExport, tileWrap, 344);
 
 // Variable-size values use byte offsets into the static label blob.
 struct LabelStaticExport {
@@ -402,7 +404,7 @@ struct LabelDynamicExport {
     float iconTransformYY;
     uint32_t renderOrder;
     uint32_t staticIndex;
-    uint32_t reserved;
+    int32_t tileWrap;
 };
 static_assert(sizeof(LabelDynamicExport) == 152, "LabelDynamicExport size must be stable for FFI");
 COMMAND_EXPORT_ABI_OFFSET(LabelDynamicExport, lat, 0);
@@ -438,7 +440,7 @@ COMMAND_EXPORT_ABI_OFFSET(LabelDynamicExport, iconTransformYX, 132);
 COMMAND_EXPORT_ABI_OFFSET(LabelDynamicExport, iconTransformYY, 136);
 COMMAND_EXPORT_ABI_OFFSET(LabelDynamicExport, renderOrder, 140);
 COMMAND_EXPORT_ABI_OFFSET(LabelDynamicExport, staticIndex, 144);
-COMMAND_EXPORT_ABI_OFFSET(LabelDynamicExport, reserved, 148);
+COMMAND_EXPORT_ABI_OFFSET(LabelDynamicExport, tileWrap, 148);
 
 class ExportFeature final : public mbgl::GeometryTileFeature {
 public:
@@ -800,6 +802,7 @@ LabelDynamicExport dynamicRecord(const LabelExport& label, uint32_t staticIndex)
     result.iconTransformYY = label.iconTransformYY;
     result.renderOrder = label.renderOrder;
     result.staticIndex = staticIndex;
+    result.tileWrap = label.tileWrap;
     return result;
 }
 
@@ -887,6 +890,7 @@ LabelExport legacyRecord(const LabelStaticExport& statik, const LabelDynamicExpo
     result.logicalTextLength = statik.logicalTextLength;
     result.visualTextSectionsOffset = statik.visualTextSectionsOffset;
     result.visualTextSectionCount = statik.visualTextSectionCount;
+    result.tileWrap = dynamic.tileWrap;
     return result;
 }
 
@@ -1747,6 +1751,7 @@ void bridge_extractLabels(const mbgl::TransformState* renderedState) {
         base.textAngle = symbol.textAngle;
         base.iconAngle = symbol.iconAngle;
         base.crossTileID = symbol.crossTileID;
+        base.tileWrap = symbol.tileWrap;
         base.textOffsetX = textCenterX;
         base.textOffsetY = textCenterY;
         base.iconOffsetX = iconCenterX;

--- a/native/src/maplibre_bridge.cpp
+++ b/native/src/maplibre_bridge.cpp
@@ -2063,7 +2063,7 @@ MAPLIBRE_API void maplibre_project_wrapped_coordinates(
                         mbgl::util::DEGREES_MAX};
             const auto screen = state.latLngToScreenCoordinate(coordinate);
             out_x[index] = static_cast<float>(screen.x);
-            out_y[index] = static_cast<float>(screen.y);
+            out_y[index] = static_cast<float>(state.getSize().height - screen.y);
         }
         return true;
     });

--- a/native/src/maplibre_bridge.cpp
+++ b/native/src/maplibre_bridge.cpp
@@ -515,6 +515,47 @@ bool bridge_projectPublishedCoordinates(
 #endif
 }
 
+bool bridge_projectPublishedWrappedCoordinates(
+    const double* latitudes,
+    const double* longitudes,
+    const int32_t* tileWraps,
+    float* outX,
+    float* outY,
+    int count) {
+#if defined(__ANDROID__) && MLN_RENDER_BACKEND_COMMAND_EXPORT
+    if (!latitudes || !longitudes || !tileWraps || !outX || !outY ||
+        count <= 0) {
+        return false;
+    }
+    std::lock_guard<std::mutex> lock(g_asyncFrame.mutex);
+    if ((!g_asyncFrame.ready && !g_asyncFrame.acquired) ||
+        !g_snapshotTransform) {
+        return false;
+    }
+    for (int index = 0; index < count; ++index) {
+        const mbgl::LatLng coordinate{
+            latitudes[index],
+            longitudes[index] +
+                static_cast<double>(tileWraps[index]) *
+                    mbgl::util::DEGREES_MAX};
+        const auto screen =
+            g_snapshotTransform->latLngToScreenCoordinate(coordinate);
+        outX[index] = static_cast<float>(screen.x);
+        outY[index] = static_cast<float>(
+            g_snapshotTransform->getSize().height - screen.y);
+    }
+    return true;
+#else
+    (void)latitudes;
+    (void)longitudes;
+    (void)tileWraps;
+    (void)outX;
+    (void)outY;
+    (void)count;
+    return false;
+#endif
+}
+
 bool bridge_unprojectPublishedCoordinate(
     double x,
     double y,
@@ -1985,6 +2026,42 @@ MAPLIBRE_API void maplibre_project_coordinates(
         for (int index = 0; index < count; index++) {
             const auto screen = g_map->pixelForLatLng(
                 mbgl::LatLng{latitudes[index], longitudes[index]});
+            out_x[index] = static_cast<float>(screen.x);
+            out_y[index] = static_cast<float>(screen.y);
+        }
+        return true;
+    });
+}
+
+MAPLIBRE_API void maplibre_project_wrapped_coordinates(
+    const double* latitudes,
+    const double* longitudes,
+    const int32_t* tile_wraps,
+    float* out_x,
+    float* out_y,
+    int count) {
+    if (!latitudes || !longitudes || !tile_wraps || !out_x || !out_y ||
+        count <= 0) {
+        return;
+    }
+    if (bridge_projectPublishedWrappedCoordinates(
+            latitudes,
+            longitudes,
+            tile_wraps,
+            out_x,
+            out_y,
+            count)) {
+        return;
+    }
+    runCameraOperation("project wrapped coordinates", [&] {
+        const auto state = g_map->getTransfromState();
+        for (int index = 0; index < count; ++index) {
+            const mbgl::LatLng coordinate{
+                latitudes[index],
+                longitudes[index] +
+                    static_cast<double>(tile_wraps[index]) *
+                        mbgl::util::DEGREES_MAX};
+            const auto screen = state.latLngToScreenCoordinate(coordinate);
             out_x[index] = static_cast<float>(screen.x);
             out_y[index] = static_cast<float>(screen.y);
         }

--- a/test/abi_generated_test.dart
+++ b/test/abi_generated_test.dart
@@ -37,7 +37,7 @@ void main() {
     expect(DrawCommandAbi.subLayerIndex, 388);
     expect(DrawCommandAbi.stencilReference, 392);
     expect(DrawCommandAbi.stencilMode, 396);
-    expect(LabelExportAbi.size, 344);
+    expect(LabelExportAbi.size, 352);
     expect(LabelExportAbi.crossTileID, 120);
     expect(LabelExportAbi.textOffset, 124);
     expect(LabelExportAbi.textFontsOffset, 148);
@@ -53,6 +53,7 @@ void main() {
     expect(LabelExportAbi.logicalTextLength, 332);
     expect(LabelExportAbi.visualTextSectionsOffset, 336);
     expect(LabelExportAbi.visualTextSectionCount, 340);
+    expect(LabelExportAbi.tileWrap, 344);
     expect(LabelStaticExportAbi.size, 200);
     expect(LabelStaticExportAbi.crossTileID, 64);
     expect(LabelStaticExportAbi.textOffset, 68);
@@ -65,7 +66,7 @@ void main() {
     expect(LabelDynamicExportAbi.textTransformXX, 108);
     expect(LabelDynamicExportAbi.renderOrder, 140);
     expect(LabelDynamicExportAbi.staticIndex, 144);
-    expect(LabelDynamicExportAbi.reserved, 148);
+    expect(LabelDynamicExportAbi.tileWrap, 148);
     expect(LabelStringRefExportAbi.size, 8);
     expect(LabelTextSectionExportAbi.size, 48);
     expect(LabelPathPointExportAbi.size, 8);

--- a/test/label_export_decoder_test.dart
+++ b/test/label_export_decoder_test.dart
@@ -200,6 +200,7 @@ List<LabelData> _decode(List<_Export> exports, _Blob blob) =>
 
 List<Object?> _labelSignature(LabelData data) => <Object?>[
   data.crossTileId,
+  data.tileWrap,
   data.lat,
   data.lon,
   data.iconLat,
@@ -395,6 +396,7 @@ List<Object?> _labelSignature(LabelData data) => <Object?>[
     (LabelExportAbi.iconTransformYX, LabelDynamicExportAbi.iconTransformYX),
     (LabelExportAbi.iconTransformYY, LabelDynamicExportAbi.iconTransformYY),
     (LabelExportAbi.renderOrder, LabelDynamicExportAbi.renderOrder),
+    (LabelExportAbi.tileWrap, LabelDynamicExportAbi.tileWrap),
   ];
   for (final (source, target) in staticFields) {
     statik.bytes.setRange(target, target + 4, full.bytes, source);
@@ -829,6 +831,7 @@ void main() {
   test('carries paint effects and stable identity', () {
     final export = _Export()
       ..u32(LabelExportAbi.crossTileID, 4294967295)
+      ..i32(LabelExportAbi.tileWrap, -2)
       ..f32(LabelExportAbi.iconHaloR, 0.25)
       ..f32(LabelExportAbi.iconHaloA, 0.5)
       ..f32(LabelExportAbi.iconHaloWidth, 3)
@@ -841,6 +844,7 @@ void main() {
     final label = _decode(<_Export>[export], _Blob()).single;
 
     expect(label.crossTileId, 4294967295);
+    expect(label.tileWrap, -2);
     expect(label.iconHaloWidth, 3);
     expect(label.iconHaloBlur, 2);
     expect(label.iconFitWidth, 48);
@@ -893,6 +897,7 @@ void main() {
       ..u32(LabelExportAbi.flags, 15)
       ..f32(LabelExportAbi.textAngle, -0.5)
       ..u32(LabelExportAbi.crossTileID, 42)
+      ..i32(LabelExportAbi.tileWrap, 1)
       ..string(
         blob,
         LabelExportAbi.textOffset,

--- a/test/label_reconciler_test.dart
+++ b/test/label_reconciler_test.dart
@@ -4,6 +4,7 @@ import 'package:maplibre_flutter_gpu/src/labels/label_reconciler.dart';
 
 LabelData _label({
   required int crossTileId,
+  int tileWrap = 0,
   String layer = 'labels',
   String text = 'label',
   String icon = '',
@@ -15,6 +16,7 @@ LabelData _label({
   bool iconPlaced = false,
 }) => LabelData(
   crossTileId: crossTileId,
+  tileWrap: tileWrap,
   lat: lat,
   lon: lon,
   iconLat: iconLat,
@@ -43,8 +45,8 @@ void main() {
 
     reconcileLabelEntries(entries, [first], fallbackGeneration: 0);
 
-    expect(entries.keys, ['labels:42']);
-    final entry = entries['labels:42']!..appeared = true;
+    expect(entries.keys, ['labels:42:0']);
+    final entry = entries['labels:42:0']!..appeared = true;
     final latest = _label(
       crossTileId: 42,
       text: 'new',
@@ -59,7 +61,7 @@ void main() {
 
     reconcileLabelEntries(entries, [latest], fallbackGeneration: 1);
 
-    expect(identical(entries['labels:42'], entry), isTrue);
+    expect(identical(entries['labels:42:0'], entry), isTrue);
     expect(identical(entry.data, latest), isTrue);
     expect(entry.data.lat, 30);
     expect(entry.data.iconLat, 50);
@@ -82,10 +84,10 @@ void main() {
 
     reconcileLabelEntries(entries, firstSnapshot, fallbackGeneration: 3);
 
-    expect(entries, containsPair('roads:7', isA<LabelReconcileEntry>()));
-    expect(entries, containsPair('places:7', isA<LabelReconcileEntry>()));
+    expect(entries, containsPair('roads:7:0', isA<LabelReconcileEntry>()));
+    expect(entries, containsPair('places:7:0', isA<LabelReconcileEntry>()));
     final firstFallbackKeys = entries.keys
-        .where((key) => key != 'roads:7' && key != 'places:7')
+        .where((key) => key != 'roads:7:0' && key != 'places:7:0')
         .toSet();
     expect(firstFallbackKeys, hasLength(4));
     expect(firstFallbackKeys.every((key) => key.startsWith('roads:-')), isTrue);
@@ -101,8 +103,8 @@ void main() {
     expect(visibleKeys, hasLength(1));
     expect(firstFallbackKeys.intersection(visibleKeys), isEmpty);
     expect(firstFallbackKeys.every((key) => !entries[key]!.visible), isTrue);
-    expect(entries['roads:7']!.visible, isFalse);
-    expect(entries['places:7']!.visible, isFalse);
+    expect(entries['roads:7:0']!.visible, isFalse);
+    expect(entries['places:7:0']!.visible, isFalse);
   });
 
   test('missing snapshots get one fade grace period without accumulating', () {
@@ -118,12 +120,12 @@ void main() {
 
     expect(maxEntryCount, 2);
     expect(entries, hasLength(2));
-    expect(entries['labels:999']!.visible, isFalse);
-    expect(entries['labels:1000']!.visible, isTrue);
+    expect(entries['labels:999:0']!.visible, isFalse);
+    expect(entries['labels:1000:0']!.visible, isTrue);
 
     reconcileLabelEntries(entries, const [], fallbackGeneration: 1000);
-    expect(entries.keys, ['labels:1000']);
-    expect(entries['labels:1000']!.visible, isFalse);
+    expect(entries.keys, ['labels:1000:0']);
+    expect(entries['labels:1000:0']!.visible, isFalse);
 
     reconcileLabelEntries(entries, const [], fallbackGeneration: 1001);
     expect(entries, isEmpty);
@@ -134,7 +136,7 @@ void main() {
     reconcileLabelEntries(entries, [
       _label(crossTileId: 1),
     ], fallbackGeneration: 0);
-    final original = entries['labels:1']!..appeared = true;
+    final original = entries['labels:1:0']!..appeared = true;
 
     reconcileLabelEntries(entries, [
       _label(crossTileId: 2),
@@ -145,10 +147,26 @@ void main() {
       _label(crossTileId: 1, text: 'revived'),
     ], fallbackGeneration: 2);
 
-    expect(identical(entries['labels:1'], original), isTrue);
+    expect(identical(entries['labels:1:0'], original), isTrue);
     expect(original.visible, isTrue);
     expect(original.appeared, isTrue);
     expect(original.data.text, 'revived');
-    expect(entries['labels:2']!.visible, isFalse);
+    expect(entries['labels:2:0']!.visible, isFalse);
+  });
+
+  test('world copies keep separate stable identities', () {
+    final entries = <String, LabelReconcileEntry>{};
+
+    reconcileLabelEntries(entries, [
+      _label(crossTileId: 7, tileWrap: -1),
+      _label(crossTileId: 7),
+      _label(crossTileId: 7, tileWrap: 1),
+    ], fallbackGeneration: 0);
+
+    expect(
+      entries.keys,
+      containsAll(['labels:7:-1', 'labels:7:0', 'labels:7:1']),
+    );
+    expect(entries, hasLength(3));
   });
 }

--- a/test/label_source_test.dart
+++ b/test/label_source_test.dart
@@ -14,6 +14,7 @@ LabelData _label({
   required String text,
   String layer = 'places',
   int crossTileId = 0,
+  int tileWrap = 0,
   bool textPlaced = true,
   bool iconPlaced = false,
   String icon = '',
@@ -26,6 +27,7 @@ LabelData _label({
   int renderOrder = 0,
 }) => LabelData(
   crossTileId: crossTileId,
+  tileWrap: tileWrap,
   lat: lat,
   lon: lon,
   iconLat: iconLat,
@@ -59,8 +61,9 @@ class _FakeBridge implements MaplibreBridge {
   Offset projectionOffset = Offset.zero;
   int getLabelsCalls = 0;
   int batchProjectionCalls = 0;
-  final List<List<({double latitude, double longitude})>> projectionInputs =
-      <List<({double latitude, double longitude})>>[];
+  final List<List<({double latitude, double longitude, int tileWrap})>>
+  projectionInputs =
+      <List<({double latitude, double longitude, int tileWrap})>>[];
   final List<int> projectionBatchSizes = <int>[];
   final List<({double lat, double lon})> projected =
       <({double lat, double lon})>[];
@@ -87,13 +90,30 @@ class _FakeBridge implements MaplibreBridge {
   List<Offset> latLonsToScreen(
     List<({double latitude, double longitude})> coordinates,
   ) {
+    return wrappedLatLonsToScreen([
+      for (final coordinate in coordinates)
+        (
+          latitude: coordinate.latitude,
+          longitude: coordinate.longitude,
+          tileWrap: 0,
+        ),
+    ]);
+  }
+
+  @override
+  List<Offset> wrappedLatLonsToScreen(
+    List<({double latitude, double longitude, int tileWrap})> coordinates,
+  ) {
     batchProjectionCalls++;
     projectionInputs.add(coordinates);
     projectionBatchSizes.add(coordinates.length);
 
     return <Offset>[
       for (final coordinate in coordinates)
-        latLonToScreen(coordinate.latitude, coordinate.longitude),
+        latLonToScreen(
+          coordinate.latitude,
+          coordinate.longitude + coordinate.tileWrap * 360,
+        ),
     ];
   }
 
@@ -226,6 +246,28 @@ void main() {
       final symbol = source.symbols.single;
       expect(symbol.textPos, isNotNull);
       expect(symbol.iconPos, isNotNull);
+    });
+
+    test('projects each low-zoom world copy independently', () {
+      final bridge = _FakeBridge(1, <LabelData>[
+        _label(text: 'west', crossTileId: 7, tileWrap: -1, lon: 140),
+        _label(text: 'center', crossTileId: 7, lon: 140),
+        _label(text: 'east', crossTileId: 7, tileWrap: 1, lon: 140),
+      ]);
+      final source = MapLabelSource()..syncFromNative(bridge);
+
+      source.cacheScreenPositions(bridge, null);
+
+      expect(source.symbols, hasLength(3));
+      expect(source.symbols.map((symbol) => symbol.textPos!.dx), <double>[
+        -220,
+        140,
+        500,
+      ]);
+      expect(
+        bridge.projectionInputs.single.map((coordinate) => coordinate.tileWrap),
+        <int>[-1, 0, 1],
+      );
     });
 
     test('reuses shared projection input across camera updates', () {

--- a/test/maplibre_map_controller_test.dart
+++ b/test/maplibre_map_controller_test.dart
@@ -324,6 +324,30 @@ class _FakeBridge implements MaplibreBridge {
   }
 
   @override
+  int get logicalWidth => 800;
+
+  @override
+  int get logicalHeight => 600;
+
+  @override
+  List<Offset> wrappedLatLonsToScreen(
+    List<({double latitude, double longitude, int tileWrap})> coordinates,
+  ) {
+    final worldSize = 512 * math.pow(2, zoom);
+
+    return <Offset>[
+      for (final coordinate in coordinates)
+        Offset(
+          400 +
+              (coordinate.longitude + coordinate.tileWrap * 360 - lon) /
+                  360 *
+                  worldSize,
+          300,
+        ),
+    ];
+  }
+
+  @override
   ({double latitude, double longitude}) screenToLatLon(double x, double y) {
     callCount++;
 
@@ -359,6 +383,20 @@ Future<CameraPosition> _apply(CameraUpdate update) async {
 }
 
 void main() {
+  test('screen offsets retain every visible wrapped world copy', () {
+    final bridge = _FakeBridge()
+      ..lat = 0
+      ..lon = 180
+      ..zoom = 0;
+    final controller = MapLibreMapController.bind(bridge);
+
+    expect(controller.toScreenOffsets(const LatLng(0, 0)), <Offset>[
+      const Offset(144, 300),
+      const Offset(656, 300),
+    ]);
+    controller.dispose();
+  });
+
   test('camera values serialize like maplibre_gl', () {
     const position = CameraPosition(
       bearing: 20,

--- a/test/native_build_configuration_test.dart
+++ b/test/native_build_configuration_test.dart
@@ -36,6 +36,23 @@ void main() {
     );
   });
 
+  test('wrapped projection converts native y coordinates to screen space', () {
+    final bridge = File('native/src/maplibre_bridge.cpp').readAsStringSync();
+    final projectionStart = bridge.indexOf(
+      'MAPLIBRE_API void maplibre_project_wrapped_coordinates',
+    );
+    final projectionEnd = bridge.indexOf(
+      'MAPLIBRE_API void maplibre_screen_to_lat_lon',
+      projectionStart,
+    );
+    expect(projectionStart, greaterThanOrEqualTo(0));
+    expect(projectionEnd, greaterThan(projectionStart));
+    expect(
+      bridge.substring(projectionStart, projectionEnd),
+      contains('state.getSize().height - screen.y'),
+    );
+  });
+
   test('owner teardown waits for an acquired frame lease', () {
     final bridge = File('native/src/maplibre_bridge.cpp').readAsStringSync();
     expect(bridge, contains('g_asyncFrame.leaseReleased.wait('));

--- a/test/split_label_export_contract_test.dart
+++ b/test/split_label_export_contract_test.dart
@@ -23,7 +23,7 @@ void main() {
     expect(source, contains('result.staticIndex = staticIndex;'));
     expect(
       source,
-      contains('COMMAND_EXPORT_ABI_OFFSET(LabelDynamicExport, reserved, 148)'),
+      contains('COMMAND_EXPORT_ABI_OFFSET(LabelDynamicExport, tileWrap, 148)'),
     );
   });
 

--- a/tool/ci/verify_desktop_artifact.py
+++ b/tool/ci/verify_desktop_artifact.py
@@ -31,7 +31,7 @@ REQUIRED_SESSION_EXPORTS = {
 }
 EXPECTED_STRIDES = {
     "maplibre_frame_get_command_stride": 400,
-    "maplibre_get_label_stride": 344,
+    "maplibre_get_label_stride": 352,
     "maplibre_get_label_static_stride": 200,
     "maplibre_get_label_dynamic_stride": 152,
 }


### PR DESCRIPTION
## Summary

- preserve the native tile wrap for every Flutter-rendered style symbol
- keep wrapped copies separate during reconciliation and project each copy at its exact world position
- add MapLibreMapController.toScreenOffsets for custom Stack overlays that need every visible world copy
- share the example marker dimensions and viewport padding through named constants

## Why

At low zoom, the viewport can be wider than one Mercator world. MapLibre then places the same symbol in multiple horizontal world copies.

The native placement already identified each copy with tileWrap, but that value was discarded by the Dart export. Reconciliation keyed symbols only by layer and cross-tile ID, so separate copies collapsed into one Widget. Projection also selected the nearest wrapped longitude, which placed surviving copies at the same screen position.

This change carries tileWrap through the native ABI and Dart model, includes it in Widget identity, and uses a dedicated wrapped projection path. The existing single-coordinate projection remains unchanged, avoiding the scrolling drift caused by changing its wrapping behavior.

Custom Stack overlays cannot represent multiple copies with one Offset. The new toScreenOffsets method returns every visible copy and accepts viewport padding so partially visible overlays can remain mounted.

## Validation

- user verified the original macOS issue no longer reproduces
- macOS visual E2E at requested zoom 0.09, constrained by MapLibre to 0.33985000288462475, shows both horizontal copies at the correct viewport edges
- rebuilt the universal macOS native bridge for arm64 and x86_64
- 89 focused Flutter tests passed
- additional decoder and controller regression suites passed
- git diff --check
- flutter analyze reported only the 2 pre-existing avoid_relative_lib_imports info findings