### PR TITLE
fix: notify custom overlays after viewport resizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ class _MapPageState extends State<MapPage> {
 | `tiltGesturesEnabled` | `bool` | `true` | Enables three-finger vertical tilt. |
 | `doubleClickZoomEnabled` | `bool?` | Follows zoom gestures | Enables double-tap zoom independently. |
 | `gestureOptions` | `MapGestureOptions` | `const MapGestureOptions()` | Configures gesture animation, thresholds, and sensitivity. |
-| `trackCameraPosition` | `bool` | `false` | Makes the controller notify its listeners when the camera changes. |
+| `trackCameraPosition` | `bool` | `false` | Makes the controller notify its listeners when the camera or viewport size changes. |
 
 ### Map controls
 

--- a/e2e/visual/gpu_app/integration_test/viewport_overlay_test.dart
+++ b/e2e/visual/gpu_app/integration_test/viewport_overlay_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:maplibre_flutter_gpu/maplibre_flutter_gpu.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('resize reprojects a controller-driven custom marker', (
+    tester,
+  ) async {
+    final size = ValueNotifier(const Size(320, 240));
+    final position = ValueNotifier(Offset.zero);
+    MapLibreMapController? controller;
+    var loaded = false;
+    const location = LatLng(0, 0);
+    const mapKey = ValueKey('map');
+    const markerKey = ValueKey('marker');
+
+    void project() {
+      position.value = controller!.toScreenOffsets(location).single;
+    }
+
+    addTearDown(() async {
+      controller?.removeListener(project);
+      await tester.pumpWidget(const SizedBox.shrink());
+      size.dispose();
+      position.dispose();
+    });
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Align(
+          alignment: Alignment.topLeft,
+          child: ValueListenableBuilder(
+            valueListenable: size,
+            builder: (context, dimensions, _) => SizedBox.fromSize(
+              size: dimensions,
+              child: Stack(
+                children: [
+                  Positioned.fill(
+                    child: MapLibreMap(
+                      key: mapKey,
+                      styleString:
+                          '{"version":8,"sources":{},"layers":['
+                          '{"id":"background","type":"background",'
+                          '"paint":{"background-color":"#eeeeee"}}]}',
+                      initialCameraPosition: const CameraPosition(
+                        target: location,
+                        zoom: 3,
+                      ),
+                      trackCameraPosition: true,
+                      compassEnabled: false,
+                      logoEnabled: false,
+                      attributionButtonEnabled: false,
+                      scaleControlEnabled: false,
+                      onMapCreated: (value) {
+                        controller = value;
+                        value.addListener(project);
+                        project();
+                      },
+                      onStyleLoadedCallback: () => loaded = true,
+                    ),
+                  ),
+                  ValueListenableBuilder(
+                    valueListenable: position,
+                    builder: (context, offset, _) => Positioned(
+                      left: offset.dx - 5,
+                      top: offset.dy - 5,
+                      child: const SizedBox(
+                        key: markerKey,
+                        width: 10,
+                        height: 10,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    for (var i = 0; i < 300 && !loaded; i++) {
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+    expect(loaded, isTrue);
+    final camera = controller!.cameraPosition;
+    for (final dimensions in [const Size(480, 360), const Size(280, 200)]) {
+      size.value = dimensions;
+      for (var i = 0; i < 20; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+      expect(controller!.cameraPosition, camera);
+      final mapOrigin = tester.getTopLeft(find.byKey(mapKey));
+      expect(
+        tester.getCenter(find.byKey(markerKey)) - mapOrigin,
+        Offset(dimensions.width / 2, dimensions.height / 2),
+      );
+    }
+  });
+}

--- a/lib/src/controller/maplibre_map_controller.dart
+++ b/lib/src/controller/maplibre_map_controller.dart
@@ -25,8 +25,10 @@ import '../native/maplibre_ffi.dart' hide LabelData;
 ///
 /// This controller is also a [ChangeNotifier]. When
 /// [MapLibreMap.trackCameraPosition] is `true`, rendered camera changes update
-/// the cached [cameraPosition] and notify listeners. Direct queries through
-/// [queryCameraPosition] update the cache without notifying listeners. Use
+/// the cached [cameraPosition] and notify listeners. Viewport size changes
+/// also notify listeners so custom overlays can reproject their coordinates.
+/// Direct queries through [queryCameraPosition] update the cache without
+/// notifying listeners. Use
 /// [MapLibreMap.onCameraMove] when a callback is more convenient than a
 /// listener.
 ///
@@ -922,12 +924,18 @@ class MapLibreMapController extends ChangeNotifier {
   ///
   /// This method is for package code. It returns `true` when the MapLibre camera
   /// differs from the cached [cameraPosition]. When `notifyListeners` is `true`,
-  /// a changed position also notifies this controller's listeners.
-  bool notifyCameraChanged({bool notifyListeners = true}) {
+  /// a changed position or [viewportChanged] also notifies listeners.
+  /// The caller reports viewport changes after a native frame is available
+  /// so listeners can project coordinates using the updated viewport.
+  bool notifyCameraChanged({
+    bool notifyListeners = true,
+    bool viewportChanged = false,
+  }) {
     _ensureNotDisposed();
     final changed = _syncCameraFromBridge();
-    if (changed && notifyListeners) super.notifyListeners();
-
+    if ((changed || viewportChanged) && notifyListeners) {
+      super.notifyListeners();
+    }
     return changed;
   }
 

--- a/lib/src/widgets/maplibre_map.dart
+++ b/lib/src/widgets/maplibre_map.dart
@@ -359,7 +359,8 @@ class MapLibreMap extends StatefulWidget {
   /// Defaults to a const [MapGestureOptions] instance.
   final MapGestureOptions gestureOptions;
 
-  /// Whether the controller notifies its listeners when the camera moves.
+  /// Whether the controller notifies its listeners when the camera moves
+  /// or the map viewport changes size.
   ///
   /// This does not control [onCameraMove], which runs whenever that callback is
   /// non-null and a camera change is observed.
@@ -754,6 +755,8 @@ class _MapLibreMapState extends State<MapLibreMap>
   final _gpuFrame = ValueNotifier(0);
   final _symbolVersion = ValueNotifier(0);
   final _symbolLayoutVersion = ValueNotifier(0);
+  // Notify viewport listeners only after a native frame is available.
+  var _viewportNotificationPending = false;
   final _controlsVersion = ValueNotifier(0);
   var _nativeCommandLayerIndices = const <int>{};
   var _symbolGpuStratumSlots = const <int>[0];
@@ -1059,6 +1062,7 @@ class _MapLibreMapState extends State<MapLibreMap>
       return;
     }
     if (!resized) return;
+    _viewportNotificationPending = true;
     final bridge = _bridge;
     // Release the previous-size snapshot before rendering the resized map.
     final staleSnapshot =
@@ -1196,8 +1200,10 @@ class _MapLibreMapState extends State<MapLibreMap>
       final cameraChanged =
           controller?.notifyCameraChanged(
             notifyListeners: widget.trackCameraPosition,
+            viewportChanged: _viewportNotificationPending,
           ) ??
           false;
+      _viewportNotificationPending = false;
       final nextZoom =
           controller?.cameraPosition?.zoom ?? _bridge.getCameraZoom();
       _gpuRenderer?.zoom = nextZoom;

--- a/test/maplibre_map_controller_test.dart
+++ b/test/maplibre_map_controller_test.dart
@@ -325,10 +325,10 @@ class _FakeBridge implements MaplibreBridge {
   }
 
   @override
-  int get logicalWidth => 800;
+  var logicalWidth = 800;
 
   @override
-  int get logicalHeight => 600;
+  var logicalHeight = 600;
 
   @override
   List<Offset> wrappedLatLonsToScreen(
@@ -339,11 +339,11 @@ class _FakeBridge implements MaplibreBridge {
     return [
       for (final coordinate in coordinates)
         Offset(
-          400 +
+          logicalWidth / 2 +
               (coordinate.longitude + coordinate.tileWrap * 360 - lon) /
                   360 *
                   worldSize,
-          300,
+          logicalHeight / 2,
         ),
     ];
   }
@@ -868,6 +868,41 @@ void main() {
       controller.dispose();
     },
   );
+
+  test('viewport changes reproject overlays with an unchanged camera', () {
+    final bridge = _FakeBridge();
+    final controller = MapLibreMapController.bind(bridge);
+    final camera = controller.cameraPosition;
+    final location = camera!.target;
+    var offsets = controller.toScreenOffsets(location);
+    var listenerCount = 0;
+    controller.addListener(() {
+      listenerCount++;
+      offsets = controller.toScreenOffsets(location);
+    });
+    expect(offsets, [const Offset(400, 300)]);
+
+    bridge.logicalWidth = 1000;
+    bridge.logicalHeight = 800;
+    expect(controller.notifyCameraChanged(viewportChanged: true), isFalse);
+    expect(controller.cameraPosition, camera);
+    expect(offsets, [const Offset(500, 400)]);
+    expect(listenerCount, 1);
+
+    expect(controller.notifyCameraChanged(), isFalse);
+    expect(listenerCount, 1);
+
+    bridge.logicalWidth = 600;
+    expect(
+      controller.notifyCameraChanged(
+        viewportChanged: true,
+        notifyListeners: false,
+      ),
+      isFalse,
+    );
+    expect(listenerCount, 1);
+    controller.dispose();
+  });
 
   test('unchanged native frames do not repeat camera notifications', () {
     final bridge = _FakeBridge();


### PR DESCRIPTION
## Summary

Custom Flutter markers driven by controller listeners stayed at their previous screen coordinates when the map resized without moving the camera. Notify listeners when a resized native frame is available so overlays reproject against the updated viewport.

Respect `trackCameraPosition` and keep camera-change detection based on the camera position. Document viewport notifications and cover controller-driven overlays with unit and macOS integration tests.

## Validation

- Controller, async snapshot, and symbol overlay tests (87 tests).
- macOS integration test passes with both viewport expansion and contraction while the camera remains fixed.
- Disabling the resize notification reproduces the regression in the same integration test: the marker remains at `(160, 120)` instead of moving to `(240, 180)` after resizing from 320 × 240 to 480 × 360.
- Targeted static analysis reports no issues.
- `git diff --check`.
