### PR TITLE
fix: retain whole-world longitude spans in bounds

### DIFF
--- a/lib/src/controller/maplibre_map_controller.dart
+++ b/lib/src/controller/maplibre_map_controller.dart
@@ -748,9 +748,9 @@ class MapLibreMapController extends ChangeNotifier {
 
         return _bridge.fitCameraBounds(
           south: bounds.southwest.latitude,
-          west: bounds.southwest.longitude,
+          west: bounds.west,
           north: bounds.northeast.latitude,
-          east: bounds.northeast.longitude,
+          east: bounds.east,
           left: update.left,
           top: update.top,
           right: update.right,

--- a/lib/src/geo/camera.dart
+++ b/lib/src/geo/camera.dart
@@ -11,7 +11,8 @@ class LatLng {
   /// The latitude is clamped to the inclusive interval `[-90.0, 90.0]`.
   const new(double latitude, double longitude)
     : latitude = latitude < -90.0 ? -90.0 : (latitude > 90.0 ? 90.0 : latitude),
-      longitude = (longitude + 180.0) % 360.0 - 180.0;
+      longitude = (longitude + 180.0) % 360.0 - 180.0,
+      _unwrappedLongitude = longitude;
 
   /// The latitude in degrees between -90.0 and 90.0, both inclusive.
   final double latitude;
@@ -19,6 +20,9 @@ class LatLng {
   /// The longitude in degrees from -180.0 inclusive to 180.0 exclusive.
   /// Values outside this range are normalized by the constructor.
   final double longitude;
+
+  // Bounds need the original span even when their corner points normalize equally.
+  final double _unwrappedLongitude;
 
   dynamic toJson() => [latitude, longitude];
 
@@ -46,7 +50,24 @@ class const LatLngBounds({
   /// The northeast corner of these bounds.
   required final LatLng northeast,
 }) {
-  List<dynamic> toList() => [southwest.toJson(), northeast.toJson()];
+  /// Whether the original corner longitudes span at least one whole world.
+  ///
+  /// Point longitudes remain normalized. Bounds retain the original span so
+  /// corners supplied at -180 and 180 describe all longitudes.
+  bool get coversAllLongitudes =>
+      (northeast._unwrappedLongitude - southwest._unwrappedLongitude).abs() >=
+      360;
+
+  /// Western boundary in degrees, or -180 for a whole-world longitude span.
+  double get west => coversAllLongitudes ? -180 : southwest.longitude;
+
+  /// Eastern boundary in degrees, or 180 for a whole-world longitude span.
+  double get east => coversAllLongitudes ? 180 : northeast.longitude;
+
+  List<dynamic> toList() => [
+    [southwest.latitude, west],
+    [northeast.latitude, east],
+  ];
 
   /// Returns whether [point] lies within these bounds.
   ///
@@ -56,11 +77,13 @@ class const LatLngBounds({
     final latitudeInBounds =
         point.latitude >= southwest.latitude &&
         point.latitude <= northeast.latitude;
-    final longitudeInBounds = southwest.longitude <= northeast.longitude
-        ? point.longitude >= southwest.longitude &&
-              point.longitude <= northeast.longitude
-        : point.longitude >= southwest.longitude ||
-              point.longitude <= northeast.longitude;
+    final longitudeInBounds =
+        coversAllLongitudes ||
+        (southwest.longitude <= northeast.longitude
+            ? point.longitude >= southwest.longitude &&
+                  point.longitude <= northeast.longitude
+            : point.longitude >= southwest.longitude ||
+                  point.longitude <= northeast.longitude);
 
     return latitudeInBounds && longitudeInBounds;
   }
@@ -69,10 +92,11 @@ class const LatLngBounds({
   bool operator ==(Object other) =>
       other is LatLngBounds &&
       other.southwest == southwest &&
-      other.northeast == northeast;
+      other.northeast == northeast &&
+      other.coversAllLongitudes == coversAllLongitudes;
 
   @override
-  int get hashCode => Object.hash(southwest, northeast);
+  int get hashCode => Object.hash(southwest, northeast, coversAllLongitudes);
 
   @override
   String toString() => 'LatLngBounds($southwest, $northeast)';

--- a/lib/src/widgets/maplibre_map.dart
+++ b/lib/src/widgets/maplibre_map.dart
@@ -926,15 +926,15 @@ class _MapLibreMapState extends State<MapLibreMap>
     // Widen each range first so both upward and downward changes are valid.
     _bridge.setBounds(
       south: bounds?.southwest.latitude,
-      west: bounds?.southwest.longitude,
+      west: bounds?.west,
       north: bounds?.northeast.latitude,
-      east: bounds?.northeast.longitude,
+      east: bounds?.east,
     );
     _bridge.setBounds(
       south: bounds?.southwest.latitude,
-      west: bounds?.southwest.longitude,
+      west: bounds?.west,
       north: bounds?.northeast.latitude,
-      east: bounds?.northeast.longitude,
+      east: bounds?.east,
       minZoom: zoom.minZoom,
       maxZoom: zoom.maxZoom,
     );

--- a/test/maplibre_map_controller_test.dart
+++ b/test/maplibre_map_controller_test.dart
@@ -24,6 +24,8 @@ class _FakeBridge implements MaplibreBridge {
   int? lastEasing;
   var usedFlight = false;
   bool? lastFitFlight;
+  double? lastFitWest;
+  double? lastFitEast;
   var cancelCount = 0;
   String? styleValue;
   final List<String> layerIds = ['background', 'roads'];
@@ -275,6 +277,8 @@ class _FakeBridge implements MaplibreBridge {
     lastDuration = duration;
     lastEasing = easing;
     lastFitFlight = flyTo;
+    lastFitWest = west;
+    lastFitEast = east;
 
     return true;
   }
@@ -379,7 +383,25 @@ Future<CameraPosition> _apply(CameraUpdate update) async {
   return result;
 }
 
+class _WorldBridge extends _FakeBridge {
+  @override
+  ({double south, double west, double north, double east}) getVisibleRegion() =>
+      (south: -80, west: -180, north: 80, east: 180);
+}
+
 void main() {
+  test('visible whole-world bounds remain whole-world when fitted', () async {
+    final bridge = _WorldBridge();
+    final controller = MapLibreMapController.bind(bridge);
+    addTearDown(controller.dispose);
+    final bounds = await controller.getVisibleRegion();
+    expect(bounds.contains(const LatLng(0, 0)), isTrue);
+    expect(bounds.coversAllLongitudes, isTrue);
+    await controller.moveCamera(CameraUpdate.newLatLngBounds(bounds));
+    expect(bridge.lastFitWest, -180);
+    expect(bridge.lastFitEast, 180);
+  });
+
   test('screen offsets retain every visible wrapped world copy', () {
     final bridge = _FakeBridge()
       ..lat = 0

--- a/test/maplibre_map_controller_test.dart
+++ b/test/maplibre_map_controller_test.dart
@@ -390,18 +390,6 @@ class _WorldBridge extends _FakeBridge {
 }
 
 void main() {
-  test('visible whole-world bounds remain whole-world when fitted', () async {
-    final bridge = _WorldBridge();
-    final controller = MapLibreMapController.bind(bridge);
-    addTearDown(controller.dispose);
-    final bounds = await controller.getVisibleRegion();
-    expect(bounds.contains(const LatLng(0, 0)), isTrue);
-    expect(bounds.coversAllLongitudes, isTrue);
-    await controller.moveCamera(CameraUpdate.newLatLngBounds(bounds));
-    expect(bridge.lastFitWest, -180);
-    expect(bridge.lastFitEast, 180);
-  });
-
   test('screen offsets retain every visible wrapped world copy', () {
     final bridge = _FakeBridge()
       ..lat = 0
@@ -961,4 +949,15 @@ void main() {
       expect(callbackCount, 0);
     },
   );
+  test('visible whole-world bounds remain whole-world when fitted', () async {
+    final bridge = _WorldBridge();
+    final controller = MapLibreMapController.bind(bridge);
+    addTearDown(controller.dispose);
+    final bounds = await controller.getVisibleRegion();
+    expect(bounds.contains(const LatLng(0, 0)), isTrue);
+    expect(bounds.coversAllLongitudes, isTrue);
+    await controller.moveCamera(CameraUpdate.newLatLngBounds(bounds));
+    expect(bridge.lastFitWest, -180);
+    expect(bridge.lastFitEast, 180);
+  });
 }

--- a/test/maplibre_map_options_test.dart
+++ b/test/maplibre_map_options_test.dart
@@ -5,6 +5,40 @@ import 'package:maplibre_flutter_gpu/maplibre_flutter_gpu.dart';
 import 'package:maplibre_flutter_gpu/src/state/gesture/gesture_math.dart';
 
 void main() {
+  test('whole-world bounds retain their span through normalization', () {
+    for (final east in [180.0, 540.0]) {
+      final bounds = LatLngBounds(
+        southwest: const LatLng(-80, -180),
+        northeast: LatLng(80, east),
+      );
+      expect(bounds.coversAllLongitudes, isTrue);
+      for (final longitude in [-180.0, -90.0, 0.0, 90.0, 179.0]) {
+        expect(bounds.contains(LatLng(0, longitude)), isTrue);
+      }
+      expect(bounds.contains(const LatLng(85, 0)), isFalse);
+      expect(bounds.toList(), [
+        [-80.0, -180.0],
+        [80.0, 180.0],
+      ]);
+      expect(
+        bounds,
+        isNot(
+          const LatLngBounds(
+            southwest: LatLng(-80, -180),
+            northeast: LatLng(80, -180),
+          ),
+        ),
+      );
+    }
+    const wrapped = LatLngBounds(
+      southwest: LatLng(-10, 170),
+      northeast: LatLng(10, 190),
+    );
+    expect(wrapped.coversAllLongitudes, isFalse);
+    expect(wrapped.contains(const LatLng(0, 180)), isTrue);
+    expect(wrapped.contains(const LatLng(0, 0)), isFalse);
+  });
+
   test('LatLng normalizes longitude like maplibre_gl', () {
     expect(const LatLng(100, 540), const LatLng(90, -180));
     expect(const LatLng(-100, -540), const LatLng(-90, -180));


### PR DESCRIPTION
## Summary

Bounds supplied with west -180 and east 180 previously collapsed to a single longitude because both LatLng corners normalize to -180. Preserve the original longitude span when interpreting bounds, expose canonical west/east boundaries, and retain whole-world coverage through contains, serialization, camera fitting, and camera constraints.

LatLng point equality and normalized coordinates remain compatible. Bounds equality distinguishes whole-world coverage from a zero-width meridian.

## Validation

- options, controller, and widget tests (31 tests)
- native visible-region adapter regression round-trips whole-world bounds into camera fitting
- tests cover 360-degree and larger spans, antimeridian crossing, latitude limits, serialization, and equality
- targeted `dart analyze` (no issues)
- `git diff --check`

## Before and after

Fit the same bounds spanning all longitudes, from latitude -30 to 30. Before this fix, both corner longitudes normalize to -180, so camera fitting treats the bounds as a zero-width meridian and zooms into the Pacific. With this fix, the 360-degree span is preserved and the map fits the full longitude range.

| Before · main `022834e` | After · `fix/world-bounds` `3a82042` |
| --- | --- |
| <img width="480" alt="Before: bounds collapse to one meridian and the camera zooms into the Pacific" src="https://github.com/user-attachments/assets/6ff68286-26f7-4ad4-8d18-b1b49bda1734" /> | <img width="480" alt="After: the full longitude range fits in the viewport" src="https://github.com/user-attachments/assets/e6acefda-456b-480e-bf40-4ff745407197" /> |
| Center longitude **-180°**, zoom **2.538** | Center longitude **0°**, zoom **0.492** |
| Effective longitudes `[-180, -180]` | Effective longitudes `[-180, 180]` |

### Reproduction

```dart
await controller.moveCamera(
  CameraUpdate.newLatLngBounds(
    const LatLngBounds(
      southwest: LatLng(-30, -180),
      northeast: LatLng(30, 180),
    ),
    left: 40,
    right: 40,
    top: 40,
    bottom: 40,
  ),
);
```

Captured from the running macOS app with Flutter 3.47.2, an 800 × 600 logical-pixel viewport, 2× PNG capture (1600 × 1200), and the [MapLibre demo style](https://demotiles.maplibre.org/style.json). Both runs used the same native artifact, initial camera (latitude 0, longitude 0, zoom 1), and 40 logical pixels of padding on every edge. The capture test passed on both revisions. These screenshots verify camera fitting visually; the unit tests separately cover containment, serialization, and bounds equality.
