### PR TITLE
chore: release 0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.6
+
+* Reduce symbol overlay rendering time by reusing unchanged widgets, avoiding
+  layout work during camera movement, and batching symbol widget rendering.
+
 ## 0.0.5
 
 * Improve rendering performance by reusing GPU resources across frames.

--- a/android/src/main/java/org/maplibre/android/http/NativeHttpRequest.java
+++ b/android/src/main/java/org/maplibre/android/http/NativeHttpRequest.java
@@ -76,7 +76,7 @@ public final class NativeHttpRequest {
       request.setReadTimeout(30_000);
       request.setInstanceFollowRedirects(true);
       request.setRequestMethod("GET");
-      request.setRequestProperty("User-Agent", "maplibre_flutter_gpu/0.0.5");
+      request.setRequestProperty("User-Agent", "maplibre_flutter_gpu/0.0.6");
       if (dataRange != null && !dataRange.isEmpty()) {
         request.setRequestProperty("Range", dataRange);
       }

--- a/darwin/maplibre_flutter_gpu.podspec
+++ b/darwin/maplibre_flutter_gpu.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'maplibre_flutter_gpu'
-  s.version = '0.0.5'
+  s.version = '0.0.6'
   s.summary = 'MapLibre maps rendered with Flutter GPU.'
   s.description = <<-DESC
 MapLibre maps for Flutter, rendered with Flutter GPU.

--- a/e2e/visual/gpu_app/pubspec.lock
+++ b/e2e/visual/gpu_app/pubspec.lock
@@ -181,7 +181,7 @@ packages:
       path: "../../.."
       relative: true
     source: path
-    version: "0.0.5"
+    version: "0.0.6"
   matcher:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -158,7 +158,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.5"
+    version: "0.0.6"
   matcher:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_flutter_landmarks_example
 description: World landmark Flutter marker example for maplibre_flutter_gpu.
 publish_to: 'none'
-version: 0.0.5
+version: 0.0.6
 
 environment:
   sdk: ^3.13.0

--- a/examples/gpu_map_scene/pubspec.lock
+++ b/examples/gpu_map_scene/pubspec.lock
@@ -158,7 +158,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.0.5"
+    version: "0.0.6"
   matcher:
     dependency: transitive
     description:

--- a/examples/gpu_map_scene/pubspec.yaml
+++ b/examples/gpu_map_scene/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_flutter_gpu_map_scene_example
 description: Geographic CC0 car and building GPU overlay example.
 publish_to: 'none'
-version: 0.0.5
+version: 0.0.6
 
 environment:
   sdk: ^3.13.0

--- a/examples/map_style_controls/pubspec.lock
+++ b/examples/map_style_controls/pubspec.lock
@@ -158,7 +158,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.0.5"
+    version: "0.0.6"
   matcher:
     dependency: transitive
     description:

--- a/examples/map_style_controls/pubspec.yaml
+++ b/examples/map_style_controls/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_flutter_map_style_controls_example
 description: Semantic map style controls using the MapLibre controller API.
 publish_to: 'none'
-version: 0.0.5
+version: 0.0.6
 
 environment:
   sdk: ^3.13.0

--- a/hook/desktop_artifacts.json
+++ b/hook/desktop_artifacts.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 1,
-  "baseUrl": "https://github.com/hyshu/maplibre_flutter_gpu/releases/download/v0.0.5/",
+  "baseUrl": "https://github.com/hyshu/maplibre_flutter_gpu/releases/download/v0.0.6/",
   "artifacts": [
-    {"os":"linux","architecture":"x64","archive":"native-linux-x64.tar.gz","member":"linux/x64/libmaplibre_bridge.so","library":"libmaplibre_bridge.so","sha256":"b7cf957a6dc3b6ab5a808ad08cc3bcac7453f7c99a9271b2db13551a317dd7b5"},
-    {"os":"linux","architecture":"arm64","archive":"native-linux-arm64.tar.gz","member":"linux/arm64/libmaplibre_bridge.so","library":"libmaplibre_bridge.so","sha256":"6160c5786e5e4f840dd58269e51c98ee71d2c6059d5005d0c4687137949953ce"},
-    {"os":"windows","architecture":"x64","archive":"native-windows-x64.tar.gz","member":"windows/x64/maplibre_bridge.dll","library":"maplibre_bridge.dll","sha256":"9a4e8d5af2e3bb3fab4502b78d1e9ddfee597b8f112b624e9f420c8f4c76b60a"},
-    {"os":"windows","architecture":"arm64","archive":"native-windows-arm64.tar.gz","member":"windows/arm64/maplibre_bridge.dll","library":"maplibre_bridge.dll","sha256":"394b74049d1aa2acdd7d552139f25205b2b68b1b3bee4e75c0a68d26cda4e79d"}
+    {"os":"linux","architecture":"x64","archive":"native-linux-x64.tar.gz","member":"linux/x64/libmaplibre_bridge.so","library":"libmaplibre_bridge.so","sha256":"de75738cbb797ce66be7c9c6d2be32bf549cb1139227dfe77926908eebd0c064"},
+    {"os":"linux","architecture":"arm64","archive":"native-linux-arm64.tar.gz","member":"linux/arm64/libmaplibre_bridge.so","library":"libmaplibre_bridge.so","sha256":"5f151d1b1542ec814a795a6eb8baf8694b3fed3850562fa1040fd809eaef083a"},
+    {"os":"windows","architecture":"x64","archive":"native-windows-x64.tar.gz","member":"windows/x64/maplibre_bridge.dll","library":"maplibre_bridge.dll","sha256":"717ec4af65660dd510847377fd9356ee6f2f91ff6bbf20eaa6dc1e8a0982a0ae"},
+    {"os":"windows","architecture":"arm64","archive":"native-windows-arm64.tar.gz","member":"windows/arm64/maplibre_bridge.dll","library":"maplibre_bridge.dll","sha256":"726c614cb8edc629ea502631bc5c1c03d403b98875a5e1adb5f4da5d8a8e3fa6"}
   ]
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maplibre_flutter_gpu
 description: >-
   MapLibre maps for Flutter, rendered with Flutter GPU.
-version: 0.0.5
+version: 0.0.6
 repository: https://github.com/hyshu/maplibre_flutter_gpu
 homepage: https://github.com/hyshu/maplibre_flutter_gpu
 issue_tracker: https://github.com/hyshu/maplibre_flutter_gpu/issues


### PR DESCRIPTION
## Summary
- bump package and examples to 0.0.6
- add the approved symbol overlay performance release note
- point desktop build hooks at immutable v0.0.6 assets from the fresh artifact build

## Release artifacts
- run: 33246668274
- source SHA: 0a04f75e4590f28fc4090f18f1f746b3ff97124e
- planned asset URL: https://github.com/hyshu/maplibre_flutter_gpu/releases/download/v0.0.6/
- Linux x64: de75738cbb797ce66be7c9c6d2be32bf549cb1139227dfe77926908eebd0c064
- Linux ARM64: 5f151d1b1542ec814a795a6eb8baf8694b3fed3850562fa1040fd809eaef083a
- Windows x64: 717ec4af65660dd510847377fd9356ee6f2f91ff6bbf20eaa6dc1e8a0982a0ae
- Windows ARM64: 726c614cb8edc629ea502631bc5c1c03d403b98875a5e1adb5f4da5d8a8e3fa6

All sidecars, archive members, platforms, and architectures were independently verified.

## Validation
- skill quick validator
- flutter test test/package_configuration_test.dart
- ./tool/ci/check_publish.sh --metadata-only
- ./tool/ci/quality.sh
- confirmed v0.0.6 is absent from tags, GitHub Releases, and pub.dev