### PR TITLE
(cancelled) chore: release 0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.6
+
+* Reduce symbol overlay rendering time by reusing unchanged widgets, avoiding
+  layout work during camera movement, and batching symbol widget rendering.
+
 ## 0.0.5
 
 * Improve rendering performance by reusing GPU resources across frames.

--- a/android/src/main/java/org/maplibre/android/http/NativeHttpRequest.java
+++ b/android/src/main/java/org/maplibre/android/http/NativeHttpRequest.java
@@ -76,7 +76,7 @@ public final class NativeHttpRequest {
       request.setReadTimeout(30_000);
       request.setInstanceFollowRedirects(true);
       request.setRequestMethod("GET");
-      request.setRequestProperty("User-Agent", "maplibre_flutter_gpu/0.0.5");
+      request.setRequestProperty("User-Agent", "maplibre_flutter_gpu/0.0.6");
       if (dataRange != null && !dataRange.isEmpty()) {
         request.setRequestProperty("Range", dataRange);
       }

--- a/darwin/maplibre_flutter_gpu.podspec
+++ b/darwin/maplibre_flutter_gpu.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'maplibre_flutter_gpu'
-  s.version = '0.0.5'
+  s.version = '0.0.6'
   s.summary = 'MapLibre maps rendered with Flutter GPU.'
   s.description = <<-DESC
 MapLibre maps for Flutter, rendered with Flutter GPU.

--- a/e2e/visual/gpu_app/pubspec.lock
+++ b/e2e/visual/gpu_app/pubspec.lock
@@ -181,7 +181,7 @@ packages:
       path: "../../.."
       relative: true
     source: path
-    version: "0.0.5"
+    version: "0.0.6"
   matcher:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -158,7 +158,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.5"
+    version: "0.0.6"
   matcher:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_flutter_landmarks_example
 description: World landmark Flutter marker example for maplibre_flutter_gpu.
 publish_to: 'none'
-version: 0.0.5
+version: 0.0.6
 
 environment:
   sdk: ^3.13.0

--- a/examples/gpu_map_scene/pubspec.lock
+++ b/examples/gpu_map_scene/pubspec.lock
@@ -158,7 +158,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.0.5"
+    version: "0.0.6"
   matcher:
     dependency: transitive
     description:

--- a/examples/gpu_map_scene/pubspec.yaml
+++ b/examples/gpu_map_scene/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_flutter_gpu_map_scene_example
 description: Geographic CC0 car and building GPU overlay example.
 publish_to: 'none'
-version: 0.0.5
+version: 0.0.6
 
 environment:
   sdk: ^3.13.0

--- a/examples/map_style_controls/pubspec.lock
+++ b/examples/map_style_controls/pubspec.lock
@@ -158,7 +158,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.0.5"
+    version: "0.0.6"
   matcher:
     dependency: transitive
     description:

--- a/examples/map_style_controls/pubspec.yaml
+++ b/examples/map_style_controls/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_flutter_map_style_controls_example
 description: Semantic map style controls using the MapLibre controller API.
 publish_to: 'none'
-version: 0.0.5
+version: 0.0.6
 
 environment:
   sdk: ^3.13.0

--- a/hook/desktop_artifacts.json
+++ b/hook/desktop_artifacts.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 1,
-  "baseUrl": "https://github.com/hyshu/maplibre_flutter_gpu/releases/download/v0.0.5/",
+  "baseUrl": "https://github.com/hyshu/maplibre_flutter_gpu/releases/download/v0.0.6/",
   "artifacts": [
-    {"os":"linux","architecture":"x64","archive":"native-linux-x64.tar.gz","member":"linux/x64/libmaplibre_bridge.so","library":"libmaplibre_bridge.so","sha256":"b7cf957a6dc3b6ab5a808ad08cc3bcac7453f7c99a9271b2db13551a317dd7b5"},
-    {"os":"linux","architecture":"arm64","archive":"native-linux-arm64.tar.gz","member":"linux/arm64/libmaplibre_bridge.so","library":"libmaplibre_bridge.so","sha256":"6160c5786e5e4f840dd58269e51c98ee71d2c6059d5005d0c4687137949953ce"},
-    {"os":"windows","architecture":"x64","archive":"native-windows-x64.tar.gz","member":"windows/x64/maplibre_bridge.dll","library":"maplibre_bridge.dll","sha256":"9a4e8d5af2e3bb3fab4502b78d1e9ddfee597b8f112b624e9f420c8f4c76b60a"},
-    {"os":"windows","architecture":"arm64","archive":"native-windows-arm64.tar.gz","member":"windows/arm64/maplibre_bridge.dll","library":"maplibre_bridge.dll","sha256":"394b74049d1aa2acdd7d552139f25205b2b68b1b3bee4e75c0a68d26cda4e79d"}
+    {"os":"linux","architecture":"x64","archive":"native-linux-x64.tar.gz","member":"linux/x64/libmaplibre_bridge.so","library":"libmaplibre_bridge.so","sha256":"1318b9e9317680e03ac5ee268fcf56edb2b8dcbf84fd55194d9f7d6e9e567b35"},
+    {"os":"linux","architecture":"arm64","archive":"native-linux-arm64.tar.gz","member":"linux/arm64/libmaplibre_bridge.so","library":"libmaplibre_bridge.so","sha256":"a39f4907236f082adcb91646fec64a94c98b1deecacbbb247ff398c1eb813806"},
+    {"os":"windows","architecture":"x64","archive":"native-windows-x64.tar.gz","member":"windows/x64/maplibre_bridge.dll","library":"maplibre_bridge.dll","sha256":"5cf50e3b7118e980ae643cf97ea4e0419f5170189a8a7e7f3fffc3410a369e4f"},
+    {"os":"windows","architecture":"arm64","archive":"native-windows-arm64.tar.gz","member":"windows/arm64/maplibre_bridge.dll","library":"maplibre_bridge.dll","sha256":"47960e006fd3e37bb0d5436c5db895e24e1a6100ac0625f28b569651dd3a118b"}
   ]
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_flutter_gpu
 description: >-
   MapLibre maps for Flutter, rendered with Flutter GPU.
-version: 0.0.5
+version: 0.0.6
 repository: https://github.com/hyshu/maplibre_flutter_gpu
 homepage: https://github.com/hyshu/maplibre_flutter_gpu
 issue_tracker: https://github.com/hyshu/maplibre_flutter_gpu/issues


### PR DESCRIPTION
## Summary

- bump the package, examples, CocoaPods metadata, Android User-Agent, and path lockfiles to 0.0.6
- document reduced symbol overlay rendering time from widget reuse, avoided camera-movement layout work, and batched symbol widget rendering
- update the desktop build-hook manifest for immutable v0.0.6 Linux and Windows assets

## Release artifacts

- Release artifacts run: 33230140355
- Source SHA: c60ed59acf34b4098bae1bef9153b09a7bac36af
- Planned asset URL: https://github.com/hyshu/maplibre_flutter_gpu/releases/download/v0.0.6/
- Linux x64: 1318b9e9317680e03ac5ee268fcf56edb2b8dcbf84fd55194d9f7d6e9e567b35
- Linux ARM64: a39f4907236f082adcb91646fec64a94c98b1deecacbbb247ff398c1eb813806
- Windows x64: 5cf50e3b7118e980ae643cf97ea4e0419f5170189a8a7e7f3fffc3410a369e4f
- Windows ARM64: 47960e006fd3e37bb0d5436c5db895e24e1a6100ac0625f28b569651dd3a118b

All seven standard artifacts succeeded. The four desktop archive sidecars, members, architectures, and independently calculated SHA-256 values were verified.

## Validation

- skill quick validator
- git diff --check
- flutter test test/package_configuration_test.dart
- ./tool/ci/check_publish.sh --metadata-only
- ./tool/ci/quality.sh
  - 646 package tests passed
  - 56.22% line coverage, minimum 44%
  - example, shared, and E2E runner tests passed
  - all analyzers completed successfully
  - final worktree diff check passed