### PR TITLE
fix: retain viewport changes during map initialization

### DIFF
--- a/lib/src/state/map_viewport.dart
+++ b/lib/src/state/map_viewport.dart
@@ -135,7 +135,6 @@ class MapViewport {
   }) {
     observedDpr = _normalizeDevicePixelRatio(observedDpr);
     final previous = _coalescer.applied;
-    final sizeChanged = previous?.logicalSize != newLogicalSize;
     final dprChanged = previous?.dpr != observedDpr;
     _coalescer.markApplied((logicalSize: newLogicalSize, dpr: observedDpr));
     if (!initialized) return false;
@@ -149,7 +148,6 @@ class MapViewport {
         'keeping native DPR $_devicePixelRatio until the map is remounted',
       );
     }
-    if (!sizeChanged) return false;
 
     return _setDimensions(newLogicalSize);
   }

--- a/lib/src/widgets/maplibre_map.dart
+++ b/lib/src/widgets/maplibre_map.dart
@@ -795,7 +795,6 @@ class _MapLibreMapState extends State<MapLibreMap>
 
       final viewport = _viewport.applied;
       if (viewport == null) return;
-      _viewport.adoptForInitialization(viewport.logicalSize, viewport.dpr);
       final shaderLibrary = await loadMapShaderLibrary();
       if (!mounted) return;
       if (!_hasBridge) {
@@ -814,6 +813,12 @@ class _MapLibreMapState extends State<MapLibreMap>
         isAlive: () => mounted,
       );
       if (style == null) return;
+      // Layout can change while shaders, the bridge, or the style are loading.
+      final latestViewport = _viewport.applied!;
+      _viewport.adoptForInitialization(
+        latestViewport.logicalSize,
+        latestViewport.dpr,
+      );
       final gpuRenderer = GpuFrameRenderer(
         bridge: _bridge,
         shaders: shaderLibrary,

--- a/test/map_viewport_test.dart
+++ b/test/map_viewport_test.dart
@@ -7,6 +7,42 @@ ViewportRequest _v(double width, double height, [double dpr = 2]) =>
     (logicalSize: Size(width, height), dpr: dpr);
 
 void main() {
+  test(
+    'initialization adopts the latest size and ratio after async loading',
+    () {
+      final viewport = MapViewport()
+        ..applyLayout(const Size(800, 600), 2, initialized: false)
+        ..applyLayout(const Size(400, 300), 3, initialized: false);
+      final latest = viewport.applied!;
+      viewport.adoptForInitialization(latest.logicalSize, latest.dpr);
+
+      expect(viewport.logicalSize, const Size(400, 300));
+      expect(viewport.devicePixelRatio, 3);
+      expect(viewport.physicalWidth, 1200);
+      expect(
+        viewport.applyLayout(latest.logicalSize, latest.dpr, initialized: true),
+        isFalse,
+      );
+    },
+  );
+
+  test('recorded layout does not suppress an unapplied native resize', () {
+    final viewport = MapViewport()
+      ..adoptForInitialization(const Size(800, 600), 2)
+      ..applyLayout(const Size(400, 300), 3, initialized: false);
+
+    expect(
+      viewport.applyLayout(const Size(400, 300), 3, initialized: true),
+      isTrue,
+    );
+    expect(viewport.logicalSize, const Size(400, 300));
+    expect(viewport.physicalWidth, 800);
+    expect(
+      viewport.applyLayout(const Size(400, 300), 3, initialized: true),
+      isFalse,
+    );
+  });
+
   group('scheduling', () {
     test('the first request schedules a callback', () {
       expect(MapViewportCoalescer().request(_v(800, 600)), isTrue);


### PR DESCRIPTION
## Summary

Resizing while shaders, the bridge, or the style were loading could leave native rendering at the original size indefinitely. Adopt the latest viewport immediately before native initialization. Compare later resize requests with actual render dimensions so an already-recorded layout cannot suppress a native resize.

## Validation

- viewport, style lifecycle, async snapshot, and map layout tests (42 tests)
- targeted `dart analyze` (no issues)
- regression covers size and DPR changes during loading and repeated resize application
- `git diff --check`
