### PR TITLE
ci: split release artifact build from preparation

### DIFF
--- a/.agents/skills/release-maplibre-flutter-gpu/SKILL.md
+++ b/.agents/skills/release-maplibre-flutter-gpu/SKILL.md
@@ -28,9 +28,9 @@ and the version tag.
 - Treat the four desktop archives as immutable build-hook dependencies. Never
   change their manifest URL or checksums without verifying the exact release
   assets first.
-- Never use a normal CI run as `artifact_run_id` for Release preparation. Its
-  desktop artifact names are intentionally different. Only a Release
-  preparation run contains all seven standard release artifact names.
+- Never use a normal CI or Release preparation run as `artifact_run_id`. Their
+  artifact contracts differ. Only a successful Release artifacts run contains
+  all seven standard native artifact names accepted by Release preparation.
 - When desktop artifacts change, finalize their checksums and update
   `hook/desktop_artifacts.json` in the release pull request. Never add a second
   manifest-only pull request after merging the release pull request.
@@ -70,16 +70,17 @@ and the version tag.
 
 Skip this section when the existing desktop assets remain compatible.
 
-1. Run Release preparation with no `artifact_run_id` on the exact protected
-   `origin/main` commit before preparing the release pull request. First list
-   existing Release preparation runs for that SHA and reuse or wait for an
-   existing `new-build` run instead of dispatching a duplicate.
+1. Run Release artifacts on the exact protected `origin/main` commit before
+   preparing the release pull request. First list existing Release artifacts
+   runs for that SHA and reuse or wait for an existing run instead of
+   dispatching a duplicate.
 
    ```sh
-   gh workflow run release-prepare.yml --ref main
+   gh workflow run release-artifacts.yml --ref main
    ```
 
-2. Require successful native build jobs and these seven standard artifacts.
+2. Require the workflow and every native build job to succeed. Require these
+   seven standard artifacts.
 
    - `native-android-arm64-v8a`
    - `native-android-x86_64`
@@ -89,22 +90,14 @@ Skip this section when the existing desktop assets remain compatible.
    - `native-windows-x64`
    - `native-windows-arm64`
 
-3. The bundle job may fail because the newly built desktop archive checksums do
-   not match the old `hook/desktop_artifacts.json`. Accept that bootstrap state
-   only when all seven artifacts exist and the only failure is the expected
-   desktop manifest checksum mismatch. Stop for any build, upload, archive
-   checksum, self-verification, packaging, or unrelated bundle failure. Keep
-   the failed bootstrap run because its artifacts are the release source. It is
-   not successful release evidence yet.
-
-4. Download the four desktop archives and their `.sha256` files into a new
+3. Download the four desktop archives and their `.sha256` files into a new
    temporary directory. Verify every sidecar, archive member, platform, and
    architecture. Calculate the SHA-256 values independently.
 
-5. Prepare the manifest values for the release pull request. Use the immutable
+4. Prepare the manifest values for the release pull request. Use the immutable
    asset URL under `releases/download/v<target-version>/` and the independently
    verified checksums. Do not create the GitHub Release or package tag yet.
-   Record the bootstrap run ID and exact source SHA.
+   Record the Release artifacts run ID and exact source SHA.
 
 ## Prepare the release pull request
 
@@ -168,8 +161,8 @@ Continue only after CHANGELOG approval.
 4. Push the `chore/` branch and create a pull request against `main`. Include
    the version bump, release notes, version-surface fixes, Skill, and validation
    results in the pull request summary. When desktop artifacts changed, also
-   include the bootstrap run ID, source SHA, verified checksums, planned Release
-   asset URL, and manifest update.
+   include the Release artifacts run ID, source SHA, verified checksums,
+   planned Release asset URL, and manifest update.
 
 5. Wait for every required PR check. Require `Publish readiness` to complete its
    native-artifact-backed pub dry-run. Do not merge without user authorization.
@@ -179,14 +172,14 @@ Continue only after CHANGELOG approval.
 1. Fetch `origin/main` after merge and resolve its exact commit. This may be a
    squash merge commit, so never substitute the pull request head SHA.
 
