### PR TITLE
docs: clarify repeated symbol builder placements

### DIFF
--- a/lib/src/gpu/prepared_graph_metrics.dart
+++ b/lib/src/gpu/prepared_graph_metrics.dart
@@ -109,8 +109,9 @@ final class PreparedGraphDetailedTimingMetrics {
     required int captureMicros,
   }) {
     _checkMicros('totalMicros', totalMicros);
-    if (validationMicros != null)
+    if (validationMicros != null) {
       _checkMicros('validationMicros', validationMicros);
+    }
     if (refreshMicros != null) _checkMicros('refreshMicros', refreshMicros);
     _checkMicros('decodeMicros', decodeMicros);
     _checkMicros('captureMicros', captureMicros);

--- a/lib/src/state/gesture/gesture_coordinator.dart
+++ b/lib/src/state/gesture/gesture_coordinator.dart
@@ -315,8 +315,9 @@ class MapGestureCoordinator({
   _DesktopMouseDragMode? _desktopMouseDragModeFor(PointerDownEvent event) {
     final platform = defaultTargetPlatform;
     if (platform != .windows && platform != .linux) return null;
-    if (event.kind != .mouse || event.buttons != kPrimaryMouseButton)
+    if (event.kind != .mouse || event.buttons != kPrimaryMouseButton) {
       return null;
+    }
     if (HardwareKeyboard.instance.isControlPressed) return .rotate;
     if (HardwareKeyboard.instance.isShiftPressed) return .tilt;
     return null;

--- a/lib/src/widgets/maplibre_map.dart
+++ b/lib/src/widgets/maplibre_map.dart
@@ -609,6 +609,10 @@ class MapLibreMap extends StatefulWidget {
   /// pointer events. Returning null hides the icon for that symbol. If this
   /// builder is null, all symbol icons are hidden.
   ///
+  /// When the same location appears more than once on screen, such as when
+  /// zooming out, the same symbol may be placed multiple times. Each placement
+  /// needs an independent widget and must not share a [GlobalKey].
+  ///
   /// Defaults to [defaultSymbolIconBuilder].
   final SymbolWidgetBuilder? symbolIconBuilder;
 
@@ -617,6 +621,10 @@ class MapLibreMap extends StatefulWidget {
   /// The returned widget is centered on [MapSymbol.textPos] and does not receive
   /// pointer events. Returning null hides the text for that symbol. If this
   /// builder is null, all symbol text is hidden.
+  ///
+  /// When the same location appears more than once on screen, such as when
+  /// zooming out, the same symbol may be placed multiple times. Each placement
+  /// needs an independent widget and must not share a [GlobalKey].
   ///
   /// Defaults to [defaultSymbolTextBuilder].
   final SymbolWidgetBuilder? symbolTextBuilder;

--- a/lib/src/widgets/symbol_overlay.dart
+++ b/lib/src/widgets/symbol_overlay.dart
@@ -165,6 +165,10 @@ class const MapSymbol({
 /// An icon widget is centered on [MapSymbol.iconPos], and a text widget is
 /// centered on [MapSymbol.textPos]. Returning null omits that part.
 ///
+/// When the same location appears more than once on screen, such as when
+/// zooming out, the same symbol may be placed multiple times. Each placement
+/// needs an independent widget and must not share a [GlobalKey].
+///
 /// Builder results receive pointer events while their symbol is visible.
 /// Gesture handlers can consume those events instead of passing them to the
 /// map beneath the overlay.


### PR DESCRIPTION
## Summary

- document that the same symbol can have multiple simultaneous placements when the same location appears more than once on screen, such as when zooming out
- clarify that each placement needs an independent widget and must not share a GlobalKey
- add braces to two multiline conditions in timing validation and desktop gesture handling

The branch contains separate commits for the formatting changes and symbol builder documentation. Runtime behavior is unchanged.

## Validation

- `dart format --output=none --set-exit-if-changed` on all four changed files
- `dart analyze` on all four changed files (no issues)
- `git diff --check`
