### PR TITLE
fix(ci): validate release artifact workflow path

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -58,7 +58,8 @@ jobs:
             gh api \
               "repos/$GITHUB_REPOSITORY/actions/runs/$ARTIFACT_RUN_ID"
           )"
-          test "$(jq -r .name <<<"$run_json")" = 'Release artifacts'
+          test "$(jq -r .path <<<"$run_json")" = \
+            '.github/workflows/release-artifacts.yml'
           test "$(jq -r .event <<<"$run_json")" = workflow_dispatch
           test "$(jq -r .head_branch <<<"$run_json")" = main
           test "$(jq -r .conclusion <<<"$run_json")" = success

--- a/test/package_configuration_test.dart
+++ b/test/package_configuration_test.dart
@@ -141,7 +141,12 @@ void main() {
 
     expect(preparationWorkflow, contains('artifact_run_id:'));
     expect(preparationWorkflow, contains('required: true'));
-    expect(preparationWorkflow, contains('Release artifacts'));
+    expect(preparationWorkflow, contains('jq -r .path'));
+    expect(
+      preparationWorkflow,
+      contains('.github/workflows/release-artifacts.yml'),
+    );
+    expect(preparationWorkflow, isNot(contains('jq -r .name')));
     expect(preparationWorkflow, contains('verify_release_artifact_source.sh'));
     expect(preparationWorkflow, isNot(contains('new-build')));
     expect(preparationWorkflow, isNot(contains('_native-artifacts.yml')));


### PR DESCRIPTION
## Summary
- validate the selected artifact run by workflow path
- stop relying on the run name, which can resolve to the customized run title
- add a regression assertion for the stable workflow identity

## Failure addressed
Release preparation run 33241259117 rejected a valid Release artifacts run because the Actions API returned its customized run title in the name field.

## Validation
- flutter test test/package_configuration_test.dart
- ./tool/ci/check_publish.sh --metadata-only
- ./tool/ci/quality.sh