### PR TITLE
(cancelled) chore: release 0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.0.5
+
+* Improve rendering performance by reusing GPU resources across frames.
+* Add Shift-drag camera tilt and Ctrl-drag rotation on Windows and Linux, plus
+  three-finger trackpad tilt on macOS.
+* Show Flutter-rendered symbol and text widgets wherever the same location
+  appears more than once in a wide viewport at low zoom, and add
+  `MapLibreMapController.toScreenOffsets` for custom overlays.
+* Fix Linux startup failures caused by libpng 1.6 patch-version differences.
+
 ## 0.0.4
 
 * Render symbol icons and text with closer MapLibre parity, including

--- a/android/src/main/java/org/maplibre/android/http/NativeHttpRequest.java
+++ b/android/src/main/java/org/maplibre/android/http/NativeHttpRequest.java
@@ -76,7 +76,7 @@ public final class NativeHttpRequest {
       request.setReadTimeout(30_000);
       request.setInstanceFollowRedirects(true);
       request.setRequestMethod("GET");
-      request.setRequestProperty("User-Agent", "maplibre_flutter_gpu/0.0.4");
+      request.setRequestProperty("User-Agent", "maplibre_flutter_gpu/0.0.5");
       if (dataRange != null && !dataRange.isEmpty()) {
         request.setRequestProperty("Range", dataRange);
       }

--- a/darwin/maplibre_flutter_gpu.podspec
+++ b/darwin/maplibre_flutter_gpu.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'maplibre_flutter_gpu'
-  s.version = '0.0.4'
+  s.version = '0.0.5'
   s.summary = 'MapLibre maps rendered with Flutter GPU.'
   s.description = <<-DESC
 MapLibre maps for Flutter, rendered with Flutter GPU.

--- a/e2e/visual/gpu_app/pubspec.lock
+++ b/e2e/visual/gpu_app/pubspec.lock
@@ -181,7 +181,7 @@ packages:
       path: "../../.."
       relative: true
     source: path
-    version: "0.0.4"
+    version: "0.0.5"
   matcher:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -158,7 +158,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.4"
+    version: "0.0.5"
   matcher:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_flutter_landmarks_example
 description: World landmark Flutter marker example for maplibre_flutter_gpu.
 publish_to: 'none'
-version: 0.0.4
+version: 0.0.5
 
 environment:
   sdk: ^3.13.0

--- a/examples/gpu_map_scene/pubspec.lock
+++ b/examples/gpu_map_scene/pubspec.lock
@@ -158,7 +158,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.0.4"
+    version: "0.0.5"
   matcher:
     dependency: transitive
     description:

--- a/examples/gpu_map_scene/pubspec.yaml
+++ b/examples/gpu_map_scene/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_flutter_gpu_map_scene_example
 description: Geographic CC0 car and building GPU overlay example.
 publish_to: 'none'
-version: 0.0.4
+version: 0.0.5
 
 environment:
   sdk: ^3.13.0

--- a/examples/map_style_controls/pubspec.lock
+++ b/examples/map_style_controls/pubspec.lock
@@ -158,7 +158,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.0.4"
+    version: "0.0.5"
   matcher:
     dependency: transitive
     description:

--- a/examples/map_style_controls/pubspec.yaml
+++ b/examples/map_style_controls/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_flutter_map_style_controls_example
 description: Semantic map style controls using the MapLibre controller API.
 publish_to: 'none'
-version: 0.0.4
+version: 0.0.5
 
 environment:
   sdk: ^3.13.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_flutter_gpu
 description: >-
   MapLibre maps for Flutter, rendered with Flutter GPU.
-version: 0.0.4
+version: 0.0.5
 repository: https://github.com/hyshu/maplibre_flutter_gpu
 homepage: https://github.com/hyshu/maplibre_flutter_gpu
 issue_tracker: https://github.com/hyshu/maplibre_flutter_gpu/issues


### PR DESCRIPTION
## Summary

- bump package, examples, CocoaPods metadata, Android User-Agent, and generated lockfiles to 0.0.5
- add user-facing release notes for GPU rendering performance, desktop camera controls, repeated low-zoom map content, and Linux libpng compatibility
- keep the repository release Skill excluded from the pub archive and validate it with the skill-creator quick validator

## Validation

- `git diff --check`
- `flutter test test/package_configuration_test.dart`
- `./tool/ci/check_publish.sh --metadata-only`
- `uv run --with pyyaml /Users/me/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/release-maplibre-flutter-gpu`
- `./tool/ci/quality.sh`

`flutter analyze` reports only the two existing `avoid_relative_lib_imports` info findings.