### PR TITLE
fix: define circle edge coverage for every blur width

### DIFF
--- a/shaders/circle.frag
+++ b/shaders/circle.frag
@@ -23,14 +23,18 @@ void main() {
     float extrude_length = length(extrude);
 
     float antialiasblur = v_data.z;
-    float antialiased_blur = -max(props.blur, antialiasblur);
+    float antialiased_blur = max(props.blur, antialiasblur);
 
-    float opacity_t = smoothstep(0.0, antialiased_blur, extrude_length - 1.0);
+    float opacity_t = 1.0 - (antialiased_blur > 0.0
+        ? smoothstep(-antialiased_blur, 0.0, extrude_length - 1.0)
+        : step(0.0, extrude_length - 1.0));
 
     float color_t = props.stroke_width < 0.01
         ? 0.0
-        : smoothstep(antialiased_blur, 0.0,
-                     extrude_length - props.radius / (props.radius + props.stroke_width));
+        : (antialiased_blur > 0.0
+            ? smoothstep(-antialiased_blur, 0.0,
+                         extrude_length - props.radius / (props.radius + props.stroke_width))
+            : step(0.0, extrude_length - props.radius / (props.radius + props.stroke_width)));
 
     frag_color = opacity_t * mix(props.color * props.opacity,
                                  props.stroke_color * props.stroke_opacity,

--- a/shaders/circle_dd.frag
+++ b/shaders/circle_dd.frag
@@ -33,12 +33,16 @@ void main() {
     float stroke_opacity = (props.data_driven_mask & 64u) != 0u ? v_stroke_data.y : props.stroke_opacity;
 
     float extrude_length = length(v_extrude);
-    float antialiased_blur = -max(blur, v_circle_data.x);
-    float opacity_t = smoothstep(0.0, antialiased_blur, extrude_length - 1.0);
+    float antialiased_blur = max(blur, v_circle_data.x);
+    float opacity_t = 1.0 - (antialiased_blur > 0.0
+        ? smoothstep(-antialiased_blur, 0.0, extrude_length - 1.0)
+        : step(0.0, extrude_length - 1.0));
     float color_t = stroke_width < 0.01
         ? 0.0
-        : smoothstep(antialiased_blur, 0.0,
-                     extrude_length - radius / (radius + stroke_width));
+        : (antialiased_blur > 0.0
+            ? smoothstep(-antialiased_blur, 0.0,
+                         extrude_length - radius / (radius + stroke_width))
+            : step(0.0, extrude_length - radius / (radius + stroke_width)));
 
     frag_color = opacity_t * mix(color * opacity,
                                  stroke_color * stroke_opacity,

--- a/test/circle_data_driven_shader_test.dart
+++ b/test/circle_data_driven_shader_test.dart
@@ -64,8 +64,8 @@ void main() {
     for (final mask in ['1u', '2u', '4u', '8u', '16u', '32u', '64u']) {
       expect(fragment, contains('props.data_driven_mask & $mask'));
     }
-    expect(fragment, contains('float antialiased_blur = -max('));
-    expect(fragment, contains('smoothstep(0.0, antialiased_blur'));
+    expect(fragment, contains('float antialiased_blur = max('));
+    expect(fragment, contains('smoothstep(-antialiased_blur, 0.0,'));
     expect(fragment, contains('radius / (radius + stroke_width)'));
     expect(fragment, contains('mix(color * opacity,'));
     expect(fragment, contains('stroke_color * stroke_opacity'));


### PR DESCRIPTION
## Summary

Make circle edge fading well-defined in GLSL for both constant and data-driven circle shaders, while preserving the intended appearance.

## Why this implementation is needed

Circle shaders blend the fill, stroke, and transparency near the edge. The previous outer fade used `smoothstep(0.0, -blur, distanceFromEdge)`, passing the boundaries in reverse order. [GLSL leaves the result undefined when `edge0 >= edge1`](https://github.khronos.org/Vulkan-Site/glsl/latest/chapters/builtinfunctions.html), so a correct-looking result on one GPU does not guarantee the same rendering on another GPU or driver.

The corrected outer fade uses:

```glsl
1.0 - smoothstep(-blur, 0.0, distanceFromEdge)
```

Here, `blur` is the positive effective blur width. Ordered boundaries give a defined interpolation, and subtracting from 1 keeps the circle opaque inside and transparent at its outer edge. The fill-to-stroke blend uses the same ordered boundaries without inversion.

When the effective blur width is zero, even ordered boundaries would be equal. Use `step` in that case to produce a hard edge without an undefined `smoothstep` call. Apply the same handling to both circle shader variants.

## Rendered result

Expected rendering with blur 0 / 0.15 / 0.5 and stroke width 0 / 6, using constant and data-driven properties.

<img width="800" alt="Circle edge fading across blur and stroke settings" src="https://github.com/user-attachments/assets/8c58405d-1c09-42a9-9947-704d624c3f66" />

## Validation

- Shader tests and bundle compilation pass.
- macOS geometry E2E passes.
- All 12 cases above match the pre-fix output exactly on macOS Metal. This verifies preserved appearance on Metal, not a reproduced rendering failure there.
