### PR TITLE
fix: exclude local build directories from pub package

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -21,6 +21,7 @@
 # Local and generated outputs
 /.dart_tool/
 /.pub/
+/build-*/
 /**/build/
 /**/coverage/
 /**/doc/api/


### PR DESCRIPTION
## Summary

Exclude root-level `build-*` directories from the pub package. Local native builds leave directories such as `build-ios-fluttergpu-device-arm64` and `build-macos-fluttergpu-arm64`, which the existing `/**/build/` rule does not match. Because `.pubignore` overrides the root `.gitignore`, its build-directory exclusions must be specified here too.

## Validation

- Checked Git-compatible ignore patterns against build paths for all five platforms and the existing `build/` path.
- Confirmed Android libraries, the Darwin XCFramework, and the Dart library entry point remain publishable under these rules.
- `git diff --check` passes.
- Full pub publish dry run was not run.
