### PR TITLE
fix: preserve screen-axis scaling for line labels

### DIFF
--- a/lib/src/widgets/symbol_overlay.dart
+++ b/lib/src/widgets/symbol_overlay.dart
@@ -1323,23 +1323,33 @@ Widget _applyLineSymbolTransform(
   double angle,
 ) {
   final scale = _lineSymbolScale(transform);
-  final scaled = scale.x.isFinite && scale.y.isFinite
-      ? Transform.scale(
-          scaleX: scale.x,
-          scaleY: scale.y,
-          alignment: Alignment.center,
-          child: child,
-        )
+  final rotated = angle.isFinite && angle != 0
+      ? Transform.rotate(angle: angle, child: child)
       : child;
-  if (!angle.isFinite || angle == 0) return scaled;
+  if (!scale.x.isFinite || !scale.y.isFinite) return rotated;
 
-  return Transform.rotate(angle: angle, child: scaled);
+  return Transform.scale(
+    scaleX: scale.x,
+    scaleY: scale.y,
+    alignment: Alignment.center,
+    child: rotated,
+  );
 }
 
+// Line paths already use screen coordinates, so pitch scaling must remain tied
+// to screen axes when the glyph rotates to follow its path.
 ({double x, double y}) _lineSymbolScale(LabelAffineTransform transform) => (
-  x: math.sqrt(transform.xx * transform.xx + transform.xy * transform.xy),
-  y: math.sqrt(transform.yx * transform.yx + transform.yy * transform.yy),
+  x: math.sqrt(transform.xx * transform.xx + transform.yx * transform.yx),
+  y: math.sqrt(transform.xy * transform.xy + transform.yy * transform.yy),
 );
+
+double _lineAdvanceScale(({double x, double y}) scale, double angle) {
+  if (!scale.x.isFinite || !scale.y.isFinite || !angle.isFinite) return 1;
+  final x = scale.x * math.cos(angle);
+  final y = scale.y * math.sin(angle);
+
+  return math.sqrt(x * x + y * y);
+}
 
 double _pathAngle(
   List<LabelPathPoint> path,
@@ -1710,7 +1720,10 @@ Widget _buildPathText(LabelData data, List<_SymbolTextPart> parts) {
   }
   final path = [for (final point in data.textPath) Offset(point.x, point.y)];
   final lineScale = _lineSymbolScale(data.textTransform);
-  final advanceScale = lineScale.x.isFinite ? lineScale.x : 1.0;
+  final pathAngle =
+      _pathAngle(data.textPath, data.angle, keepUpright: data.textKeepUpright) +
+      data.textRotation;
+  final advanceScale = _lineAdvanceScale(lineScale, pathAngle);
   final placements = layoutSymbolGlyphsAlongPath(path, [
     for (final glyph in glyphs) glyph.advance * advanceScale,
   ], keepUpright: data.textKeepUpright);
@@ -1796,8 +1809,8 @@ Matrix4 _pathGlyphTransform(LabelAffineTransform transform, double angle) {
 
   return Matrix4.identity()
     ..setEntry(0, 0, cosine * scaleX)
-    ..setEntry(1, 0, sine * scaleX)
-    ..setEntry(0, 1, -sine * scaleY)
+    ..setEntry(1, 0, sine * scaleY)
+    ..setEntry(0, 1, -sine * scaleX)
     ..setEntry(1, 1, cosine * scaleY);
 }
 

--- a/test/symbol_overlay_test.dart
+++ b/test/symbol_overlay_test.dart
@@ -1947,6 +1947,46 @@ void main() {
     expect(transform.transform.storage[5], closeTo(math.cos(rotation), 0.001));
   });
 
+  testWidgets('line text keeps pitch compression in screen vertical axis', (
+    tester,
+  ) async {
+    final symbol = MapSymbol(
+      key: 'pitched-line',
+      data: _label(
+        'platform',
+        20,
+        alongLine: true,
+        textPath: const [LabelPathPoint(-80, 0), LabelPathPoint(80, 0)],
+        textTransform: const LabelAffineTransform(
+          xx: 0,
+          xy: 0.5,
+          yx: -1,
+          yy: 0,
+        ),
+      ),
+      textPos: Offset.zero,
+      iconPos: null,
+      icon: null,
+      visible: true,
+      fadeIn: false,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => buildDefaultSymbolText(context, symbol)!,
+        ),
+      ),
+    );
+
+    final transforms = tester.widgetList<Transform>(find.byType(Transform));
+    expect(transforms, isNotEmpty);
+    for (final transform in transforms) {
+      expect(transform.transform.storage[0], closeTo(1, 0.001));
+      expect(transform.transform.storage[5], closeTo(0.5, 0.001));
+    }
+  });
+
   testWidgets('point text uses final affine transform and screen translation', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary

- keep line-label pitch scaling tied to screen axes after path rotation
- scale glyph advances along the rendered line direction
- add a regression test for a rotated, pitched line label

## Problem

Map-aligned labels using `symbol-placement: line` decomposed the native affine transform into axis scales and then rotated those scales with the label. At some map bearings, vertical pitch compression therefore became horizontal compression. Point labels were unaffected because they already apply the full affine transform.

## Screenshots

High tilt reproduces the incorrect horizontal compression in the circled Shinjuku platform label.

<img width="600" height="600" src="https://github.com/user-attachments/assets/cb937b72-b100-4b9e-80be-8b8dc253002b" />

The lower-tilt reference shows the label width that should be retained while pitch compresses the screen vertical axis.

<img width="600" height="600" src="https://github.com/user-attachments/assets/1669cff9-c541-4fd0-a235-710934db4401" />

## Validation

- `dart analyze lib/src/widgets/symbol_overlay.dart test/symbol_overlay_test.dart`
- `flutter test test/symbol_overlay_test.dart`
- `flutter test` (647 tests)