### PR TITLE
fix(linux): support compatible libpng patch versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,75 @@ jobs:
           retention-days: 14
           compression-level: 0
 
+  linux_compat:
+    name: Linux x64 compatibility
+    needs: linux
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install Linux desktop dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes \
+            clang \
+            cmake \
+            libcurl4-openssl-dev \
+            libgtk-3-dev \
+            libicu-dev \
+            libjpeg-dev \
+            liblzma-dev \
+            libpng-dev \
+            libuv1-dev \
+            libwebp-dev \
+            mesa-vulkan-drivers \
+            ninja-build \
+            pkg-config \
+            xvfb
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          channel: stable
+          flutter-version: 3.47.0
+          cache: true
+
+      - name: Download Ubuntu 22.04 Linux bridge
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ci-native-linux-x64-${{ github.run_id }}
+          path: build/ci-native/linux-x64
+
+      - name: Install Linux bridge
+        run: >-
+          ./tool/ci/install_native_artifacts.sh
+          build/ci-native/linux-x64
+          linux-x64
+
+      - name: Run PNG compatibility smoke
+        env:
+          LIBGL_ALWAYS_SOFTWARE: '1'
+        run: >-
+          xvfb-run -a bash ./e2e/visual/run_linux.sh
+          --scene text-symbol
+          --output e2e/visual/report-linux-compat
+          --allow-missing-baseline
+
+      - name: Upload Linux compatibility report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: linux-x64-compat-${{ github.run_id }}-${{ github.run_attempt }}
+          path: e2e/visual/report-linux-compat/text-symbol/
+          if-no-files-found: warn
+          retention-days: 14
+          compression-level: 0
+
   linux_arm64:
     name: Linux ARM64
     runs-on: ubuntu-22.04-arm
@@ -1533,6 +1602,7 @@ jobs:
       - quality
       - linux
       - linux_visual
+      - linux_compat
       - linux_arm64
       - windows
       - windows_visual
@@ -1560,6 +1630,7 @@ jobs:
           QUALITY_RESULT: ${{ needs.quality.result }}
           LINUX_RESULT: ${{ needs.linux.result }}
           LINUX_VISUAL_RESULT: ${{ needs.linux_visual.result }}
+          LINUX_COMPAT_RESULT: ${{ needs.linux_compat.result }}
           LINUX_ARM64_RESULT: ${{ needs.linux_arm64.result }}
           WINDOWS_RESULT: ${{ needs.windows.result }}
           WINDOWS_VISUAL_RESULT: ${{ needs.windows_visual.result }}
@@ -1585,6 +1656,7 @@ jobs:
           test "$QUALITY_RESULT" = success
           test "$LINUX_RESULT" = success
           test "$LINUX_VISUAL_RESULT" = success
+          test "$LINUX_COMPAT_RESULT" = success
           test "$LINUX_ARM64_RESULT" = success
           test "$WINDOWS_RESULT" = success
           test "$WINDOWS_VISUAL_RESULT" = success

--- a/test/native_build_configuration_test.dart
+++ b/test/native_build_configuration_test.dart
@@ -257,6 +257,15 @@ void main() {
     expect(manifest, contains('windows/arm64/maplibre_bridge.dll'));
   });
 
+  test('PNG decoding delegates runtime compatibility checks to libpng', () {
+    final reader = File(
+      'vendor/maplibre-native/platform/default/src/mbgl/util/png_reader.cpp',
+    ).readAsStringSync();
+
+    expect(reader, contains('png_create_read_struct(PNG_LIBPNG_VER_STRING'));
+    expect(reader, isNot(contains('png_access_version_number')));
+  });
+
   test('native desktop projects reject unsupported and 32-bit targets', () {
     for (final path in <String>[
       'native/platforms/linux/CMakeLists.txt',

--- a/test/package_configuration_test.dart
+++ b/test/package_configuration_test.dart
@@ -221,6 +221,21 @@ void main() {
     expect(quality, contains('linux-x64'));
   });
 
+  test('Linux compatibility smoke runs the Ubuntu 22.04 artifact on 24.04', () {
+    final workflow = File('.github/workflows/ci.yml').readAsStringSync();
+    final compatibilityStart = workflow.indexOf('  linux_compat:');
+    final armStart = workflow.indexOf('\n  linux_arm64:', compatibilityStart);
+    final compatibility = workflow.substring(compatibilityStart, armStart);
+
+    expect(compatibility, contains('needs: linux'));
+    expect(compatibility, contains('runs-on: ubuntu-24.04'));
+    expect(
+      compatibility,
+      contains(r'ci-native-linux-x64-${{ github.run_id }}'),
+    );
+    expect(compatibility, contains('--scene text-symbol'));
+  });
+
   test('required CI covers mobile, Darwin, and desktop jobs', () {
     final workflow = File('.github/workflows/ci.yml').readAsStringSync();
     final required = workflow.substring(workflow.indexOf('  required:'));
@@ -239,6 +254,7 @@ void main() {
       'macos_functional',
       'linux',
       'linux_visual',
+      'linux_compat',
       'linux_arm64',
       'windows',
       'windows_visual',


### PR DESCRIPTION
## Summary

- rely on libpng runtime compatibility checks instead of rejecting different patch versions
- update the MapLibre Native submodule with the Linux PNG reader fix
- run an Ubuntu 22.04-built bridge on Ubuntu 24.04 with a PNG-backed visual smoke test
- make the cross-version smoke test part of the required CI gate

## Why

Linux release artifacts are built on Ubuntu 22.04 and dynamically load the host libpng16 library. The MapLibre Native PNG reader compared the complete compile-time and runtime version numbers, so compatible libpng 1.6 patch releases caused startup to abort before decoding any PNG.

libpng already checks runtime compatibility when png_create_read_struct receives PNG_LIBPNG_VER_STRING. Removing the stricter duplicate check preserves the older build baseline while allowing the release artifact to run on newer Ubuntu versions.

## Validation

- 31 focused native build and package configuration tests passed
- workflow YAML parsing passed
- git diff --check passed
- Ubuntu 24.04 compatibility smoke added for the text-symbol scene