-2. Select a Release preparation run containing all seven standard artifacts.
-   Never select a normal CI run. Prefer a run for the exact merge SHA. The
-   pre-pull-request bootstrap run may be reused when the full diff from its
-   source SHA to the merge SHA contains only approved release metadata,
-   CHANGELOG, `.pubignore`, this Skill, and the verified
+2. Select the successful Release artifacts run containing all seven standard
+   artifacts. Never select a normal CI or Release preparation run. The
+   pre-pull-request run may be reused when the full diff from its source SHA to
+   the merge SHA contains only approved release metadata, CHANGELOG,
+   `.pubignore`, this Skill, and the verified
    `hook/desktop_artifacts.json` update. Stop if any native source, vendor
    revision, build hook behavior, build configuration, or native build and
-   packaging script changed.
+   packaging script changed. Release preparation enforces this allowlist too.
 
 3. When the manifest points to new `v<target-version>` assets, download and
    reverify the four desktop archives from the selected artifact run. Stop for
@@ -199,9 +192,9 @@ Continue only after CHANGELOG approval.
    asset and every downloaded asset has the recorded SHA-256.
 
 5. Before dispatching, list Release preparation runs for the exact merge SHA.
-   Match both the SHA and `artifact_run_id` shown in the run title. Reuse or wait
-   for an existing matching run instead of dispatching the same preparation
-   twice.
+   Match both the SHA and Release artifacts run ID shown in the run title.
+   Reuse or wait for an existing matching run instead of dispatching the same
+   preparation twice.
 
    ```sh
    gh workflow run release-prepare.yml --ref main \

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,0 +1,53 @@
+name: Release artifacts
+run-name: Release artifacts for ${{ github.sha }}
+
+on:
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: release-artifacts-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  guard:
+    name: Guard artifact source
+    runs-on: macos-15
+    timeout-minutes: 5
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Require protected main source
+        env:
+          EXPECTED_REPOSITORY: hyshu/maplibre_flutter_gpu
+          ACTUAL_REPOSITORY: ${{ github.repository }}
+          ACTUAL_REF: ${{ github.ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$ACTUAL_REPOSITORY" = "$EXPECTED_REPOSITORY"
+          test "$ACTUAL_REF" = refs/heads/main
+
+      - name: Require publish metadata
+        run: ./tool/ci/check_publish.sh --metadata-only
+
+  native:
+    name: Mobile and Darwin artifacts
+    needs: guard
+    uses: ./.github/workflows/_native-artifacts.yml
+    with:
+      retention_days: 7
+
+  desktop:
+    name: Desktop artifacts
+    needs: guard
+    uses: ./.github/workflows/_desktop-artifacts.yml
+    with:
+      retention_days: 7

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,21 +1,20 @@
 name: Release preparation
-run-name: Release preparation for ${{ github.sha }} using artifacts ${{ inputs.artifact_run_id || 'new-build' }}
+run-name: Release preparation for ${{ github.sha }} using artifacts ${{ inputs.artifact_run_id }}
 
 on:
   workflow_dispatch:
     inputs:
       artifact_run_id:
-        description: Successful workflow run containing all native artifacts.
-        required: false
+        description: Successful Release artifacts run containing all native artifacts.
+        required: true
         type: string
-        default: ''
 
 permissions:
   actions: read
   contents: read
 
 concurrency:
-  group: release-prepare-${{ github.sha }}-${{ inputs.artifact_run_id || 'new-build' }}
+  group: release-prepare-${{ github.sha }}-${{ inputs.artifact_run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -23,11 +22,13 @@ jobs:
     name: Guard release source
     runs-on: macos-15
     timeout-minutes: 5
+    outputs:
+      artifact_source_sha: ${{ steps.artifact_source.outputs.sha }}
     steps:
       - name: Check out source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Require protected main source
@@ -44,35 +45,39 @@ jobs:
       - name: Require publish metadata
         run: ./tool/ci/check_publish.sh --metadata-only
 
-      - name: Validate native artifact source
-        if: ${{ inputs.artifact_run_id != '' }}
+      - name: Resolve native artifact source
+        id: artifact_source
         env:
           ARTIFACT_RUN_ID: ${{ inputs.artifact_run_id }}
-        run: '[[ "$ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ ]]'
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          run_json="$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$ARTIFACT_RUN_ID"
+          )"
+          test "$(jq -r .name <<<"$run_json")" = 'Release artifacts'
+          test "$(jq -r .event <<<"$run_json")" = workflow_dispatch
+          test "$(jq -r .head_branch <<<"$run_json")" = main
+          test "$(jq -r .conclusion <<<"$run_json")" = success
+          source_sha="$(jq -r .head_sha <<<"$run_json")"
+          [[ "$source_sha" =~ ^[0-9a-f]{40}$ ]]
+          echo "sha=$source_sha" >>"$GITHUB_OUTPUT"
 
-  native:
-    name: Mobile and Darwin artifacts
-    if: ${{ inputs.artifact_run_id == '' }}
-    needs: guard
-    uses: ./.github/workflows/_native-artifacts.yml
-    with:
-      retention_days: 7
-
-  desktop:
-    name: Desktop artifacts
-    if: ${{ inputs.artifact_run_id == '' }}
-    needs: guard
-    uses: ./.github/workflows/_desktop-artifacts.yml
-    with:
-      retention_days: 7
+      - name: Require compatible artifact source
+        env:
+          ARTIFACT_SOURCE_SHA: ${{ steps.artifact_source.outputs.sha }}
+          RELEASE_SOURCE_SHA: ${{ github.sha }}
+        run: >-
+          ./tool/ci/verify_release_artifact_source.sh
+          "$ARTIFACT_SOURCE_SHA"
+          "$RELEASE_SOURCE_SHA"
 
   bundle:
     name: Release bundle
-    if: ${{ always() && needs.guard.result == 'success' && (needs.native.result == 'success' || needs.native.result == 'skipped') && (needs.desktop.result == 'success' || needs.desktop.result == 'skipped') }}
-    needs:
-      - guard
-      - native
-      - desktop
+    needs: guard
     runs-on: macos-15-intel
     timeout-minutes: 45
     env:
@@ -96,7 +101,7 @@ jobs:
         with:
           name: native-android-arm64-v8a
           path: ${{ runner.temp }}/native-artifacts
-          run-id: ${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}
+          run-id: ${{ inputs.artifact_run_id }}
           github-token: ${{ github.token }}
 
       - name: Download Android x64 artifact
@@ -104,7 +109,7 @@ jobs:
         with:
           name: native-android-x86_64
           path: ${{ runner.temp }}/native-artifacts
-          run-id: ${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}
+          run-id: ${{ inputs.artifact_run_id }}
           github-token: ${{ github.token }}
 
       - name: Download Darwin artifact
@@ -112,7 +117,7 @@ jobs:
         with:
           name: native-darwin
           path: ${{ runner.temp }}/native-artifacts
-          run-id: ${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}
+          run-id: ${{ inputs.artifact_run_id }}
           github-token: ${{ github.token }}
 
       - name: Download Linux x64 artifact
@@ -120,7 +125,7 @@ jobs:
         with:
           name: native-linux-x64
           path: ${{ runner.temp }}/native-artifacts
-          run-id: ${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}
+          run-id: ${{ inputs.artifact_run_id }}
           github-token: ${{ github.token }}
 
       - name: Download Linux ARM64 artifact
@@ -128,7 +133,7 @@ jobs:
         with:
           name: native-linux-arm64
           path: ${{ runner.temp }}/native-artifacts
-          run-id: ${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}
+          run-id: ${{ inputs.artifact_run_id }}
           github-token: ${{ github.token }}
 
       - name: Download Windows x64 artifact
@@ -136,7 +141,7 @@ jobs:
         with:
           name: native-windows-x64
           path: ${{ runner.temp }}/native-artifacts
-          run-id: ${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}
+          run-id: ${{ inputs.artifact_run_id }}
           github-token: ${{ github.token }}
 
       - name: Download Windows ARM64 artifact
@@ -144,7 +149,7 @@ jobs:
         with:
           name: native-windows-arm64
           path: ${{ runner.temp }}/native-artifacts
-          run-id: ${{ inputs.artifact_run_id != '' && inputs.artifact_run_id || github.run_id }}
+          run-id: ${{ inputs.artifact_run_id }}
           github-token: ${{ github.token }}
 
       - name: Prepare release bundle

--- a/test/package_configuration_test.dart
+++ b/test/package_configuration_test.dart
@@ -121,18 +121,38 @@ void main() {
     expect(pubignore, isNot(contains('/vendor/**')));
   });
 
-  test('release workflow can reuse native artifacts from one run', () {
-    final workflow = File('.github/workflows/release-prepare.yml')
+  test('release workflows separate artifact builds from preparation', () {
+    final artifactWorkflow = File('.github/workflows/release-artifacts.yml')
+        .readAsStringSync();
+    final preparationWorkflow = File('.github/workflows/release-prepare.yml')
         .readAsStringSync();
 
-    expect(workflow, contains('artifact_run_id:'));
-    expect(workflow, contains("inputs.artifact_run_id == ''"));
+    expect(artifactWorkflow, contains('name: Release artifacts'));
     expect(
-      RegExp(r'run-id:.*inputs\.artifact_run_id').allMatches(workflow),
+      artifactWorkflow,
+      contains('uses: ./.github/workflows/_native-artifacts.yml'),
+    );
+    expect(
+      artifactWorkflow,
+      contains('uses: ./.github/workflows/_desktop-artifacts.yml'),
+    );
+    expect(artifactWorkflow, isNot(contains('artifact_run_id')));
+    expect(artifactWorkflow, isNot(contains('prepare_release_bundle.sh')));
+
+    expect(preparationWorkflow, contains('artifact_run_id:'));
+    expect(preparationWorkflow, contains('required: true'));
+    expect(preparationWorkflow, contains('Release artifacts'));
+    expect(preparationWorkflow, contains('verify_release_artifact_source.sh'));
+    expect(preparationWorkflow, isNot(contains('new-build')));
+    expect(preparationWorkflow, isNot(contains('_native-artifacts.yml')));
+    expect(preparationWorkflow, isNot(contains('_desktop-artifacts.yml')));
+    expect(
+      RegExp(r'run-id:.*inputs\.artifact_run_id')
+          .allMatches(preparationWorkflow),
       hasLength(7),
     );
     expect(
-      RegExp(r'github-token:.*github\.token').allMatches(workflow),
+      RegExp(r'github-token:.*github\.token').allMatches(preparationWorkflow),
       hasLength(7),
     );
     for (final artifact in <String>[
@@ -141,7 +161,71 @@ void main() {
       'native-windows-x64',
       'native-windows-arm64',
     ]) {
-      expect(workflow, contains(artifact));
+      expect(preparationWorkflow, contains(artifact));
+    }
+  });
+
+  test('release artifact reuse accepts only release metadata changes', () {
+    final repository = Directory.systemTemp.createTempSync(
+      'maplibre-release-artifact-source-',
+    );
+    final script = File('tool/ci/verify_release_artifact_source.sh')
+        .absolute
+        .path;
+
+    ProcessResult runGit(List<String> arguments) {
+      final result = Process.runSync(
+        'git',
+        arguments,
+        workingDirectory: repository.path,
+      );
+      expect(result.exitCode, 0, reason: '${result.stdout}\n${result.stderr}');
+
+      return result;
+    }
+
+    String head() {
+      return runGit(<String>['rev-parse', 'HEAD']).stdout.toString().trim();
+    }
+
+    try {
+      runGit(<String>['init', '--quiet']);
+      runGit(<String>['config', 'user.name', 'Release Test']);
+      runGit(<String>['config', 'user.email', 'release@example.invalid']);
+      File('${repository.path}/CHANGELOG.md').writeAsStringSync('base\n');
+      runGit(<String>['add', 'CHANGELOG.md']);
+      runGit(<String>['commit', '--quiet', '-m', 'base']);
+      final artifactSource = head();
+
+      File('${repository.path}/CHANGELOG.md').writeAsStringSync('release\n');
+      runGit(<String>['add', 'CHANGELOG.md']);
+      runGit(<String>['commit', '--quiet', '-m', 'release metadata']);
+      final compatibleRelease = head();
+      final compatible = Process.runSync(script, <String>[
+        artifactSource,
+        compatibleRelease,
+        repository.path,
+      ]);
+      expect(
+        compatible.exitCode,
+        0,
+        reason: '${compatible.stdout}\n${compatible.stderr}',
+      );
+
+      final nativeSource = File('${repository.path}/native/src/change.cpp');
+      nativeSource.parent.createSync(recursive: true);
+      nativeSource.writeAsStringSync('int changed;\n');
+      runGit(<String>['add', nativeSource.path]);
+      runGit(<String>['commit', '--quiet', '-m', 'native change']);
+      final incompatible = Process.runSync(script, <String>[
+        artifactSource,
+        head(),
+        repository.path,
+      ]);
+      expect(incompatible.exitCode, isNot(0));
+      expect(incompatible.stderr, contains('native/src/change.cpp'));
+    } finally {
+      repository.deleteSync(recursive: true);
     }
   });
 

--- a/tool/ci/verify_release_artifact_source.sh
+++ b/tool/ci/verify_release_artifact_source.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$#" -lt 2 || "$#" -gt 3 ]]; then
+    echo "Usage: $0 <artifact-source-commit> <release-commit> [repository]" >&2
+    exit 64
+fi
+
+ARTIFACT_SOURCE_COMMIT="$1"
+RELEASE_COMMIT="$2"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPOSITORY="${3:-$(cd "${SCRIPT_DIR}/../.." && pwd)}"
+
+git -C "${REPOSITORY}" rev-parse --verify \
+    "${ARTIFACT_SOURCE_COMMIT}^{commit}" >/dev/null
+git -C "${REPOSITORY}" rev-parse --verify \
+    "${RELEASE_COMMIT}^{commit}" >/dev/null
+git -C "${REPOSITORY}" merge-base --is-ancestor \
+    "${ARTIFACT_SOURCE_COMMIT}" \
+    "${RELEASE_COMMIT}"
+
+while IFS= read -r path; do
+    case "${path}" in
+        .agents/skills/release-maplibre-flutter-gpu/SKILL.md | \
+            .pubignore | \
+            CHANGELOG.md | \
+            android/src/main/java/org/maplibre/android/http/NativeHttpRequest.java | \
+            darwin/maplibre_flutter_gpu.podspec | \
+            e2e/visual/gpu_app/pubspec.lock | \
+            example/pubspec.lock | \
+            example/pubspec.yaml | \
+            examples/gpu_map_scene/pubspec.lock | \
+            examples/gpu_map_scene/pubspec.yaml | \
+            examples/map_style_controls/pubspec.lock | \
+            examples/map_style_controls/pubspec.yaml | \
+            hook/desktop_artifacts.json | \
+            pubspec.yaml)
+            ;;
+        *)
+            echo "error: artifact source is incompatible with release change: ${path}" >&2
+            exit 1
+            ;;
+    esac
+done < <(
+    git -C "${REPOSITORY}" diff \
+        --name-only \
+        "${ARTIFACT_SOURCE_COMMIT}..${RELEASE_COMMIT}"
+)
+
+echo "Release artifact source is compatible with the release commit."


### PR DESCRIPTION
## Summary

- add a dedicated Release artifacts workflow that builds and uploads the seven standard native artifacts without running manifest or publish validation
- require Release preparation to consume a successful Release artifacts run instead of optionally building artifacts itself
- validate the artifact run identity, source SHA, success state, and source-to-release diff before reuse
- update the release Skill to use the two successful workflow stages

This removes the expected red bootstrap run caused by comparing newly built desktop archives against the previous release manifest. A failed Release artifacts run now always means artifact production failed, while a successful Release preparation run means the merged release source and published desktop assets are ready for publication.

## Validation

- actionlint on both release workflows
- Ruby YAML parsing on both release workflows
- release Skill quick validation
- flutter test test/package_configuration_test.dart
- ./tool/ci/quality.sh