### PR TITLE
feat(macos): add three-finger trackpad tilt

### DIFF
--- a/darwin/maplibre_flutter_gpu/Sources/maplibre_flutter_gpu/MaplibreFlutterGpuPlugin.swift
+++ b/darwin/maplibre_flutter_gpu/Sources/maplibre_flutter_gpu/MaplibreFlutterGpuPlugin.swift
@@ -9,11 +9,30 @@ import MapLibreBridge
 public final class MaplibreFlutterGpuPlugin: NSObject, FlutterPlugin {
 #if os(macOS)
   private static var terminationObserver: NSObjectProtocol?
+  private static let trackpadTiltChannelName =
+    "dev.maplibre.flutter_gpu/macos_trackpad_tilt"
+
+  private weak var flutterView: NSView?
+  private var trackpadTiltChannel: FlutterMethodChannel?
+  private var tiltRegions: [Int: NSRect] = [:]
+  private var activeTiltRegion: Int?
+  private var previousTrackpadDragPoint: NSPoint?
+  private var eventMonitor: Any?
 #endif
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     _ = maplibre_flutter_gpu_force_link()
 #if os(macOS)
+    let plugin = MaplibreFlutterGpuPlugin()
+    let channel = FlutterMethodChannel(
+      name: trackpadTiltChannelName,
+      binaryMessenger: registrar.messenger
+    )
+    plugin.flutterView = registrar.view
+    plugin.trackpadTiltChannel = channel
+    registrar.addMethodCallDelegate(plugin, channel: channel)
+    plugin.installTrackpadMonitor()
+
     if terminationObserver == nil {
       terminationObserver = NotificationCenter.default.addObserver(
         forName: NSApplication.willTerminateNotification,
@@ -25,4 +44,106 @@ public final class MaplibreFlutterGpuPlugin: NSObject, FlutterPlugin {
     }
 #endif
   }
+
+#if os(macOS)
+  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    guard let arguments = call.arguments as? [String: Any],
+          let id = arguments["id"] as? Int else {
+      result(FlutterError(code: "invalid_arguments", message: nil, details: nil))
+      return
+    }
+    switch call.method {
+    case "setTiltRegion":
+      guard let x = arguments["x"] as? Double,
+            let y = arguments["y"] as? Double,
+            let width = arguments["width"] as? Double,
+            let height = arguments["height"] as? Double,
+            let enabled = arguments["enabled"] as? Bool else {
+        result(FlutterError(code: "invalid_arguments", message: nil, details: nil))
+        return
+      }
+      if enabled {
+        tiltRegions[id] = NSRect(x: x, y: y, width: width, height: height)
+      } else {
+        tiltRegions.removeValue(forKey: id)
+      }
+      result(nil)
+    case "removeTiltRegion":
+      tiltRegions.removeValue(forKey: id)
+      result(nil)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private func installTrackpadMonitor() {
+    let mouseDragEvents: NSEvent.EventTypeMask = [
+      .leftMouseDown,
+      .leftMouseDragged,
+      .leftMouseUp,
+    ]
+    eventMonitor = NSEvent.addLocalMonitorForEvents(matching: mouseDragEvents) {
+      [weak self] event in
+      self?.handleTrackpadDragEvent(event) ?? event
+    }
+  }
+
+  private func startTrackpadTilt(at location: NSPoint) -> Bool {
+    guard let region = tiltRegions.first(where: { $0.value.contains(location) })?.key else {
+      return false
+    }
+    activeTiltRegion = region
+    previousTrackpadDragPoint = location
+    sendTrackpadTilt(id: region, phase: "start")
+    return true
+  }
+
+  private func updateTrackpadTilt(deltaY: CGFloat) {
+    guard let region = activeTiltRegion else { return }
+    sendTrackpadTilt(id: region, phase: "update", deltaY: deltaY)
+  }
+
+  private func endTrackpadTilt() {
+    guard let region = activeTiltRegion else { return }
+    sendTrackpadTilt(id: region, phase: "end")
+    activeTiltRegion = nil
+    previousTrackpadDragPoint = nil
+  }
+
+  private func handleTrackpadDragEvent(_ event: NSEvent) -> NSEvent? {
+    guard event.subtype == .touch, let flutterView else { return event }
+    let point = flutterView.convert(event.locationInWindow, from: nil)
+    switch event.type {
+    case .leftMouseDown:
+      return startTrackpadTilt(at: point) ? nil : event
+    case .leftMouseDragged:
+      guard activeTiltRegion != nil else { return event }
+      if let previousTrackpadDragPoint {
+        updateTrackpadTilt(deltaY: point.y - previousTrackpadDragPoint.y)
+      }
+      previousTrackpadDragPoint = point
+      return nil
+    case .leftMouseUp:
+      guard activeTiltRegion != nil else { return event }
+      endTrackpadTilt()
+      return nil
+    default:
+      return event
+    }
+  }
+
+  private func sendTrackpadTilt(id: Int, phase: String, deltaY: Double? = nil) {
+    var arguments: [String: Any] = ["id": id, "phase": phase]
+    if let deltaY {
+      arguments["deltaY"] = deltaY
+    }
+    trackpadTiltChannel?.invokeMethod("trackpadTilt", arguments: arguments)
+  }
+
+  deinit {
+    if let eventMonitor {
+      NSEvent.removeMonitor(eventMonitor)
+    }
+  }
+#endif
 }

--- a/lib/src/state/gesture/gesture_coordinator.dart
+++ b/lib/src/state/gesture/gesture_coordinator.dart
@@ -76,6 +76,7 @@ class MapGestureCoordinator {
   var _scaleGestureActive = false;
   var _suppressScaleUntilPointersReleased = false;
   var _trackpadGestureActive = false;
+  var _macosTrackpadTiltActive = false;
   var _previousTrackpadScale = 1.0;
   var _previousTrackpadRotation = 0.0;
   Offset? _doubleTapPosition;
@@ -354,6 +355,33 @@ class MapGestureCoordinator {
     if (cameraChanged) _scheduleGestureRender();
   }
 
+  /// Begins a native macOS three-finger trackpad tilt.
+  void onMacosTrackpadTiltStart() {
+    if (host.gestureBridge == null || !host.gestureSettings.tiltEnabled) return;
+    _macosTrackpadTiltActive = true;
+    _beginScaleGesture();
+  }
+
+  /// Applies one native macOS three-finger trackpad scrolling delta.
+  void onMacosTrackpadTiltUpdate(double scrollingDelta) {
+    if (!_macosTrackpadTiltActive || !host.gestureSettings.tiltEnabled) return;
+    final bridge = host.gestureBridge;
+    if (bridge == null) return;
+    bridge.pitchBy(trackpadTiltDelta(scrollingDelta));
+    _scheduleGestureRender();
+  }
+
+  /// Completes a native macOS three-finger trackpad tilt.
+  void onMacosTrackpadTiltEnd() {
+    if (!_macosTrackpadTiltActive) return;
+    _macosTrackpadTiltActive = false;
+    _scaleGestureActive = false;
+    _clearScaleTracking();
+    if (host.gestureBridge == null) return;
+    _renderGestureNow();
+    host.endCameraGesture();
+  }
+
   /// Completes a scale gesture and starts a fling when appropriate.
   void onScaleEnd(ScaleEndDetails details) {
     if (_quickZoomPointer != null) return;
@@ -388,6 +416,7 @@ class MapGestureCoordinator {
   void _clearScaleTracking() {
     _pan.clearPanSamples();
     _trackpadGestureActive = false;
+    _macosTrackpadTiltActive = false;
     _previousTrackpadScale = 1;
     _previousTrackpadRotation = 0;
   }

--- a/lib/src/state/gesture/gesture_math.dart
+++ b/lib/src/state/gesture/gesture_math.dart
@@ -26,6 +26,9 @@ double trackpadScaleDelta(double currentScale, double previousScale) {
   return currentScale / previousScale;
 }
 
+/// Converts a macOS three-finger scrolling delta into pitch degrees.
+double trackpadTiltDelta(double scrollingDelta) => -scrollingDelta * 0.5;
+
 /// Converts vertical quick-zoom movement into an exponential scale factor.
 ///
 /// Returns 1 when the movement or sensitivity is invalid.

--- a/lib/src/state/gesture/macos_trackpad_tilt.dart
+++ b/lib/src/state/gesture/macos_trackpad_tilt.dart
@@ -1,0 +1,94 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// Routes native macOS three-finger trackpad swipes to one map region.
+class MacosTrackpadTiltRegistration {
+  MacosTrackpadTiltRegistration._({
+    required this.onStart,
+    required this.onUpdate,
+    required this.onEnd,
+  }) : id = _nextId++ {
+    _registrations[id] = this;
+    _installHandler();
+  }
+
+  static const _channel = MethodChannel(
+    'dev.maplibre.flutter_gpu/macos_trackpad_tilt',
+  );
+  static final Map<int, MacosTrackpadTiltRegistration> _registrations =
+      <int, MacosTrackpadTiltRegistration>{};
+  static var _nextId = 1;
+  static var _handlerInstalled = false;
+
+  /// Creates a registration on macOS and returns null on other platforms.
+  static MacosTrackpadTiltRegistration? register({
+    required VoidCallback onStart,
+    required ValueChanged<double> onUpdate,
+    required VoidCallback onEnd,
+  }) {
+    if (kIsWeb || defaultTargetPlatform != TargetPlatform.macOS) return null;
+
+    return MacosTrackpadTiltRegistration._(
+      onStart: onStart,
+      onUpdate: onUpdate,
+      onEnd: onEnd,
+    );
+  }
+
+  final int id;
+  final VoidCallback onStart;
+  final ValueChanged<double> onUpdate;
+  final VoidCallback onEnd;
+  var _disposed = false;
+
+  static void _installHandler() {
+    if (_handlerInstalled) return;
+    _handlerInstalled = true;
+    _channel.setMethodCallHandler((call) async {
+      if (call.method != 'trackpadTilt') return;
+      final arguments = Map<Object?, Object?>.from(call.arguments as Map);
+      final registration = _registrations[arguments['id'] as int?];
+      if (registration == null) return;
+      switch (arguments['phase']) {
+        case 'start':
+          registration.onStart();
+        case 'update':
+          final delta = arguments['deltaY'];
+          if (delta is num) registration.onUpdate(delta.toDouble());
+        case 'end':
+          registration.onEnd();
+      }
+    });
+  }
+
+  /// Updates map bounds in logical coordinates relative to Flutter view.
+  void updateRegion(Rect region, {required bool enabled}) {
+    if (_disposed) return;
+    unawaited(
+      _channel
+          .invokeMethod<void>('setTiltRegion', <String, Object>{
+            'id': id,
+            'x': region.left,
+            'y': region.top,
+            'width': region.width,
+            'height': region.height,
+            'enabled': enabled,
+          })
+          .catchError((_) {}),
+    );
+  }
+
+  /// Stops native event routing for this map.
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    _registrations.remove(id);
+    unawaited(
+      _channel
+          .invokeMethod<void>('removeTiltRegion', <String, Object>{'id': id})
+          .catchError((_) {}),
+    );
+  }
+}

--- a/lib/src/widgets/maplibre_map.dart
+++ b/lib/src/widgets/maplibre_map.dart
@@ -19,6 +19,7 @@ import '../sprites/sprite_atlas.dart';
 import '../state/gesture/gesture_coordinator.dart';
 import '../state/gesture/gesture_math.dart';
 import '../state/gesture/gesture_options.dart';
+import '../state/gesture/macos_trackpad_tilt.dart';
 import '../state/map_render_scheduler.dart';
 import '../state/map_style_session.dart';
 import '../state/map_viewport.dart';
@@ -753,12 +754,19 @@ class _MapLibreMapState extends State<MapLibreMap>
   Completer<void>? _styleMutationBarrier;
 
   late final MapGestureCoordinator _gestures;
+  final GlobalKey _gestureRegionKey = GlobalKey();
+  MacosTrackpadTiltRegistration? _macosTrackpadTilt;
 
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
     _gestures = MapGestureCoordinator(vsync: this, host: this);
+    _macosTrackpadTilt = MacosTrackpadTiltRegistration.register(
+      onStart: _gestures.onMacosTrackpadTiltStart,
+      onUpdate: _gestures.onMacosTrackpadTiltUpdate,
+      onEnd: _gestures.onMacosTrackpadTiltEnd,
+    );
     _renders = MapRenderScheduler(
       isAlive: () => mounted && _initialized,
       hasPendingNativeWork: () => _hasBridge && _bridge.processEvents(),
@@ -1321,6 +1329,7 @@ class _MapLibreMapState extends State<MapLibreMap>
   void dispose() {
     _initialized = false;
     WidgetsBinding.instance.removeObserver(this);
+    _macosTrackpadTilt?.dispose();
     _renders.dispose();
     _gestures.dispose();
     _controller?.dispose();
@@ -1579,6 +1588,7 @@ class _MapLibreMapState extends State<MapLibreMap>
           widget.zoomGesturesEnabled ||
           widget.rotateGesturesEnabled ||
           widget.tiltGesturesEnabled;
+      _scheduleMacosTrackpadTiltRegionUpdate();
 
       return ClipRect(
         child: Stack(
@@ -1587,6 +1597,7 @@ class _MapLibreMapState extends State<MapLibreMap>
           children: [
             const SizedBox.expand(),
             Listener(
+              key: _gestureRegionKey,
               onPointerDown: _gestures.onPointerDown,
               onPointerMove: _gestures.onPointerMove,
               onPointerUp: _gestures.onPointerEnd,
@@ -1674,6 +1685,22 @@ class _MapLibreMapState extends State<MapLibreMap>
       );
     },
   );
+
+  void _scheduleMacosTrackpadTiltRegionUpdate() {
+    final registration = _macosTrackpadTilt;
+    if (registration == null) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final box =
+          _gestureRegionKey.currentContext?.findRenderObject() as RenderBox?;
+      if (box == null || !box.hasSize) return;
+      final origin = box.localToGlobal(Offset.zero);
+      registration.updateRegion(
+        origin & box.size,
+        enabled: widget.tiltGesturesEnabled,
+      );
+    });
+  }
 }
 
 class _MapGpuStratum extends StatefulWidget {

--- a/test/gesture_coordinator_test.dart
+++ b/test/gesture_coordinator_test.dart
@@ -12,6 +12,7 @@ class _RecordingBridge implements MaplibreBridge {
       <({double scale, double x, double y})>[];
   final List<Offset> moveCalls = <Offset>[];
   final List<double> rotationCalls = <double>[];
+  final List<double> pitchCalls = <double>[];
   int animatedScaleCalls = 0;
 
   @override
@@ -24,6 +25,9 @@ class _RecordingBridge implements MaplibreBridge {
 
   @override
   void rotateBy(double degrees) => rotationCalls.add(degrees);
+
+  @override
+  void pitchBy(double degrees) => pitchCalls.add(degrees);
 
   @override
   bool scaleByAnimated({
@@ -250,6 +254,29 @@ void main() {
 
     await tester.pump();
     coordinator.onScaleEnd(ScaleEndDetails(pointerCount: 2));
+
+    expect(host.renderCalls, 2);
+    expect(host.endCalls, 1);
+  });
+
+  testWidgets('applies macOS three-finger trackpad tilt', (tester) async {
+    final bridge = _RecordingBridge();
+    final host = _FakeHost(bridge: bridge);
+    final coordinator = MapGestureCoordinator(
+      vsync: const TestVSync(),
+      host: host,
+    );
+    addTearDown(coordinator.dispose);
+
+    coordinator.onMacosTrackpadTiltStart();
+    coordinator.onMacosTrackpadTiltUpdate(8);
+    coordinator.onMacosTrackpadTiltUpdate(-4);
+
+    expect(host.beginCalls, 1);
+    expect(bridge.pitchCalls, <double>[-4, 2]);
+
+    await tester.pump();
+    coordinator.onMacosTrackpadTiltEnd();
 
     expect(host.renderCalls, 2);
     expect(host.endCalls, 1);

--- a/test/maplibre_map_options_test.dart
+++ b/test/maplibre_map_options_test.dart
@@ -58,6 +58,7 @@ void main() {
     expect(trackpadScaleDelta(1.2, 1.1), closeTo(1.0909, 0.0001));
     expect(trackpadScaleDelta(0, 1), 1);
     expect(trackpadScaleDelta(double.nan, 1), 1);
+    expect(trackpadTiltDelta(8), -4);
     expect(quickZoomScaleDelta(-10), closeTo(0.90484, 0.00001));
     expect(quickZoomScaleDelta(10), closeTo(1.10517, 0.00001));
     expect(quickZoomScaleDelta(double.nan), 1);

--- a/test/native_build_configuration_test.dart
+++ b/test/native_build_configuration_test.dart
@@ -128,6 +128,17 @@ void main() {
     expect(runtime, contains('worker.join();'));
   });
 
+  test('macOS separates three-finger drag from two-finger scrolling', () {
+    final plugin = File(
+      'darwin/maplibre_flutter_gpu/Sources/maplibre_flutter_gpu/'
+      'MaplibreFlutterGpuPlugin.swift',
+    ).readAsStringSync();
+    expect(plugin, contains('.leftMouseDragged'));
+    expect(plugin, contains('event.subtype == .touch'));
+    expect(plugin, isNot(contains('touches(matching:')));
+    expect(plugin, isNot(contains('.scrollWheel')));
+  });
+
   test('Android reuses one process DSO for every map session', () {
     final plugin = File(
       'android/src/main/java/dev/maplibre/fluttergpu/'


### PR DESCRIPTION
## Summary

- route macOS three-finger drag gestures to camera tilt
- keep two-finger trackpad scrolling available for map panning
- limit native gesture interception to enabled map regions
- coalesce native pitch updates with the existing gesture render lifecycle

## Why

Flutter trackpad pan/zoom events do not expose the exact finger count on macOS. Treating scroll events as three-finger input also intercepts normal two-finger panning.

macOS three-finger drag is delivered as a touch-generated primary mouse drag. This change detects that native event path and forwards only its vertical movement to the map tilt coordinator.

## Validation

- 37 focused gesture and native configuration tests passed
- macOS debug example build succeeded
- flutter analyze reported only the 2 pre-existing avoid_relative_lib_imports info findings
- git diff --check