### PR TITLE
feat(desktop): add modifier mouse camera controls

### DIFF
--- a/lib/src/state/gesture/gesture_coordinator.dart
+++ b/lib/src/state/gesture/gesture_coordinator.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import '../../native/maplibre_ffi.dart';
@@ -8,6 +10,8 @@ import 'gesture_math.dart';
 import 'gesture_options.dart';
 import 'multi_pointer_tracker.dart';
 import 'pan_fling_tracker.dart';
+
+enum _DesktopMouseDragMode { tilt, rotate }
 
 /// Which gestures the map currently accepts.
 typedef MapGestureSettings = ({
@@ -76,6 +80,8 @@ class MapGestureCoordinator {
   var _scaleGestureActive = false;
   var _suppressScaleUntilPointersReleased = false;
   var _trackpadGestureActive = false;
+  _DesktopMouseDragMode? _desktopMouseDragMode;
+  int? _desktopMouseDragPointer;
   var _previousTrackpadScale = 1.0;
   var _previousTrackpadRotation = 0.0;
   Offset? _doubleTapPosition;
@@ -182,6 +188,7 @@ class MapGestureCoordinator {
       _pan.clearPanSamples();
       host.endCameraGesture();
     }
+    final desktopMouseDragMode = _desktopMouseDragModeFor(event);
     if (_pointerPositions.isEmpty) {
       final settings = host.gestureSettings;
       _suppressScaleUntilPointersReleased =
@@ -189,8 +196,10 @@ class MapGestureCoordinator {
           !settings.zoomEnabled &&
           !settings.rotateEnabled &&
           !settings.tiltEnabled;
-      _armQuickZoomFromRawTap(event);
-      _singleTapPointer = event.pointer;
+      if (desktopMouseDragMode == null) {
+        _armQuickZoomFromRawTap(event);
+      }
+      _singleTapPointer = desktopMouseDragMode == null ? event.pointer : null;
       _singleTapMoved = false;
     } else {
       _singleTapPointer = null;
@@ -202,6 +211,10 @@ class MapGestureCoordinator {
     _pointerDownPositions[event.pointer] = event.localPosition;
     _pointerDownTimes[event.pointer] = event.timeStamp;
     _pointers.down(event.pointer, event.localPosition);
+    if (desktopMouseDragMode != null) {
+      _desktopMouseDragMode = desktopMouseDragMode;
+      _desktopMouseDragPointer = event.pointer;
+    }
     if (_pointerPositions.length == 2) {
       _twoFingerTapStarts
         ..clear()
@@ -217,6 +230,7 @@ class MapGestureCoordinator {
 
   /// Stops tracking a pointer and completes any recognized tap gesture.
   void onPointerEnd(PointerEvent event) {
+    final wasDesktopMouseDrag = event.pointer == _desktopMouseDragPointer;
     final wasQuickZoomPointer = event.pointer == _quickZoomPointer;
     _rememberCompletedSingleTap(event, wasQuickZoomPointer);
     final twoFingerTap = _finishTwoFingerTapIfRecognized(event);
@@ -224,6 +238,7 @@ class MapGestureCoordinator {
     _pointerDownPositions.remove(event.pointer);
     _pointerDownTimes.remove(event.pointer);
     _pointers.up(event.pointer);
+    if (wasDesktopMouseDrag) _finishDesktopMouseDrag();
     if (_pointerPositions.isEmpty) {
       _suppressScaleUntilPointersReleased = false;
     }
@@ -242,6 +257,7 @@ class MapGestureCoordinator {
       }
     }
     _trackTwoFingerTapMove(event);
+    if (_applyDesktopMouseDragMove(event)) return;
     if (_applyQuickZoomMove(event)) return;
     _pointers.move(event.pointer, event.localPosition);
     if (!_pointers.isMultiPointer || _twoFingerUpdateScheduled) return;
@@ -278,7 +294,8 @@ class MapGestureCoordinator {
 
   /// Begins a scale gesture and clears motion inherited from an earlier input.
   void onScaleStart(ScaleStartDetails details) {
-    if (_quickZoomPointer != null ||
+    if (_desktopMouseDragMode != null ||
+        _quickZoomPointer != null ||
         (_suppressScaleUntilPointersReleased &&
             details.kind != PointerDeviceKind.trackpad)) {
       return;
@@ -295,6 +312,60 @@ class MapGestureCoordinator {
     host.beginCameraGesture();
     _flingController.stop();
     _pan.clearPanSamples();
+  }
+
+  _DesktopMouseDragMode? _desktopMouseDragModeFor(PointerDownEvent event) {
+    final platform = defaultTargetPlatform;
+    if (platform != TargetPlatform.windows &&
+        platform != TargetPlatform.linux) {
+      return null;
+    }
+    if (event.kind != PointerDeviceKind.mouse ||
+        event.buttons != kPrimaryMouseButton) {
+      return null;
+    }
+    if (HardwareKeyboard.instance.isControlPressed) {
+      return _DesktopMouseDragMode.rotate;
+    }
+    if (HardwareKeyboard.instance.isShiftPressed) {
+      return _DesktopMouseDragMode.tilt;
+    }
+    return null;
+  }
+
+  bool _applyDesktopMouseDragMove(PointerMoveEvent event) {
+    final mode = _desktopMouseDragMode;
+    if (mode == null || event.pointer != _desktopMouseDragPointer) return false;
+    if ((event.buttons & kPrimaryMouseButton) == 0) {
+      _finishDesktopMouseDrag();
+      return true;
+    }
+    final bridge = host.gestureBridge;
+    if (bridge == null) return true;
+    final settings = host.gestureSettings;
+    switch (mode) {
+      case _DesktopMouseDragMode.tilt:
+        if (!settings.tiltEnabled) return true;
+        _beginScaleGesture();
+        bridge.pitchBy(mouseTiltDelta(event.delta.dy));
+      case _DesktopMouseDragMode.rotate:
+        if (!settings.rotateEnabled) return true;
+        _beginScaleGesture();
+        bridge.rotateBy(mouseRotateDelta(event.delta.dx));
+    }
+    _scheduleGestureRender();
+    return true;
+  }
+
+  void _finishDesktopMouseDrag() {
+    _desktopMouseDragMode = null;
+    _desktopMouseDragPointer = null;
+    if (!_scaleGestureActive) return;
+    _scaleGestureActive = false;
+    _clearScaleTracking();
+    if (host.gestureBridge == null) return;
+    _renderGestureNow();
+    host.endCameraGesture();
   }
 
   /// Applies pan, zoom, and rotation updates from a scale recognizer.

--- a/lib/src/state/gesture/gesture_math.dart
+++ b/lib/src/state/gesture/gesture_math.dart
@@ -26,6 +26,12 @@ double trackpadScaleDelta(double currentScale, double previousScale) {
   return currentScale / previousScale;
 }
 
+/// Converts vertical mouse movement into pitch degrees.
+double mouseTiltDelta(double verticalDelta) => -verticalDelta * 0.5;
+
+/// Converts horizontal mouse movement into bearing degrees.
+double mouseRotateDelta(double horizontalDelta) => horizontalDelta * 0.5;
+
 /// Converts vertical quick-zoom movement into an exponential scale factor.
 ///
 /// Returns 1 when the movement or sensitivity is invalid.

--- a/lib/src/widgets/maplibre_map.dart
+++ b/lib/src/widgets/maplibre_map.dart
@@ -319,7 +319,8 @@ class MapLibreMap extends StatefulWidget {
   /// Defaults to [MinMaxTiltPreference.unbounded].
   final MinMaxTiltPreference minMaxTiltPreference;
 
-  /// Whether two-finger gestures can rotate the camera.
+  /// Whether two-finger gestures and Ctrl with left-drag on Windows and Linux
+  /// can rotate the camera.
   ///
   /// Defaults to true.
   final bool rotateGesturesEnabled;
@@ -336,7 +337,8 @@ class MapLibreMap extends StatefulWidget {
   /// Defaults to true.
   final bool zoomGesturesEnabled;
 
-  /// Whether three-finger vertical drag gestures can tilt the camera.
+  /// Whether three-finger vertical drag gestures and Shift with left-drag on
+  /// Windows and Linux can tilt the camera.
   ///
   /// Defaults to true.
   final bool tiltGesturesEnabled;

--- a/test/gesture_coordinator_test.dart
+++ b/test/gesture_coordinator_test.dart
@@ -1,6 +1,8 @@
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:maplibre_flutter_gpu/src/native/maplibre_ffi.dart';
@@ -12,6 +14,7 @@ class _RecordingBridge implements MaplibreBridge {
       <({double scale, double x, double y})>[];
   final List<Offset> moveCalls = <Offset>[];
   final List<double> rotationCalls = <double>[];
+  final List<double> pitchCalls = <double>[];
   int animatedScaleCalls = 0;
 
   @override
@@ -24,6 +27,9 @@ class _RecordingBridge implements MaplibreBridge {
 
   @override
   void rotateBy(double degrees) => rotationCalls.add(degrees);
+
+  @override
+  void pitchBy(double degrees) => pitchCalls.add(degrees);
 
   @override
   bool scaleByAnimated({
@@ -253,6 +259,79 @@ void main() {
 
     expect(host.renderCalls, 2);
     expect(host.endCalls, 1);
+  });
+
+  testWidgets('applies Windows and Linux modifier mouse drags', (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+    final bridge = _RecordingBridge();
+    final host = _FakeHost(bridge: bridge);
+    final coordinator = MapGestureCoordinator(
+      vsync: const TestVSync(),
+      host: host,
+    );
+    addTearDown(coordinator.dispose);
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+    coordinator.onPointerDown(
+      const PointerDownEvent(
+        pointer: 10,
+        kind: PointerDeviceKind.mouse,
+        buttons: kPrimaryMouseButton,
+        position: Offset(20, 20),
+      ),
+    );
+    coordinator.onPointerMove(
+      const PointerMoveEvent(
+        pointer: 10,
+        kind: PointerDeviceKind.mouse,
+        buttons: kPrimaryMouseButton,
+        position: Offset(20, 28),
+        delta: Offset(0, 8),
+      ),
+    );
+    coordinator.onPointerEnd(
+      const PointerUpEvent(
+        pointer: 10,
+        kind: PointerDeviceKind.mouse,
+        position: Offset(20, 28),
+      ),
+    );
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    coordinator.onPointerDown(
+      const PointerDownEvent(
+        pointer: 11,
+        kind: PointerDeviceKind.mouse,
+        buttons: kPrimaryMouseButton,
+        position: Offset(20, 20),
+      ),
+    );
+    coordinator.onPointerMove(
+      const PointerMoveEvent(
+        pointer: 11,
+        kind: PointerDeviceKind.mouse,
+        buttons: kPrimaryMouseButton,
+        position: Offset(28, 20),
+        delta: Offset(8, 0),
+      ),
+    );
+    coordinator.onPointerEnd(
+      const PointerUpEvent(
+        pointer: 11,
+        kind: PointerDeviceKind.mouse,
+        position: Offset(28, 20),
+      ),
+    );
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+
+    expect(bridge.pitchCalls, <double>[-4]);
+    expect(bridge.rotationCalls, <double>[4]);
+    expect(bridge.moveCalls, isEmpty);
+    expect(host.beginCalls, 2);
+    expect(host.endCalls, 2);
+    debugDefaultTargetPlatformOverride = null;
   });
 
   testWidgets('dispose cancels pending tap zoom completion', (tester) async {

--- a/test/maplibre_map_options_test.dart
+++ b/test/maplibre_map_options_test.dart
@@ -58,6 +58,8 @@ void main() {
     expect(trackpadScaleDelta(1.2, 1.1), closeTo(1.0909, 0.0001));
     expect(trackpadScaleDelta(0, 1), 1);
     expect(trackpadScaleDelta(double.nan, 1), 1);
+    expect(mouseTiltDelta(8), -4);
+    expect(mouseRotateDelta(8), 4);
     expect(quickZoomScaleDelta(-10), closeTo(0.90484, 0.00001));
     expect(quickZoomScaleDelta(10), closeTo(1.10517, 0.00001));
     expect(quickZoomScaleDelta(double.nan), 1);


### PR DESCRIPTION
## Summary

- tilt the camera with Shift and left-drag on Windows and Linux
- rotate the camera with Ctrl and left-drag on Windows and Linux
- preserve unmodified left-drag panning and mouse-wheel zoom
- respect the existing tilt and rotate gesture enablement settings

## Why

Windows and Linux desktop users primarily use mouse input, while three-finger trackpad gestures are not consistently exposed with a reliable finger count. Modifier-assisted mouse drags provide explicit tilt and rotation controls without changing the existing pan and zoom bindings.

## Validation

- 22 focused gesture and option tests passed
- wheel zoom and existing pan/trackpad gesture regression tests passed
- flutter analyze reported only the 2 pre-existing avoid_relative_lib_imports info findings
- git diff --check